### PR TITLE
Added path argument for task execution at specific path

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ The `worker` will start a schedule consumer when `cronicle run --queue ` is in d
 cronicle worker --queue redis
 ```
 
+---
+
+## Command Templates
+The cronicle command string accepts the following template argumets
+```
+	 ${date}: 		  "2006-01-02"
+	 ${datetime}: 	"2006-01-02T15:04:05Z07:00"
+	 ${timestamp}: 	"2006-01-02 15:04:05Z07:00"
+	 ${path}:       task.Path
+```
+
 
 
 

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -19,6 +19,7 @@ func (task *Task) Exec(t time.Time) exec.Result {
 		"${date}", t.Format(TimeArgumentFormatMap["${date}"]),
 		"${datetime}", t.Format(TimeArgumentFormatMap["${datetime}"]),
 		"${timestamp}", t.Format(TimeArgumentFormatMap["${timestamp}"]),
+		"${path}", task.Path,
 	)
 	if len(task.Command) > 0 {
 		cmd := make([]string, len(task.Command))


### PR DESCRIPTION
Enable the command string to take a `${path}` template which will populate with the absolute path of the task command execution. 