### PR TITLE
Pretty rendering for the whole cronicle execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,49 @@ schedule "example" {
 
 `cronicle run --path cron/cronicle.hcl`
 ```
-INFO[2020-10-06T21:44:16-07:00] Starting Scheduler...                         cronicle=start
-INFO[2020-10-06T21:44:16-07:00] Loading config...                             cronicle=heartbeat path=./cronicle.hcl
-INFO[2020-10-06T21:44:21-07:00] Queuing...                                    schedule=example
-INFO[2020-10-06T21:44:21-07:00]                                               attempt=1 schedule=example task=hello
-INFO[2020-10-06T21:44:21-07:00] X: 0.360346904169                             commit=f99ad6af7de email=jason.shiverick@gmail.com exit=0 schedule=example success=true task=hello
+21:44:16 config loaded path=./cronicle/cronicle.hcl schedules=1 tasks=1
+21:44:16 Starting Scheduler... cronicle=start
+21:44:16 Starting cron... schedule=example cron="@every 5s"
+21:44:21 Queuing... schedule=example
+──── 21:44:21 · schedule "example" ──────────────────────────────────
+DAG:
+  └─ hello
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+shell run · schedule=example · task=hello · python run.py
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+X: 0.360346904169
+
+[exit=0 · 12ms]
+
+✓ schedule "example" complete · 1 task · 0.5s
 ```
+
+Agent tasks render in the same shape, with token usage and cost in the footer:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+agent run · schedule=example · task=summarize · model=claude-opus-4-7
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Today's deploy added agent task support, fixed a queue race, and bumped Go to 1.26.
+
+[64 in / 25 out tokens · $0.001050 · 873ms · stop=end_turn]
+```
+
+### Output formats
+
+`--log-format` controls stdout (default `auto` — pretty when at a TTY, text when piped):
+
+| flag | shape | best for |
+|---|---|---|
+| `--log-format=pretty` | bordered blocks, dim lifecycle | humans at a TTY |
+| `--log-format=text` | `time=... level=INFO msg=... key=val` | piping to a log consumer |
+| `--log-format=json` | one JSON object per line | strictest machine parsing |
+
+`--log-to-file` is independent of stdout: when set, structured JSON is mirrored to `.cronicle/log/cronicle.jsonl` (rotated by lumberjack: 500MB × 3 backups × 28 days, gzipped). Pretty stdout + tail-able JSON file at the same time is the intended composition.
+
+When `--log-to-file` is on, each task execution also writes a per-run JSONL transcript at `.cronicle/runs/{ts}-{schedule}-{task}.jsonl` (request / response / accounting). Without it, `cronicle exec` is fully ephemeral and writes nothing to disk.
 
 ---
 
@@ -158,9 +195,9 @@ retry {
 Run a Claude agent invocation in place of a shell command. A task may have an
 `agent` block or a `command`, but not both. `${date}`, `${datetime}`, and
 `${timestamp}` are substituted into `prompt` and `system` at execution time.
-Each run writes a JSONL transcript (request, response, token usage, cost) to
-`.cronicle/runs/` next to the cronicle root. Requires `ANTHROPIC_API_KEY` in the
-environment.
+With `--log-to-file`, each run writes a JSONL transcript (request, response,
+token usage, cost) to `.cronicle/runs/` next to the cronicle root. Requires
+`ANTHROPIC_API_KEY` in the environment.
 
 ```hcl
 task "summarize" {

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -13,8 +13,6 @@ import (
 	redisvice "github.com/matryer/vice/queues/redis"
 	"github.com/nsqio/go-nsq"
 
-	"github.com/fatih/color"
-
 	"path/filepath"
 
 	cron "github.com/robfig/cron/v3"
@@ -38,9 +36,16 @@ func Run(cronicleFile string, runOptions RunOptions) {
 		Fatal(err)
 	}
 	confPriorGlobal = conf
-	hcl := conf.Hcl()
-	slantyedCyan := color.New(color.FgCyan, color.Italic).SprintFunc()
-	fmt.Printf("%s", slantyedCyan(string(hcl.Bytes)))
+
+	taskCount := 0
+	for _, s := range conf.Schedules {
+		taskCount += len(s.Tasks)
+	}
+	slog.Info("config loaded",
+		"path", cronicleFileAbs,
+		"schedules", len(conf.Schedules),
+		"tasks", taskCount,
+	)
 
 	if runOptions.LogToFile {
 		if err := EnableFileLog(croniclePath); err != nil {

--- a/internal/cronicle/dag.go
+++ b/internal/cronicle/dag.go
@@ -20,22 +20,46 @@ func (schedule Schedule) ExecuteTasks() {
 	taskMap := schedule.TaskMap()
 
 	deps := make(map[string][]string)
+	taskNames := make([]string, 0, len(schedule.Tasks))
 	for _, task := range schedule.Tasks {
 		deps[task.Name] = task.Depends
+		taskNames = append(taskNames, task.Name)
 	}
 
-	slog.Info(dagString(deps),
+	startedAt := time.Now()
+	slog.Info("schedule started",
+		"entry_type", "schedule_start",
 		"schedule", schedule.Name,
 		"clock", now.Format(time.Kitchen),
 		"date", now.Format(time.RFC850),
+		"tasks", taskNames,
+		"dag", dagString(deps),
 	)
 
-	if err := walkDAG(deps, func(name string) error {
+	walkErr := walkDAG(deps, func(name string) error {
 		task := taskMap[name]
 		_, err := task.Execute(now)
 		return err
-	}); err != nil {
-		slog.Error("dag walk failed", "error", err.Error())
+	})
+	durationMs := time.Since(startedAt).Milliseconds()
+
+	if walkErr != nil {
+		slog.Error("schedule failed",
+			"entry_type", "schedule_complete",
+			"schedule", schedule.Name,
+			"task_count", len(schedule.Tasks),
+			"duration_ms", durationMs,
+			"success", false,
+			"error", walkErr.Error(),
+		)
+	} else {
+		slog.Info("schedule complete",
+			"entry_type", "schedule_complete",
+			"schedule", schedule.Name,
+			"task_count", len(schedule.Tasks),
+			"duration_ms", durationMs,
+			"success", true,
+		)
 	}
 }
 

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -157,7 +157,8 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 	var result exec.Result
 	err := try.Do(func(attempt int) (bool, error) {
 
-		slog.Info("Executing...",
+		slog.Info("task started",
+			"entry_type", "task_start",
 			"schedule", task.ScheduleName,
 			"task", task.Name,
 			"attempt", attempt,
@@ -203,6 +204,7 @@ func (task *Task) Log(res exec.Result) {
 	commit, email := task.gitMeta()
 
 	args := []any{
+		"entry_type", "shell_run",
 		"schedule", task.ScheduleName,
 		"task", task.Name,
 		"path", task.Path,
@@ -211,6 +213,8 @@ func (task *Task) Log(res exec.Result) {
 		"email", email,
 		"command", strings.Join(res.Command, " "),
 		"duration_ms", task.lastDurationMs,
+		"stdout", res.Stdout,
+		"stderr", res.Stderr,
 	}
 	if task.lastTranscript != "" {
 		args = append(args, "transcript", task.lastTranscript)
@@ -218,9 +222,9 @@ func (task *Task) Log(res exec.Result) {
 
 	if res.Error != nil {
 		args = append(args, "error", res.Error.Error(), "success", false)
-		slog.Error(res.Stderr, args...)
+		slog.Error("shell task failed", args...)
 	} else {
 		args = append(args, "success", true)
-		slog.Info(res.Stdout, args...)
+		slog.Info("shell task complete", args...)
 	}
 }

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -537,7 +537,8 @@ func (p *prettyHandler) renderScheduleStart(r slog.Record) error {
 	schedule := attrString(r, "schedule")
 	tasks := attrStrings(r, "tasks")
 
-	headerLine := fmt.Sprintf("schedule \"%s\"", schedule)
+	timeStr := r.Time.Format("15:04:05")
+	headerLine := fmt.Sprintf("%s · schedule \"%s\"", timeStr, schedule)
 	const totalWidth = 70
 	const leftRule = 4 // "────"
 	trailingCount := totalWidth - leftRule - 1 - len(headerLine) - 1

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -481,7 +481,7 @@ func (p *prettyHandler) renderShellRun(r slog.Record) error {
 	success := attrBool(r, "success")
 
 	headerLine := fmt.Sprintf("shell run · schedule=%s · task=%s · %s",
-		schedule, task, truncate(command, 60))
+		schedule, task, truncate(escapeControl(command), 60))
 	bar := strings.Repeat("━", len(headerLine)+8)
 
 	var b bytes.Buffer
@@ -624,6 +624,13 @@ func (p *prettyHandler) renderDimLine(r slog.Record) error {
 
 	_, err := p.out.Write(b.Bytes())
 	return err
+}
+
+// escapeControl replaces newlines and tabs with their literal escape forms so
+// they don't break a single-line header layout when the source is shell input.
+func escapeControl(s string) string {
+	r := strings.NewReplacer("\n", "\\n", "\t", "\\t", "\r", "\\r")
+	return r.Replace(s)
 }
 
 // truncate trims s to at most n runes, appending "…" when shortened.

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -267,8 +267,10 @@ func formatValue(v slog.Value) string {
 
 // ---- prettyHandler ---------------------------------------------------------
 
-// prettyHandler renders records with entry_type=agent_run as a multi-line
-// block; everything else falls through to the wrapped fallback handler.
+// prettyHandler renders structural records (entry_type=…) as multi-line blocks
+// or compact section headers, and everything else as a dim single line. The
+// fallback handler exists for nested compositions but isn't used for direct
+// rendering — pretty mode always renders something itself.
 type prettyHandler struct {
 	fallback slog.Handler
 	out      io.Writer
@@ -278,11 +280,24 @@ func (p *prettyHandler) Enabled(ctx context.Context, l slog.Level) bool {
 	return p.fallback.Enabled(ctx, l)
 }
 
-func (p *prettyHandler) Handle(ctx context.Context, r slog.Record) error {
-	if !isAgentRun(r) {
-		return p.fallback.Handle(ctx, r)
+func (p *prettyHandler) Handle(_ context.Context, r slog.Record) error {
+	switch entryType(r) {
+	case "agent_run":
+		return p.renderAgentRun(r)
+	case "shell_run":
+		return p.renderShellRun(r)
+	case "schedule_start":
+		return p.renderScheduleStart(r)
+	case "schedule_complete":
+		return p.renderScheduleComplete(r)
+	case "task_start":
+		// Block headers (agent_run / shell_run) subsume the start signal,
+		// so suppress task_start in pretty mode. The file mirror still
+		// gets the event.
+		return nil
+	default:
+		return p.renderDimLine(r)
 	}
-	return p.renderAgentRun(r)
 }
 
 func (p *prettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
@@ -293,16 +308,72 @@ func (p *prettyHandler) WithGroup(name string) slog.Handler {
 	return &prettyHandler{fallback: p.fallback.WithGroup(name), out: p.out}
 }
 
-func isAgentRun(r slog.Record) bool {
-	found := false
+// entryType extracts the entry_type attr from a record, returning "" if absent.
+func entryType(r slog.Record) string {
+	var et string
 	r.Attrs(func(a slog.Attr) bool {
-		if a.Key == "entry_type" && a.Value.String() == "agent_run" {
-			found = true
+		if a.Key == "entry_type" {
+			et = a.Value.String()
 			return false
 		}
 		return true
 	})
-	return found
+	return et
+}
+
+// attrString fetches a string-valued attribute by key, returning "" if missing.
+func attrString(r slog.Record, key string) string {
+	var s string
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			s = a.Value.String()
+			return false
+		}
+		return true
+	})
+	return s
+}
+
+// attrInt64 fetches an int64-valued attribute by key, returning 0 if missing.
+func attrInt64(r slog.Record, key string) int64 {
+	var n int64
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			n = a.Value.Int64()
+			return false
+		}
+		return true
+	})
+	return n
+}
+
+// attrBool fetches a bool-valued attribute by key, returning false if missing.
+func attrBool(r slog.Record, key string) bool {
+	var v bool
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			v = a.Value.Bool()
+			return false
+		}
+		return true
+	})
+	return v
+}
+
+// attrStrings fetches a []string-valued attribute by key. Used for the
+// schedule_start "tasks" attr, which slog.Any-wraps a string slice.
+func attrStrings(r slog.Record, key string) []string {
+	var out []string
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key != key {
+			return true
+		}
+		if v, ok := a.Value.Any().([]string); ok {
+			out = v
+		}
+		return false
+	})
+	return out
 }
 
 func (p *prettyHandler) renderAgentRun(r slog.Record) error {
@@ -389,4 +460,185 @@ func (p *prettyHandler) renderAgentRun(r slog.Record) error {
 
 	_, err := p.out.Write(b.Bytes())
 	return err
+}
+
+// renderShellRun renders a shell task as a block with the same shape as
+// agent_run: header rule, header line, body (stdout or stderr), footer.
+func (p *prettyHandler) renderShellRun(r slog.Record) error {
+	header := color.New(color.FgCyan, color.Bold).SprintFunc()
+	rule := color.New(color.FgCyan).SprintFunc()
+	footer := color.New(color.Faint).SprintFunc()
+	errc := color.New(color.FgRed, color.Bold).SprintFunc()
+
+	schedule := attrString(r, "schedule")
+	task := attrString(r, "task")
+	command := attrString(r, "command")
+	stdout := attrString(r, "stdout")
+	stderr := attrString(r, "stderr")
+	transcript := attrString(r, "transcript")
+	durationMs := attrInt64(r, "duration_ms")
+	exit := attrInt64(r, "exit")
+	success := attrBool(r, "success")
+
+	headerLine := fmt.Sprintf("shell run · schedule=%s · task=%s · %s",
+		schedule, task, truncate(command, 60))
+	bar := strings.Repeat("━", len(headerLine)+8)
+
+	var b bytes.Buffer
+	b.WriteString(rule(bar))
+	b.WriteByte('\n')
+	b.WriteString(header(headerLine))
+	b.WriteByte('\n')
+	b.WriteString(rule(bar))
+	b.WriteString("\n\n")
+
+	if success {
+		body := strings.TrimRight(stdout, "\n")
+		if body == "" {
+			b.WriteString(footer("(no stdout)\n"))
+		} else {
+			b.WriteString(body)
+			b.WriteByte('\n')
+		}
+	} else {
+		b.WriteString(errc("ERROR (exit "))
+		fmt.Fprintf(&b, "%d", exit)
+		b.WriteString(errc("):\n"))
+		body := strings.TrimRight(stderr, "\n")
+		if body == "" {
+			body = strings.TrimRight(stdout, "\n")
+		}
+		b.WriteString(body)
+		b.WriteByte('\n')
+	}
+
+	b.WriteByte('\n')
+	footerParts := []string{
+		fmt.Sprintf("exit=%d", exit),
+		fmt.Sprintf("%dms", durationMs),
+	}
+	if transcript != "" {
+		footerParts = append(footerParts, fmt.Sprintf("transcript=%s", filepath.Base(transcript)))
+	}
+	b.WriteString(footer("[" + strings.Join(footerParts, " · ") + "]"))
+	b.WriteString("\n\n")
+
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// renderScheduleStart renders the section header above a schedule's task
+// blocks: a horizontal rule, the schedule name, and the DAG list.
+func (p *prettyHandler) renderScheduleStart(r slog.Record) error {
+	rule := color.New(color.FgMagenta).SprintFunc()
+	header := color.New(color.FgMagenta, color.Bold).SprintFunc()
+	dim := color.New(color.Faint).SprintFunc()
+
+	schedule := attrString(r, "schedule")
+	tasks := attrStrings(r, "tasks")
+
+	headerLine := fmt.Sprintf("schedule \"%s\"", schedule)
+	const totalWidth = 70
+	const leftRule = 4 // "────"
+	trailingCount := totalWidth - leftRule - 1 - len(headerLine) - 1
+	if trailingCount < 0 {
+		trailingCount = 0
+	}
+
+	var b bytes.Buffer
+	b.WriteString(rule(strings.Repeat("─", leftRule)))
+	b.WriteByte(' ')
+	b.WriteString(header(headerLine))
+	b.WriteByte(' ')
+	b.WriteString(rule(strings.Repeat("─", trailingCount)))
+	b.WriteByte('\n')
+
+	if len(tasks) > 0 {
+		b.WriteString(dim("DAG:\n"))
+		for i, t := range tasks {
+			prefix := "  ├─ "
+			if i == len(tasks)-1 {
+				prefix = "  └─ "
+			}
+			b.WriteString(dim(prefix + t + "\n"))
+		}
+	}
+	b.WriteByte('\n')
+
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// renderScheduleComplete renders the summary line at the bottom of a schedule.
+func (p *prettyHandler) renderScheduleComplete(r slog.Record) error {
+	ok := color.New(color.FgGreen, color.Bold).SprintFunc()
+	bad := color.New(color.FgRed, color.Bold).SprintFunc()
+	dim := color.New(color.Faint).SprintFunc()
+
+	schedule := attrString(r, "schedule")
+	taskCount := attrInt64(r, "task_count")
+	durationMs := attrInt64(r, "duration_ms")
+	success := attrBool(r, "success")
+
+	var b bytes.Buffer
+	if success {
+		b.WriteString(ok("✓ "))
+		fmt.Fprintf(&b, "schedule \"%s\" complete ", schedule)
+	} else {
+		b.WriteString(bad("✗ "))
+		fmt.Fprintf(&b, "schedule \"%s\" failed ", schedule)
+		errMsg := attrString(r, "error")
+		if errMsg != "" {
+			b.WriteString(dim("(" + errMsg + ") "))
+		}
+	}
+	taskWord := "tasks"
+	if taskCount == 1 {
+		taskWord = "task"
+	}
+	b.WriteString(dim(fmt.Sprintf("· %d %s · %s", taskCount, taskWord, formatDuration(durationMs))))
+	b.WriteString("\n\n")
+
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// renderDimLine renders a record as a faint single line. Used for lifecycle
+// events (Loading, executing tasks, heartbeat, refreshing config, etc.) that
+// don't carry a structural entry_type.
+func (p *prettyHandler) renderDimLine(r slog.Record) error {
+	dim := color.New(color.Faint).SprintFunc()
+
+	var b bytes.Buffer
+	b.WriteString(dim(r.Time.Format("15:04:05")))
+	b.WriteByte(' ')
+	b.WriteString(dim(r.Message))
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "entry_type" {
+			return true
+		}
+		fmt.Fprintf(&b, " %s", dim(a.Key+"="+formatValue(a.Value)))
+		return true
+	})
+	b.WriteByte('\n')
+
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// truncate trims s to at most n runes, appending "…" when shortened.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+// formatDuration renders a millisecond value as "Nms" or "N.Ns" depending on
+// magnitude.
+func formatDuration(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%.1fs", float64(ms)/1000)
 }


### PR DESCRIPTION
## Summary

Pretty mode now renders the full schedule lifecycle, not just agent runs. Each schedule gets a magenta section header with its DAG; each task — shell *or* agent — renders as a bordered block with header, body, and metadata footer; the schedule closes with a green checkmark summary line. Lifecycle events (Loading, executing tasks, heartbeat refresh) render as compact dim lines for context without ceremony.

## What it looks like

\`\`\`
12:04:31 Loading /tmp/cronicle-agent-smoke/parallel.hcl
12:04:31 executing tasks... cronicle=exec
──── schedule "parallel" ─────────────────────────────────────────────
DAG:
  ├─ haiku_about_cron
  ├─ haiku_about_git
  └─ haiku_about_yaml

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
agent run · schedule=parallel · task=haiku_about_cron · model=claude-haiku-4-5
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Tasks tick like clockwork
At midnight the logs fill up
Servers sleep, then wake

[22 in / 22 out tokens · $0.000132 · 797ms · stop=end_turn]

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
shell run · schedule=mixed · task=gather · /bin/sh -c echo 'host=...'
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

host=x1.local; date=2026-05-09

[exit=0 · 5ms]

✓ schedule "parallel" complete · 3 tasks · 3.8s
\`\`\`

## What changed

**Three new \`entry_type\` values on the slog stream:**

| entry_type | emitted by | carries |
|---|---|---|
| \`schedule_start\` | \`ExecuteTasks\` (before DAG walk) | name, ordered task list, DAG string |
| \`schedule_complete\` | \`ExecuteTasks\` (after DAG walk) | name, task_count, duration_ms, success |
| \`shell_run\` | \`task.Log\` (shell branch) | command, stdout, stderr, exit, duration, transcript |

\`agent_run\` is unchanged. \`task_start\` is now tagged so the file mirror has structured events (it was just \"Executing...\" before).

**Pretty handler dispatch:**

| entry_type | rendering |
|---|---|
| \`agent_run\` | bordered block (existing) |
| \`shell_run\` | bordered block (new, same shape) |
| \`schedule_start\` | magenta rule + name + DAG tree |
| \`schedule_complete\` | green checkmark summary line |
| \`task_start\` | suppressed in pretty (block headers subsume the start signal) |
| (default) | faint single-line dim renderer for lifecycle/unknown records |

## Backward compatibility

- Text and JSON stdout modes are unchanged in shape; they just gain the new \`entry_type\` field on each event. Log consumers that filter on entry_type can route/group accordingly.
- File mirror (\`cronicle.jsonl\`) carries every event regardless of stdout format, including all the new structural events.
- The shell run event message changed from \`<stdout>\` to \`shell task complete\` to match the new structured shape; consumers grepping for stdout-as-message will need to read the \`stdout\` field instead. Same data, different shape.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/cronicle/...\` — 53 of 55 pass; the 2 failures are pre-existing GitHub-SSH-dependent tests, unrelated to this PR
- [x] Pretty mode against parallel/mixed/longer schedules — schedule header + DAG, agent blocks, shell blocks, multi-line agent responses, summary line all render
- [x] Text mode + \`--log-to-file\` — every event including new entry_types appears as logfmt on stdout and JSON in cronicle.jsonl
- [x] JSON mode — every event as a JSON object per line

## Sequencing

This is PR 3 of 4 in the agent-pretty-logging series:
1. ✅ slog migration (#62)
2. ✅ unified transcripts + opt-in disk persistence (#63)
3. **This PR** — pretty rendering for the whole execution
4. Next: streaming agent output (text deltas, thinking blocks, tool calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)