### PR TITLE
Migrate from logrus to log/slog

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -16,11 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"log/slog"
 	"path/filepath"
 	"strings"
 
 	"github.com/jshiv/cronicle/internal/cronicle"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"time"
@@ -58,7 +58,7 @@ cronicle exec --time 2020-10-01T00:00:00-08:00 --end 2020-10-03T00:00:00-08:00`,
 		if logToFile {
 			if abs, err := filepath.Abs(path); err == nil {
 				if err := cronicle.EnableFileLog(filepath.Dir(abs)); err != nil {
-					log.Fatal(err)
+					cronicle.Fatal(err)
 				}
 			}
 		}
@@ -79,7 +79,7 @@ cronicle exec --time 2020-10-01T00:00:00-08:00 --end 2020-10-03T00:00:00-08:00`,
 		} else {
 			//TODO: Add flags for timeFlag format and timezone
 			if n, err := time.Parse(time.RFC3339, timeFlag); err != nil {
-				log.Error(err)
+				slog.Error("time parse failed", "error", err.Error())
 			} else {
 				now = n
 			}
@@ -92,7 +92,7 @@ cronicle exec --time 2020-10-01T00:00:00-08:00 --end 2020-10-03T00:00:00-08:00`,
 		} else {
 			//TODO: Add flags for endFlag format and timezone
 			if n, err := time.Parse(time.RFC3339, endFlag); err != nil {
-				log.Error(err)
+				slog.Error("time parse failed", "error", err.Error())
 			} else {
 				end = n
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,13 +17,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jshiv/cronicle/internal/cronicle"
 	homedir "github.com/mitchellh/go-homedir"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -72,8 +70,7 @@ schedule "example" {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
-		os.Exit(1)
+		cronicle.Fatal(err)
 	}
 }
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -16,10 +16,10 @@ limitations under the License.
 package cmd
 
 import (
+	"log/slog"
+
 	"github.com/jshiv/cronicle/internal/cronicle"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // workerCmd represents the worker command
@@ -53,7 +53,7 @@ Multipule workers can be started, they will take turns consuming from the queue.
 		queueName, _ := cmd.Flags().GetString("queue-name")
 		addr, _ := cmd.Flags().GetString("addr")
 
-		log.Info("Starting Worker from: " + path)
+		slog.Info("Starting Worker from: " + path)
 		runOptions := cronicle.RunOptions{RunWorker: true, QueueType: queueType, QueueName: queueName, Addr: addr}
 		cronicle.StartWorker(path, runOptions)
 	},

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/matryer/vice v1.0.1-0.20190210090722-660007f4486b
+	github.com/mattn/go-isatty v0.0.22
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.34.1
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/whilp/git-urls v1.0.0
@@ -53,7 +53,6 @@ require (
 	github.com/matryer/is v1.4.0 // indirect
 	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,6 @@ github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9t
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
-github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -3,7 +3,6 @@ package cronicle
 import (
 	"errors"
 	"fmt"
-	"log"
 	"path/filepath"
 	"time"
 )
@@ -317,7 +316,7 @@ func (conf *Config) TaskArray() TaskArray {
 
 	err := conf.Validate() // ensure that schedule.Name and task.ScheduleName are not empty
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
 	tasks := TaskArray{}
 

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -3,6 +3,7 @@ package cronicle
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"path/filepath"
 
 	cron "github.com/robfig/cron/v3"
-	log "github.com/sirupsen/logrus"
 )
 
 // Run is the main function of the cron package
@@ -25,17 +25,17 @@ func Run(cronicleFile string, runOptions RunOptions) {
 
 	cronicleFileAbs, err := filepath.Abs(cronicleFile)
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
 
 	if !fileExists(cronicleFileAbs) {
-		log.Fatal("file does not exist: ", cronicleFileAbs)
+		Fatal("file does not exist", "path", cronicleFileAbs)
 	}
 	croniclePath := filepath.Dir(cronicleFileAbs)
 
 	conf, err := GetConfig(cronicleFileAbs)
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
 	confPriorGlobal = conf
 	hcl := conf.Hcl()
@@ -44,7 +44,7 @@ func Run(cronicleFile string, runOptions RunOptions) {
 
 	if runOptions.LogToFile {
 		if err := EnableFileLog(croniclePath); err != nil {
-			log.Fatal(err)
+			Fatal(err)
 		}
 	}
 
@@ -87,11 +87,11 @@ func StartWorker(path string, runOptions RunOptions) {
 
 	pathAbs, err := filepath.Abs(path)
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
 
 	if runOptions.QueueType == "" {
-		log.Error("--queue must be specified in distributed mode. [Options: redis, nsq]")
+		slog.Error("--queue must be specified in distributed mode. [Options: redis, nsq]")
 	}
 	transport := MakeViceTransport(runOptions.QueueType, runOptions.Addr)
 	schedules := transport.Receive(runOptions.QueueName)
@@ -148,30 +148,30 @@ func StartCron(cronicleFile string, queue chan<- []byte) {
 
 	conf, err := GetConfig(cronicleFile)
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
 	var loc *time.Location
 	if conf.Timezone != "" {
 		loc, err = time.LoadLocation(conf.Timezone)
 		if err != nil {
-			log.Fatal(err)
+			Fatal(err)
 		}
 	} else {
 		loc = time.Local
 	}
 
 	ApplyTimezone(loc)
-	log.WithFields(log.Fields{"cronicle": "start"}).Info("Starting Scheduler...")
+	slog.Info("Starting Scheduler...", "cronicle", "start")
 
 	for _, schedule := range conf.Schedules {
 		switch {
 		case schedule.Cron == "@once":
-			log.WithFields(log.Fields{"schedule": schedule.Name, "cron": schedule.Cron}).Info("Executing @Once")
+			slog.Info("Executing @Once", "schedule", schedule.Name, "cron", schedule.Cron)
 			ProduceSchedule(schedule, queue)()
 		case schedule.Cron == "":
-			log.WithFields(log.Fields{"schedule": schedule.Name, "cron": schedule.Cron}).Info("Skip execution. Use 'cronicle exec' to run.")
+			slog.Info("Skip execution. Use 'cronicle exec' to run.", "schedule", schedule.Name, "cron", schedule.Cron)
 		default:
-			log.WithFields(log.Fields{"schedule": schedule.Name, "cron": schedule.Cron}).Info("Starting cron...")
+			slog.Info("Starting cron...", "schedule", schedule.Name, "cron", schedule.Cron)
 		}
 	}
 
@@ -193,14 +193,14 @@ var confPriorGlobal *Config
 //schedules to the cron.
 func LoadCron(cronicleFile string, c *cron.Cron, queue chan<- []byte, force bool) {
 
-	log.WithFields(log.Fields{"cronicle": "heartbeat", "path": cronicleFile}).Info("Loading config...")
+	slog.Info("Loading config...", "cronicle", "heartbeat", "path", cronicleFile)
 	conf, err := GetConfig(cronicleFile)
 	if err != nil {
-		log.Error(err)
+		slog.Error("config load failed", "error", err.Error())
 	}
 
 	if string(confPriorGlobal.Hcl().Bytes) != string(conf.Hcl().Bytes) || force {
-		log.WithFields(log.Fields{"cronicle": "heartbeat", "path": cronicleFile}).Info("Refreshing config...")
+		slog.Info("Refreshing config...", "cronicle", "heartbeat", "path", cronicleFile)
 		c.Stop()
 		for _, entry := range c.Entries() {
 			// assumes that LoadCron has entry.ID == 1
@@ -213,14 +213,14 @@ func LoadCron(cronicleFile string, c *cron.Cron, queue chan<- []byte, force bool
 		for _, schedule := range conf.Schedules {
 			switch {
 			case schedule.Cron == "@once":
-				log.WithFields(log.Fields{"schedule": schedule.Name, "cron": schedule.Cron}).Info("@once execution complete at 'cronicle run'")
+				slog.Info("@once execution complete at 'cronicle run'", "schedule", schedule.Name, "cron", schedule.Cron)
 			case schedule.Cron == "":
-				log.WithFields(log.Fields{"schedule": schedule.Name, "cron": schedule.Cron}).Warn("Skip execution. Use 'cronicle exec' to run.")
+				slog.Warn("Skip execution. Use 'cronicle exec' to run.", "schedule", schedule.Name, "cron", schedule.Cron)
 			default:
 				_, err := c.AddFunc(schedule.Cron, ProduceSchedule(schedule, queue))
 				if err != nil {
 					fmt.Printf("\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf("schedule cron format error: %s", schedule.Name))
-					log.Fatal(err)
+					Fatal(err)
 				}
 			}
 
@@ -247,7 +247,7 @@ func ConsumeSchedule(queue <-chan []byte, path string, wg *sync.WaitGroup) {
 			var schedule Schedule
 			err := json.Unmarshal(scheduleBytes, &schedule)
 			if err != nil {
-				log.Error(err)
+				slog.Error("schedule unmarshal failed", "error", err.Error())
 			}
 			schedule.PropigateTaskProperties(p)
 			schedule.ExecuteTasks()
@@ -259,7 +259,7 @@ func ConsumeSchedule(queue <-chan []byte, path string, wg *sync.WaitGroup) {
 //schdule to the message queue for consumption
 func ProduceSchedule(schedule Schedule, queue chan<- []byte) func() {
 	return func() {
-		log.WithFields(log.Fields{"schedule": schedule.Name}).Info("Queuing...")
+		slog.Info("Queuing...", "schedule", schedule.Name)
 		var loc *time.Location
 		if schedule.Timezone != "" {
 			loc, _ = time.LoadLocation(schedule.Timezone)
@@ -279,9 +279,7 @@ func ProduceSchedule(schedule Schedule, queue chan<- []byte) func() {
 		startDate, _ := time.Parse("2006-01-02", schedule.StartDate)
 		if schedule.Now.After(endDate) || schedule.Now.Before(startDate) {
 			s := fmt.Sprintf("now=%s is not between start_date=%s and end_date=%s... Schedule will not execute.", schedule.Now, startDate, endDate)
-			log.WithFields(log.Fields{
-				"schedule": schedule.Name,
-			}).Warn(s)
+			slog.Warn(s, "schedule", schedule.Name)
 		} else {
 			schedule.CleanGit()
 			queue <- schedule.JSON()
@@ -296,30 +294,30 @@ func ExecTasks(cronicleFile string, taskName string, scheduleName string, now ti
 
 	cronicleFileAbs, err := filepath.Abs(cronicleFile)
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
-	log.Info("Loading " + cronicleFileAbs)
+	slog.Info("Loading " + cronicleFileAbs)
 	if !fileExists(cronicleFileAbs) {
-		log.Fatal("file does not exist: ", cronicleFileAbs)
+		Fatal("file does not exist", "path", cronicleFileAbs)
 	}
 
 	conf, err := GetConfig(cronicleFileAbs)
 	if err != nil {
-		log.Fatal(err)
+		Fatal(err)
 	}
 
 	var loc *time.Location
 	if conf.Timezone != "" {
 		loc, err = time.LoadLocation(conf.Timezone)
 		if err != nil {
-			log.Fatal(err)
+			Fatal(err)
 		}
 	} else {
 		loc = time.Local
 	}
 
 	ApplyTimezone(loc)
-	log.WithFields(log.Fields{"cronicle": "exec"}).Info("executing tasks...")
+	slog.Info("executing tasks...", "cronicle", "exec")
 
 	nowInLoc := now.In(loc)
 	var schedules []Schedule

--- a/internal/cronicle/dag.go
+++ b/internal/cronicle/dag.go
@@ -2,11 +2,10 @@ package cronicle
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // ExecuteTasks executes all tasks in dependency order, running independent tasks concurrently.
@@ -25,18 +24,18 @@ func (schedule Schedule) ExecuteTasks() {
 		deps[task.Name] = task.Depends
 	}
 
-	log.WithFields(log.Fields{
-		"schedule": schedule.Name,
-		"clock":    now.Format(time.Kitchen),
-		"date":     now.Format(time.RFC850),
-	}).Info(dagString(deps))
+	slog.Info(dagString(deps),
+		"schedule", schedule.Name,
+		"clock", now.Format(time.Kitchen),
+		"date", now.Format(time.RFC850),
+	)
 
 	if err := walkDAG(deps, func(name string) error {
 		task := taskMap[name]
 		_, err := task.Execute(now)
 		return err
 	}); err != nil {
-		log.Error(err)
+		slog.Error("dag walk failed", "error", err.Error())
 	}
 }
 

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -3,6 +3,7 @@ package cronicle
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -10,8 +11,6 @@ import (
 	"github.com/jshiv/cronicle/pkg/agent"
 	"github.com/jshiv/cronicle/pkg/exec"
 	"gopkg.in/matryer/try.v1"
-
-	log "github.com/sirupsen/logrus"
 )
 
 //Exec executes task.Command at task.Path and returns the exec.Result struct
@@ -66,28 +65,27 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	res, err := agent.Run(context.Background(), cfg)
 	durationMs := time.Since(startedAt).Milliseconds()
 
-	fields := log.Fields{
-		"entry_type":    "agent_run",
-		"schedule":      task.ScheduleName,
-		"task":          task.Name,
-		"model":         res.Model,
-		"input_tokens":  res.InputTokens,
-		"output_tokens": res.OutputTokens,
-		"cache_read":    res.CacheReadIn,
-		"cache_write":   res.CacheWriteIn,
-		"cost_usd":      fmt.Sprintf("%.6f", res.CostUSD),
-		"duration_ms":   durationMs,
-		"stop_reason":   res.StopReason,
-		"transcript":    res.TranscriptPath,
-		"response":      res.Stdout,
+	attrs := []slog.Attr{
+		slog.String("entry_type", "agent_run"),
+		slog.String("schedule", task.ScheduleName),
+		slog.String("task", task.Name),
+		slog.String("model", res.Model),
+		slog.Int("input_tokens", res.InputTokens),
+		slog.Int("output_tokens", res.OutputTokens),
+		slog.Int("cache_read", res.CacheReadIn),
+		slog.Int("cache_write", res.CacheWriteIn),
+		slog.String("cost_usd", fmt.Sprintf("%.6f", res.CostUSD)),
+		slog.Int64("duration_ms", durationMs),
+		slog.String("stop_reason", res.StopReason),
+		slog.String("transcript", res.TranscriptPath),
+		slog.String("response", res.Stdout),
 	}
 	if err != nil {
-		fields["success"] = false
-		fields["error"] = err.Error()
-		log.WithFields(fields).Error("agent run failed")
+		attrs = append(attrs, slog.Bool("success", false), slog.String("error", err.Error()))
+		slog.LogAttrs(context.Background(), slog.LevelError, "agent run failed", attrs...)
 	} else {
-		fields["success"] = true
-		log.WithFields(fields).Info("agent run")
+		attrs = append(attrs, slog.Bool("success", true))
+		slog.LogAttrs(context.Background(), slog.LevelInfo, "agent run", attrs...)
 	}
 	return res.Result
 }
@@ -128,7 +126,7 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 		// var err error
 		// task.Git, err = Clone(task.CroniclePath, task.CronicleRepo.URL, task.CronicleRepo.DeployKey)
 		if err != nil {
-			log.Error(err)
+			slog.Error("clone failed", "error", err.Error())
 			return exec.Result{}, err
 		}
 	}
@@ -137,13 +135,13 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 	var result exec.Result
 	err := try.Do(func(attempt int) (bool, error) {
 
-		log.WithFields(log.Fields{
-			"schedule": task.ScheduleName,
-			"task":     task.Name,
-			"attempt":  attempt,
-			"clock":    t.Format(time.Kitchen),
-			"date":     t.Format(time.RFC850),
-		}).Info("Executing...")
+		slog.Info("Executing...",
+			"schedule", task.ScheduleName,
+			"task", task.Name,
+			"attempt", attempt,
+			"clock", t.Format(time.Kitchen),
+			"date", t.Format(time.RFC850),
+		)
 		var err error
 		result = task.Exec(t)
 		err = result.Error
@@ -191,28 +189,28 @@ func (task *Task) Log(res exec.Result) {
 	}
 
 	if res.Error != nil {
-		log.WithFields(log.Fields{
-			"schedule": task.ScheduleName,
-			"task":     task.Name,
-			"path":     task.Path,
-			"exit":     res.ExitStatus,
-			"error":    res.Error,
-			"commit":   commit,
-			"email":    email,
-			"success":  false,
-			"command":  strings.Join(res.Command, " "),
-		}).Error(res.Stderr)
+		slog.Error(res.Stderr,
+			"schedule", task.ScheduleName,
+			"task", task.Name,
+			"path", task.Path,
+			"exit", res.ExitStatus,
+			"error", res.Error.Error(),
+			"commit", commit,
+			"email", email,
+			"success", false,
+			"command", strings.Join(res.Command, " "),
+		)
 	} else {
-		log.WithFields(log.Fields{
-			"schedule": task.ScheduleName,
-			"task":     task.Name,
-			"path":     task.Path,
-			"exit":     res.ExitStatus,
-			"commit":   commit,
-			"email":    email,
-			"success":  true,
-			"command":  strings.Join(res.Command, " "),
-		}).Info(res.Stdout)
+		slog.Info(res.Stdout,
+			"schedule", task.ScheduleName,
+			"task", task.Name,
+			"path", task.Path,
+			"exit", res.ExitStatus,
+			"commit", commit,
+			"email", email,
+			"success", true,
+			"command", strings.Join(res.Command, " "),
+		)
 	}
 
 }

--- a/internal/cronicle/init.go
+++ b/internal/cronicle/init.go
@@ -2,6 +2,7 @@ package cronicle
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -23,7 +23,7 @@ func Init(croniclePath string, cloneRepo string, deployKey string, defaultConf C
 
 	absCroniclePath, err := filepath.Abs(croniclePath)
 	if err != nil {
-		log.Error(err)
+		slog.Error("filepath.Abs failed", "error", err.Error())
 	}
 
 	//if remote is given, clone it to the cronicle path
@@ -33,7 +33,7 @@ func Init(croniclePath string, cloneRepo string, deployKey string, defaultConf C
 			auth, err := ssh.NewPublicKeysFromFile("git", deployKey, "")
 			auth.HostKeyCallback = gossh.InsecureIgnoreHostKey()
 			if err != nil {
-				log.Fatal(err)
+				Fatal(err)
 			}
 			cloneOptions = git.CloneOptions{URL: cloneRepo, Auth: auth}
 		} else {
@@ -42,7 +42,7 @@ func Init(croniclePath string, cloneRepo string, deployKey string, defaultConf C
 
 		_, err = git.PlainClone(absCroniclePath, false, &cloneOptions)
 		if err != nil {
-			log.Fatal(err)
+			Fatal(err)
 		}
 	}
 
@@ -65,11 +65,11 @@ func Init(croniclePath string, cloneRepo string, deployKey string, defaultConf C
 		f, err := os.OpenFile(path.Join(absCroniclePath, ".gitignore"),
 			os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			log.Println(err)
+			slog.Error("gitignore open failed", "error", err.Error())
 		}
 		defer f.Close()
 		if _, err := f.WriteString(".cronicle\n"); err != nil {
-			log.Println(err)
+			slog.Error("gitignore write failed", "error", err.Error())
 		}
 	}
 

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -2,8 +2,10 @@ package cronicle
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +13,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -25,7 +26,7 @@ const (
 	LogFormatJSON   LogFormat = "json"
 )
 
-// SetupLogging configures logrus's stdout formatter according to format.
+// SetupLogging configures slog's default logger according to format.
 // "auto" picks pretty when stdout is a TTY, text otherwise.
 func SetupLogging(format LogFormat) {
 	resolved := format
@@ -37,138 +38,303 @@ func SetupLogging(format LogFormat) {
 		}
 	}
 
+	var handler slog.Handler
 	switch resolved {
 	case LogFormatPretty:
-		log.SetFormatter(&prettyFormatter{
-			fallback: &log.TextFormatter{
-				FullTimestamp: true,
-				ForceColors:   true,
-			},
-		})
+		handler = &prettyHandler{
+			fallback: newTintHandler(os.Stdout),
+			out:      os.Stdout,
+		}
 	case LogFormatJSON:
-		log.SetFormatter(&log.JSONFormatter{})
+		handler = slog.NewJSONHandler(os.Stdout, nil)
 	default:
-		log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+		handler = slog.NewTextHandler(os.Stdout, nil)
 	}
-
-	log.SetOutput(os.Stdout)
-	log.SetLevel(log.InfoLevel)
+	slog.SetDefault(slog.New(handler))
 }
 
-// EnableFileLog adds a logrus hook that mirrors every log entry as JSON to
-// croniclePath/.cronicle/log/cronicle.jsonl, rotated by lumberjack.
+// EnableFileLog composes the current default handler with a JSON-mirroring
+// handler that writes to .cronicle/log/cronicle.jsonl, rotated by lumberjack.
 // Stdout output is unaffected.
 func EnableFileLog(croniclePath string) error {
 	logDir := filepath.Join(croniclePath, ".cronicle", "log")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return err
 	}
-	hook := &jsonFileHook{
-		writer: &lumberjack.Logger{
-			Filename:   filepath.Join(logDir, "cronicle.jsonl"),
-			MaxSize:    500, // MB per file before rotation
-			MaxBackups: 3,   // keep up to 3 rotated files
-			MaxAge:     28,  // days; older files deleted
-			Compress:   true,
-		},
-		formatter: &log.JSONFormatter{},
+	file := &lumberjack.Logger{
+		Filename:   filepath.Join(logDir, "cronicle.jsonl"),
+		MaxSize:    500, // MB per file before rotation
+		MaxBackups: 3,   // keep up to 3 rotated files
+		MaxAge:     28,  // days; older files deleted
+		Compress:   true,
 	}
-	log.AddHook(hook)
+	fileHandler := slog.NewJSONHandler(file, nil)
+	current := slog.Default().Handler()
+	slog.SetDefault(slog.New(&multiHandler{handlers: []slog.Handler{current, fileHandler}}))
 	return nil
 }
 
-// jsonFileHook writes every log entry as JSON to an io.Writer (typically a
-// rotating lumberjack logger). Stdout is untouched, so this hook composes with
-// any stdout formatter.
-type jsonFileHook struct {
-	writer    io.Writer
-	formatter log.Formatter
-}
-
-func (h *jsonFileHook) Levels() []log.Level {
-	return log.AllLevels
-}
-
-func (h *jsonFileHook) Fire(e *log.Entry) error {
-	b, err := h.formatter.Format(e)
-	if err != nil {
-		return err
+// ApplyTimezone wraps the default logger's current handler in a tzHandler so
+// timestamps render in loc. Idempotent — won't double-wrap.
+func ApplyTimezone(loc *time.Location) {
+	current := slog.Default().Handler()
+	if _, alreadyTZ := current.(*tzHandler); alreadyTZ {
+		return
 	}
-	_, err = h.writer.Write(b)
+	slog.SetDefault(slog.New(&tzHandler{inner: current, loc: loc}))
+}
+
+// Fatal logs an error-level message via slog and exits with status 1.
+// Accepts either a single error, a single string message, or a message
+// followed by slog-style key/value pairs.
+func Fatal(args ...any) {
+	switch len(args) {
+	case 0:
+		slog.Error("fatal")
+	case 1:
+		switch v := args[0].(type) {
+		case error:
+			slog.Error("fatal", "error", v.Error())
+		case string:
+			slog.Error(v)
+		default:
+			slog.Error(fmt.Sprint(v))
+		}
+	default:
+		if msg, ok := args[0].(string); ok {
+			slog.Error(msg, args[1:]...)
+		} else {
+			slog.Error(fmt.Sprint(args...))
+		}
+	}
+	os.Exit(1)
+}
+
+// ---- multiHandler ----------------------------------------------------------
+
+// multiHandler fans Handle out to multiple slog.Handlers, replicating the
+// "logrus hook" pattern for slog. Used to mirror stdout to the file.
+type multiHandler struct{ handlers []slog.Handler }
+
+func (m *multiHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	for _, h := range m.handlers {
+		if h.Enabled(ctx, l) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *multiHandler) Handle(ctx context.Context, r slog.Record) error {
+	var firstErr error
+	for _, h := range m.handlers {
+		if !h.Enabled(ctx, r.Level) {
+			continue
+		}
+		// Each handler gets its own clone since handlers may mutate Time.
+		if err := h.Handle(ctx, r.Clone()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (m *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	out := make([]slog.Handler, len(m.handlers))
+	for i, h := range m.handlers {
+		out[i] = h.WithAttrs(attrs)
+	}
+	return &multiHandler{handlers: out}
+}
+
+func (m *multiHandler) WithGroup(name string) slog.Handler {
+	out := make([]slog.Handler, len(m.handlers))
+	for i, h := range m.handlers {
+		out[i] = h.WithGroup(name)
+	}
+	return &multiHandler{handlers: out}
+}
+
+// ---- tzHandler -------------------------------------------------------------
+
+// tzHandler adjusts each record's Time to a fixed location before delegating.
+type tzHandler struct {
+	inner slog.Handler
+	loc   *time.Location
+}
+
+func (h *tzHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.inner.Enabled(ctx, l)
+}
+func (h *tzHandler) Handle(ctx context.Context, r slog.Record) error {
+	r.Time = r.Time.In(h.loc)
+	return h.inner.Handle(ctx, r)
+}
+func (h *tzHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &tzHandler{inner: h.inner.WithAttrs(attrs), loc: h.loc}
+}
+func (h *tzHandler) WithGroup(name string) slog.Handler {
+	return &tzHandler{inner: h.inner.WithGroup(name), loc: h.loc}
+}
+
+// ---- tintHandler -----------------------------------------------------------
+
+// tintHandler renders records in a colored "INFO[ts] msg key=val" style
+// reminiscent of logrus's default text output. Used as the fallback for
+// non-agent records in pretty mode.
+type tintHandler struct {
+	out   io.Writer
+	attrs []slog.Attr
+}
+
+func newTintHandler(out io.Writer) *tintHandler { return &tintHandler{out: out} }
+
+func (h *tintHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= slog.LevelInfo
+}
+
+func (h *tintHandler) Handle(_ context.Context, r slog.Record) error {
+	var lc, kc func(a ...any) string
+	switch r.Level {
+	case slog.LevelDebug:
+		lc = color.New(color.FgBlue).SprintFunc()
+	case slog.LevelWarn:
+		lc = color.New(color.FgYellow, color.Bold).SprintFunc()
+	case slog.LevelError:
+		lc = color.New(color.FgRed, color.Bold).SprintFunc()
+	default:
+		lc = color.New(color.FgCyan, color.Bold).SprintFunc()
+	}
+	kc = color.New(color.FgCyan).SprintFunc()
+
+	var b bytes.Buffer
+	levelTag := strings.ToUpper(r.Level.String())
+	if len(levelTag) > 4 {
+		levelTag = levelTag[:4]
+	}
+	fmt.Fprintf(&b, "%s[%s] %s", lc(levelTag), r.Time.Format(time.RFC3339), r.Message)
+
+	for _, a := range h.attrs {
+		fmt.Fprintf(&b, " %s=%s", kc(a.Key), formatValue(a.Value))
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%s", kc(a.Key), formatValue(a.Value))
+		return true
+	})
+	b.WriteByte('\n')
+	_, err := h.out.Write(b.Bytes())
 	return err
 }
 
-// TZFormatter enables timezone specifc logrus formatting
-// Example:
-// loc, _ = time.LoadLocation("America/Los_Angeles")
-// log.SetFormatter(TZFormatter{Formatter: &log.TextFormatter{
-//
-//	FullTimestamp: true,
-//	}, loc: loc})
-type TZFormatter struct {
-	log.Formatter
-	loc *time.Location
+func (h *tintHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	cp := *h
+	cp.attrs = append(cp.attrs[:len(cp.attrs):len(cp.attrs)], attrs...)
+	return &cp
 }
 
-// Format sets the timezone for the given loc *time.Timezone
-func (u TZFormatter) Format(e *log.Entry) ([]byte, error) {
-	e.Time = e.Time.In(u.loc)
-	return u.Formatter.Format(e)
-}
+func (h *tintHandler) WithGroup(_ string) slog.Handler { return h }
 
-// ApplyTimezone wraps the standard logger's current formatter in a TZFormatter
-// so timestamps render in loc. This preserves the user's --log-format choice
-// instead of clobbering it with a fresh TextFormatter.
-func ApplyTimezone(loc *time.Location) {
-	current := log.StandardLogger().Formatter
-	if _, alreadyTZ := current.(TZFormatter); alreadyTZ {
-		return
+// formatValue renders a slog value in a logfmt-ish style: bare for safe
+// scalars, quoted when it contains whitespace or quotes.
+func formatValue(v slog.Value) string {
+	s := v.String()
+	if strings.ContainsAny(s, " \t\n\"") {
+		return fmt.Sprintf("%q", s)
 	}
-	log.SetFormatter(TZFormatter{Formatter: current, loc: loc})
+	return s
 }
 
-// prettyFormatter renders agent_run entries as a multi-line block and falls
-// back to a wrapped TextFormatter for everything else.
-type prettyFormatter struct {
-	fallback log.Formatter
+// ---- prettyHandler ---------------------------------------------------------
+
+// prettyHandler renders records with entry_type=agent_run as a multi-line
+// block; everything else falls through to the wrapped fallback handler.
+type prettyHandler struct {
+	fallback slog.Handler
+	out      io.Writer
 }
 
-func (p *prettyFormatter) Format(e *log.Entry) ([]byte, error) {
-	entryType, _ := e.Data["entry_type"].(string)
-	if entryType != "agent_run" {
-		return p.fallback.Format(e)
+func (p *prettyHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return p.fallback.Enabled(ctx, l)
+}
+
+func (p *prettyHandler) Handle(ctx context.Context, r slog.Record) error {
+	if !isAgentRun(r) {
+		return p.fallback.Handle(ctx, r)
 	}
-	return p.renderAgentRun(e), nil
+	return p.renderAgentRun(r)
 }
 
-func (p *prettyFormatter) renderAgentRun(e *log.Entry) []byte {
+func (p *prettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &prettyHandler{fallback: p.fallback.WithAttrs(attrs), out: p.out}
+}
+
+func (p *prettyHandler) WithGroup(name string) slog.Handler {
+	return &prettyHandler{fallback: p.fallback.WithGroup(name), out: p.out}
+}
+
+func isAgentRun(r slog.Record) bool {
+	found := false
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "entry_type" && a.Value.String() == "agent_run" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (p *prettyHandler) renderAgentRun(r slog.Record) error {
 	header := color.New(color.FgCyan, color.Bold).SprintFunc()
 	rule := color.New(color.FgCyan).SprintFunc()
 	footer := color.New(color.Faint).SprintFunc()
 	errc := color.New(color.FgRed, color.Bold).SprintFunc()
 
-	schedule, _ := e.Data["schedule"].(string)
-	task, _ := e.Data["task"].(string)
-	model, _ := e.Data["model"].(string)
-	response, _ := e.Data["response"].(string)
-	costStr, _ := e.Data["cost_usd"].(string)
-	durationMs := asInt64(e.Data["duration_ms"])
-	in := asInt64(e.Data["input_tokens"])
-	out := asInt64(e.Data["output_tokens"])
-	transcript, _ := e.Data["transcript"].(string)
-	stop, _ := e.Data["stop_reason"].(string)
-	errMsg, _ := e.Data["error"].(string)
-	success, _ := e.Data["success"].(bool)
+	var (
+		schedule, task, model, response, costStr string
+		stop, transcript, errMsg                  string
+		durationMs, in, out                       int64
+		success                                   bool
+	)
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "schedule":
+			schedule = a.Value.String()
+		case "task":
+			task = a.Value.String()
+		case "model":
+			model = a.Value.String()
+		case "response":
+			response = a.Value.String()
+		case "cost_usd":
+			costStr = a.Value.String()
+		case "duration_ms":
+			durationMs = a.Value.Int64()
+		case "input_tokens":
+			in = a.Value.Int64()
+		case "output_tokens":
+			out = a.Value.Int64()
+		case "transcript":
+			transcript = a.Value.String()
+		case "stop_reason":
+			stop = a.Value.String()
+		case "error":
+			errMsg = a.Value.String()
+		case "success":
+			success = a.Value.Bool()
+		}
+		return true
+	})
 
 	headerLine := fmt.Sprintf("agent run · schedule=%s · task=%s · model=%s",
 		schedule, task, model)
-	bar := strings.Repeat("━", lenWithoutANSI(headerLine)+8)
+	bar := strings.Repeat("━", len(headerLine)+8)
 
 	var b bytes.Buffer
 	b.WriteString(rule(bar))
-	b.WriteString("\n")
+	b.WriteByte('\n')
 	b.WriteString(header(headerLine))
-	b.WriteString("\n")
+	b.WriteByte('\n')
 	b.WriteString(rule(bar))
 	b.WriteString("\n\n")
 
@@ -177,15 +343,15 @@ func (p *prettyFormatter) renderAgentRun(e *log.Entry) []byte {
 			b.WriteString(footer("(no text response)\n"))
 		} else {
 			b.WriteString(strings.TrimRight(response, "\n"))
-			b.WriteString("\n")
+			b.WriteByte('\n')
 		}
 	} else {
 		b.WriteString(errc("ERROR: "))
 		b.WriteString(errMsg)
-		b.WriteString("\n")
+		b.WriteByte('\n')
 	}
 
-	b.WriteString("\n")
+	b.WriteByte('\n')
 	footerParts := []string{
 		fmt.Sprintf("%d in / %d out tokens", in, out),
 		fmt.Sprintf("$%s", costStr),
@@ -200,38 +366,6 @@ func (p *prettyFormatter) renderAgentRun(e *log.Entry) []byte {
 	b.WriteString(footer("[" + strings.Join(footerParts, " · ") + "]"))
 	b.WriteString("\n\n")
 
-	return b.Bytes()
-}
-
-func asInt64(v any) int64 {
-	switch n := v.(type) {
-	case int:
-		return int64(n)
-	case int64:
-		return n
-	case float64:
-		return int64(n)
-	}
-	return 0
-}
-
-// lenWithoutANSI counts visible runes, ignoring ANSI escape codes. Used so the
-// rule line above the header matches its visible width when colors are on.
-func lenWithoutANSI(s string) int {
-	n := 0
-	in := false
-	for _, r := range s {
-		if r == 0x1b {
-			in = true
-			continue
-		}
-		if in {
-			if r == 'm' {
-				in = false
-			}
-			continue
-		}
-		n++
-	}
-	return n
+	_, err := p.out.Write(b.Bytes())
+	return err
 }

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	log "github.com/sirupsen/logrus"
+	"log/slog"
 )
 
 // HclWriteFile contains the encoded hclwrite.File and the byte array of the file with
@@ -64,7 +64,7 @@ func MarshallHcl(conf Config, path string) string {
 	_, writeErr := destination.Write(b)
 	// _, writeErr := f.WriteTo(destination)
 	if writeErr != nil {
-		log.Error("write error")
+		slog.Error("write error")
 	}
 	destination.Close()
 	return path
@@ -96,7 +96,7 @@ func ParseFile(cronicleFile string, parser *hclparse.Parser) (*Config, hcl.Diagn
 func (conf Config) JSON() []byte {
 	b, err := json.Marshal(&conf)
 	if err != nil {
-		log.Error(err)
+		slog.Error("json marshal failed", "error", err.Error())
 	}
 	return b
 }
@@ -105,7 +105,7 @@ func (conf Config) JSON() []byte {
 func (schedule Schedule) JSON() []byte {
 	b, err := json.Marshal(&schedule)
 	if err != nil {
-		log.Error(err)
+		slog.Error("json marshal failed", "error", err.Error())
 	}
 	return b
 }
@@ -114,7 +114,7 @@ func (schedule Schedule) JSON() []byte {
 func (task Task) JSON() []byte {
 	b, err := json.Marshal(&task)
 	if err != nil {
-		log.Error(err)
+		slog.Error("json marshal failed", "error", err.Error())
 	}
 	return b
 }


### PR DESCRIPTION
## Summary

logrus has been in maintenance mode since ~2020. log/slog (Go 1.21+) is the standard library's modern replacement and lets us drop a third-party dependency. This is the foundation PR for the next two threads: pretty rendering across the whole execution, and streaming agent output.

## What changed

**logrus.Formatter + logrus.Hook → slog.Handler composition**

The migration replaces the prior Formatter+Hook model with slog's Handler model, which composes more cleanly:

- `prettyHandler` renders \`agent_run\` records as a multi-line block and delegates non-agent records to a wrapped fallback. Same UX as before.
- `tintHandler` is the new fallback for pretty mode: a colored \`INFO[ts] msg key=val\` style reminiscent of logrus's TextFormatter, written from scratch as a slog.Handler.
- `multiHandler` fans \`Handle\` out across multiple handlers, replacing the logrus \`AddHook\` pattern. Used by \`EnableFileLog\` to mirror stdout to \`.cronicle/log/cronicle.jsonl\`.
- `tzHandler` wraps any handler to apply a timezone, replacing \`TZFormatter\`.
- \`cronicle.Fatal\` helper replaces \`log.Fatal\` (slog has no Fatal level).

## Visible differences

| Mode | Before (logrus) | After (slog) |
|---|---|---|
| pretty | bordered block + colored INFO[ts] | Identical UX |
| text | \`time="..." level=info msg="..." k=v\` | \`time=... level=INFO msg=... k=v\` (uppercase level, unquoted time) |
| json | \`{"level":"info","msg":"...","time":"..."}\` | \`{"time":"...","level":"INFO","msg":"...",...}\` |

Both text and json are still parsed cleanly by Vector/Datadog/Loki/Promtail without parser changes — they key on field names, not order.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go mod tidy\` removes \`sirupsen/logrus\` (verified: \`grep -c sirupsen go.mod\` = 0)
- [x] \`go test ./internal/cronicle/...\` — 53 of 55 specs pass; the 2 remaining failures are pre-existing GitHub-SSH-dependent tests, unrelated to this PR
- [x] End-to-end smoke runs against the live API for all three formats:
  - \`--log-format=pretty\` → bordered agent block + colored INFO[ts] lines (matches prior UX)
  - \`--log-format=text\` → one logfmt line per event with response field
  - \`--log-format=json\` → one JSON object per event
  - \`--log-format=pretty --log-to-file\` → pretty stdout + structured JSON file simultaneously

## Sequencing

This is PR 1 of 3 in the agent-pretty-logging stack:
1. **This PR**: migrate to slog (foundation, no UX change)
2. Next: pretty rendering for the whole cronicle execution (DAG print, lifecycle events, shell task output)
3. Then: streaming agent output (text deltas, thinking blocks, tool calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)