### PR TITLE
Updated refspec to avoid weird HEAD state

### DIFF
--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -152,12 +152,12 @@ func (g *Git) Checkout(branch string, commit string) error {
 	var fetchOptions git.FetchOptions
 	if g.authMethod == nil {
 		fetchOptions = git.FetchOptions{
-			RefSpecs: []c.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+			RefSpecs: []c.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "refs/*:refs/*"},
 			Force:    true,
 		}
 	} else {
 		fetchOptions = git.FetchOptions{
-			RefSpecs: []c.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+			RefSpecs: []c.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "refs/*:refs/*"},
 			Force:    true,
 			Auth:     *g.authMethod,
 		}


### PR DESCRIPTION
Currently the fetch puts the repo into an ambiguous state

``` 
git status
warning: refname 'HEAD' is ambiguous.
warning: refname 'HEAD' is ambiguous
```

https://stackoverflow.com/questions/1692892/warning-refname-head-is-ambiguous

This is caused by the ref-spec `"HEAD:refs/heads/HEAD"` which merges HEAD. The fix updates the spec to be + with wild card. `"refs/*:refs/*"` is to match local refs which the many of the unit tests depend on.