### PR TITLE
Pretty/text/json log formats and JSON file mirror

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -53,6 +53,15 @@ cronicle exec --time 2020-10-01T00:00:00-08:00 --end 2020-10-03T00:00:00-08:00`,
 		timeFlag, _ := cmd.Flags().GetString("time")
 		cron, _ := cmd.Flags().GetString("cron")
 		command, _ := cmd.Flags().GetString("command")
+		logToFile, _ := cmd.Flags().GetBool("log-to-file")
+
+		if logToFile {
+			if abs, err := filepath.Abs(path); err == nil {
+				if err := cronicle.EnableFileLog(filepath.Dir(abs)); err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
 
 		if cron != "" && command != "" {
 			conf := cronicle.Default()
@@ -103,6 +112,7 @@ func init() {
 	execCmd.Flags().String("end", "", "date range end Timestamp [2006-01-02T15:04:05-08:00]")
 	execCmd.Flags().String("cron", "", "crontab expression for running a command e.g. @every 1h")
 	execCmd.Flags().String("command", "", "command to run on the given cron [/bin/echo cronicle]")
+	execCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); stdout is unaffected")
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/jshiv/cronicle/internal/cronicle"
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -28,8 +29,15 @@ import (
 
 var cfgFile string
 
+// logFormat is bound to the --log-format persistent flag and resolved by
+// PersistentPreRun before any subcommand executes.
+var logFormat string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cronicle.SetupLogging(cronicle.LogFormat(logFormat))
+	},
 	Use:   "cronicle",
 	Short: "Cronicle is a distributed, git integrated cron based task engine.",
 	Long: `Cronicle is a distributed, "schedule as code" cron based task engine.
@@ -77,25 +85,12 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cronicle.yaml)")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "auto",
+		"stdout log format: auto (pretty if TTY, text if piped), pretty, text, or json")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
-	// Log with the ASCII formatter with full timestamp.
-	log.SetFormatter(&log.TextFormatter{
-		DisableColors: false,
-		FullTimestamp: true,
-	})
-	// Log as JSON instead of the default ASCII formatter.
-	// log.SetFormatter(&log.JSONFormatter{})
-
-	// Output to stdout instead of the default stderr
-	// Can be any io.Writer, see below for File example
-	log.SetOutput(os.Stdout)
-
-	// Only log the warning severity or above.
-	log.SetLevel(log.InfoLevel)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,7 +86,7 @@ func init() {
 	runCmd.Flags().String("addr", "", addrDesc)
 	runCmd.Flags().String("cron", "", "crontab expression for running a command e.g. @every 1h")
 	runCmd.Flags().String("command", "", "command to run on the given cron [/bin/echo cronicle]")
-	runCmd.Flags().Bool("log-to-file", false, "log to path/.cronicle/log/cronicle.log")
+	runCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); stdout is unaffected and remains controlled by --log-format")
 
 	// Here you will define your flags and configuration settings.
 

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -3,7 +3,6 @@ package cronicle
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"sync"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	nsqvice "github.com/matryer/vice/queues/nsq"
 	redisvice "github.com/matryer/vice/queues/redis"
 	"github.com/nsqio/go-nsq"
-	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/fatih/color"
 
@@ -45,15 +43,9 @@ func Run(cronicleFile string, runOptions RunOptions) {
 	fmt.Printf("%s", slantyedCyan(string(hcl.Bytes)))
 
 	if runOptions.LogToFile {
-		logPath := path.Join(croniclePath, path.Join(".cronicle", "log"))
-		logFile := path.Join(logPath, "cronicle.log")
-		log.SetOutput(&lumberjack.Logger{
-			Filename:   logFile,
-			MaxSize:    500, // megabytes
-			MaxBackups: 3,
-			MaxAge:     28,   //days
-			Compress:   true, // disabled by default
-		})
+		if err := EnableFileLog(croniclePath); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if runOptions.QueueType == "" {
@@ -168,9 +160,7 @@ func StartCron(cronicleFile string, queue chan<- []byte) {
 		loc = time.Local
 	}
 
-	log.SetFormatter(TZFormatter{Formatter: &log.TextFormatter{
-		FullTimestamp: true,
-	}, loc: loc})
+	ApplyTimezone(loc)
 	log.WithFields(log.Fields{"cronicle": "start"}).Info("Starting Scheduler...")
 
 	for _, schedule := range conf.Schedules {
@@ -328,9 +318,7 @@ func ExecTasks(cronicleFile string, taskName string, scheduleName string, now ti
 		loc = time.Local
 	}
 
-	log.SetFormatter(TZFormatter{Formatter: &log.TextFormatter{
-		FullTimestamp: true,
-	}, loc: loc})
+	ApplyTimezone(loc)
 	log.WithFields(log.Fields{"cronicle": "exec"}).Info("executing tasks...")
 
 	nowInLoc := now.In(loc)

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -43,9 +43,11 @@ func (task *Task) Exec(t time.Time) exec.Result {
 	return result
 }
 
-// execAgent dispatches the task to pkg/agent and surfaces the run as an
-// exec.Result so the rest of the cronicle execution path is unchanged.
-// Token/cost/transcript metadata is logged but lives in the transcript file.
+// execAgent dispatches the task to pkg/agent and emits a single structured
+// log entry covering the run. The entry carries entry_type="agent_run" so the
+// pretty formatter can render it as a multi-line block; in text/json mode the
+// fields stay on one line. task.Log is skipped for agent tasks because this
+// function owns the agent's logging end-to-end.
 func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	transcriptDir := filepath.Join(task.CroniclePath, ".cronicle", "runs")
 	runID := fmt.Sprintf("%s-%s-%s", t.UTC().Format("20060102T150405Z"), task.ScheduleName, task.Name)
@@ -60,18 +62,32 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		RunID:         runID,
 	}
 
+	startedAt := time.Now()
 	res, err := agent.Run(context.Background(), cfg)
-	if err == nil {
-		log.WithFields(log.Fields{
-			"schedule":      task.ScheduleName,
-			"task":          task.Name,
-			"model":         res.Model,
-			"input_tokens":  res.InputTokens,
-			"output_tokens": res.OutputTokens,
-			"cost_usd":      fmt.Sprintf("%.4f", res.CostUSD),
-			"transcript":    res.TranscriptPath,
-			"stop_reason":   res.StopReason,
-		}).Info("agent run complete")
+	durationMs := time.Since(startedAt).Milliseconds()
+
+	fields := log.Fields{
+		"entry_type":    "agent_run",
+		"schedule":      task.ScheduleName,
+		"task":          task.Name,
+		"model":         res.Model,
+		"input_tokens":  res.InputTokens,
+		"output_tokens": res.OutputTokens,
+		"cache_read":    res.CacheReadIn,
+		"cache_write":   res.CacheWriteIn,
+		"cost_usd":      fmt.Sprintf("%.6f", res.CostUSD),
+		"duration_ms":   durationMs,
+		"stop_reason":   res.StopReason,
+		"transcript":    res.TranscriptPath,
+		"response":      res.Stdout,
+	}
+	if err != nil {
+		fields["success"] = false
+		fields["error"] = err.Error()
+		log.WithFields(fields).Error("agent run failed")
+	} else {
+		fields["success"] = true
+		log.WithFields(fields).Info("agent run")
 	}
 	return res.Result
 }
@@ -157,7 +173,12 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 }
 
 //Log logs the exit status, stderr, git commit and other logging data.
+//Agent tasks own their logging end-to-end via execAgent, so this is a no-op
+//for them.
 func (task *Task) Log(res exec.Result) {
+	if task.Agent != nil {
+		return
+	}
 
 	var commit string
 	var email string

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -1,24 +1,237 @@
 package cronicle
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-//TZFormatter enables timezone specifc logrus formatting
+// LogFormat selects the stdout log rendering.
+type LogFormat string
+
+const (
+	LogFormatAuto   LogFormat = "auto"
+	LogFormatPretty LogFormat = "pretty"
+	LogFormatText   LogFormat = "text"
+	LogFormatJSON   LogFormat = "json"
+)
+
+// SetupLogging configures logrus's stdout formatter according to format.
+// "auto" picks pretty when stdout is a TTY, text otherwise.
+func SetupLogging(format LogFormat) {
+	resolved := format
+	if resolved == "" || resolved == LogFormatAuto {
+		if isatty.IsTerminal(os.Stdout.Fd()) {
+			resolved = LogFormatPretty
+		} else {
+			resolved = LogFormatText
+		}
+	}
+
+	switch resolved {
+	case LogFormatPretty:
+		log.SetFormatter(&prettyFormatter{
+			fallback: &log.TextFormatter{
+				FullTimestamp: true,
+				ForceColors:   true,
+			},
+		})
+	case LogFormatJSON:
+		log.SetFormatter(&log.JSONFormatter{})
+	default:
+		log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+	}
+
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.InfoLevel)
+}
+
+// EnableFileLog adds a logrus hook that mirrors every log entry as JSON to
+// croniclePath/.cronicle/log/cronicle.jsonl, rotated by lumberjack.
+// Stdout output is unaffected.
+func EnableFileLog(croniclePath string) error {
+	logDir := filepath.Join(croniclePath, ".cronicle", "log")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return err
+	}
+	hook := &jsonFileHook{
+		writer: &lumberjack.Logger{
+			Filename:   filepath.Join(logDir, "cronicle.jsonl"),
+			MaxSize:    500, // MB per file before rotation
+			MaxBackups: 3,   // keep up to 3 rotated files
+			MaxAge:     28,  // days; older files deleted
+			Compress:   true,
+		},
+		formatter: &log.JSONFormatter{},
+	}
+	log.AddHook(hook)
+	return nil
+}
+
+// jsonFileHook writes every log entry as JSON to an io.Writer (typically a
+// rotating lumberjack logger). Stdout is untouched, so this hook composes with
+// any stdout formatter.
+type jsonFileHook struct {
+	writer    io.Writer
+	formatter log.Formatter
+}
+
+func (h *jsonFileHook) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (h *jsonFileHook) Fire(e *log.Entry) error {
+	b, err := h.formatter.Format(e)
+	if err != nil {
+		return err
+	}
+	_, err = h.writer.Write(b)
+	return err
+}
+
+// TZFormatter enables timezone specifc logrus formatting
 // Example:
 // loc, _ = time.LoadLocation("America/Los_Angeles")
 // log.SetFormatter(TZFormatter{Formatter: &log.TextFormatter{
-// 	FullTimestamp: true,
-// 	}, loc: loc})
+//
+//	FullTimestamp: true,
+//	}, loc: loc})
 type TZFormatter struct {
 	log.Formatter
 	loc *time.Location
 }
 
-//Format sets the timezone for the given loc *time.Timezone
+// Format sets the timezone for the given loc *time.Timezone
 func (u TZFormatter) Format(e *log.Entry) ([]byte, error) {
 	e.Time = e.Time.In(u.loc)
 	return u.Formatter.Format(e)
+}
+
+// ApplyTimezone wraps the standard logger's current formatter in a TZFormatter
+// so timestamps render in loc. This preserves the user's --log-format choice
+// instead of clobbering it with a fresh TextFormatter.
+func ApplyTimezone(loc *time.Location) {
+	current := log.StandardLogger().Formatter
+	if _, alreadyTZ := current.(TZFormatter); alreadyTZ {
+		return
+	}
+	log.SetFormatter(TZFormatter{Formatter: current, loc: loc})
+}
+
+// prettyFormatter renders agent_run entries as a multi-line block and falls
+// back to a wrapped TextFormatter for everything else.
+type prettyFormatter struct {
+	fallback log.Formatter
+}
+
+func (p *prettyFormatter) Format(e *log.Entry) ([]byte, error) {
+	entryType, _ := e.Data["entry_type"].(string)
+	if entryType != "agent_run" {
+		return p.fallback.Format(e)
+	}
+	return p.renderAgentRun(e), nil
+}
+
+func (p *prettyFormatter) renderAgentRun(e *log.Entry) []byte {
+	header := color.New(color.FgCyan, color.Bold).SprintFunc()
+	rule := color.New(color.FgCyan).SprintFunc()
+	footer := color.New(color.Faint).SprintFunc()
+	errc := color.New(color.FgRed, color.Bold).SprintFunc()
+
+	schedule, _ := e.Data["schedule"].(string)
+	task, _ := e.Data["task"].(string)
+	model, _ := e.Data["model"].(string)
+	response, _ := e.Data["response"].(string)
+	costStr, _ := e.Data["cost_usd"].(string)
+	durationMs := asInt64(e.Data["duration_ms"])
+	in := asInt64(e.Data["input_tokens"])
+	out := asInt64(e.Data["output_tokens"])
+	transcript, _ := e.Data["transcript"].(string)
+	stop, _ := e.Data["stop_reason"].(string)
+	errMsg, _ := e.Data["error"].(string)
+	success, _ := e.Data["success"].(bool)
+
+	headerLine := fmt.Sprintf("agent run · schedule=%s · task=%s · model=%s",
+		schedule, task, model)
+	bar := strings.Repeat("━", lenWithoutANSI(headerLine)+8)
+
+	var b bytes.Buffer
+	b.WriteString(rule(bar))
+	b.WriteString("\n")
+	b.WriteString(header(headerLine))
+	b.WriteString("\n")
+	b.WriteString(rule(bar))
+	b.WriteString("\n\n")
+
+	if success {
+		if response == "" {
+			b.WriteString(footer("(no text response)\n"))
+		} else {
+			b.WriteString(strings.TrimRight(response, "\n"))
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString(errc("ERROR: "))
+		b.WriteString(errMsg)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	footerParts := []string{
+		fmt.Sprintf("%d in / %d out tokens", in, out),
+		fmt.Sprintf("$%s", costStr),
+		fmt.Sprintf("%dms", durationMs),
+	}
+	if stop != "" {
+		footerParts = append(footerParts, fmt.Sprintf("stop=%s", stop))
+	}
+	if transcript != "" {
+		footerParts = append(footerParts, fmt.Sprintf("transcript=%s", filepath.Base(transcript)))
+	}
+	b.WriteString(footer("[" + strings.Join(footerParts, " · ") + "]"))
+	b.WriteString("\n\n")
+
+	return b.Bytes()
+}
+
+func asInt64(v any) int64 {
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	}
+	return 0
+}
+
+// lenWithoutANSI counts visible runes, ignoring ANSI escape codes. Used so the
+// rule line above the header matches its visible width when colors are on.
+func lenWithoutANSI(s string) int {
+	n := 0
+	in := false
+	for _, r := range s {
+		if r == 0x1b {
+			in = true
+			continue
+		}
+		if in {
+			if r == 'm' {
+				in = false
+			}
+			continue
+		}
+		n++
+	}
+	return n
 }


### PR DESCRIPTION
## Summary

Adds a logging UX layer for agent tasks that serves both humans and log consumers, without conflating the two.

**Two orthogonal flags, sensible defaults:**

| Flag | Controls | Default |
|---|---|---|
| `--log-format` (persistent) | stdout: `auto` / `pretty` / `text` / `json` | `auto` (pretty if TTY, text if piped) |
| `--log-to-file` (`run` and `exec`) | mirrors structured JSON to `.cronicle/log/cronicle.jsonl` | off |

The two flags are independent — pretty stdout + tail-able JSON file at the same time is the intended composition. File logging uses lumberjack rotation (500MB / 3 backups / 28 days / gzip), so disk usage is bounded.

**Three stdout formats:**

- **pretty**: each agent run renders as a multi-line block (header rule / `agent run · schedule=… · task=… · model=…` / rule / response body / `[N in / N out tokens · $cost · Nms · stop=… · transcript=…]`). Non-agent log lines use the colored `INFO[ts]` style. Default at the terminal.
- **text**: classic logrus `time="…" level=info msg="agent run" key=val …` with response in a `response` field. Default when piped. Parses cleanly in Vector/Datadog/Loki/Promtail without parser config.
- **json**: `{"level":"info","msg":"agent run","response":"…",…}`. Strictest machine format.

**Single structured event per agent run.** Previously an agent invocation produced two log lines (the `agent run complete` info line plus a `task.Log(result)` line whose message was the response body). Multi-line responses broke logrus's per-line contract — the structured fields landed on the last line of the body. Now agent dispatch emits one entry carrying `response` as a field; logrus escapes newlines naturally, so the line stays single-line in text/json mode and the pretty formatter renders the response as a block. `task.Log` is a no-op for agent tasks.

**ApplyTimezone helper.** Two call sites in `cron.go` were unconditionally setting `TZFormatter{Formatter: &log.TextFormatter{...}}`, which clobbered the user's `--log-format` choice. The new `ApplyTimezone` helper wraps the *current* formatter so the timezone setting composes with whatever stdout format the user picked.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/cronicle/...\` — 53 of 55 specs pass; the 2 remaining failures are pre-existing GitHub-SSH-dependent tests, unrelated to this PR
- [x] End-to-end smoke runs against the live API for all three formats:
  - \`--log-format=pretty\` against parallel.hcl: 3 agent blocks render cleanly
  - \`--log-format=text\` against longer.hcl: one logfmt line per run with response field
  - \`--log-format=json\` against mixed.hcl: one JSON object per run, response field intact
  - \`--log-format=pretty --log-to-file\` against cronicle.hcl: pretty stdout + structured JSON file simultaneously

## Known follow-ups (not in this PR)

- Tools/MCP, HITL gates, and inter-task structured I/O are still out of scope.
- Streaming-time budget enforcement (currently \`budget_usd\` is post-hoc).
- Optional rotation tuning flags (\`--log-max-size\`, \`--log-max-backups\`, \`--log-max-age\`) — defaults are fine for now.
- Optional file-format flag (\`--log-file-format=text\`) — only worth adding if a real consumer requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)