### PR TITLE
Multi-turn agent loop with bash tool and bounded iteration

### DIFF
--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -83,8 +83,20 @@ type Agent struct {
 	System string `hcl:"system,optional"`
 	// MaxTokens caps the response length. 0 uses the pkg/agent default.
 	MaxTokens int `hcl:"max_tokens,optional"`
-	// BudgetUSD aborts the task if the run's cost exceeds this. 0 disables.
+	// BudgetUSD aborts the task if the run's cumulative cost exceeds this.
+	// Checked after each turn for mid-run abort. 0 disables.
 	BudgetUSD float64 `hcl:"budget_usd,optional"`
+	// Tools is the allowlist of Anthropic-defined tools the agent can
+	// invoke. Empty means single-turn agent (current behavior). Known
+	// values: "bash". Unknown names cause Validate to fail.
+	Tools []string `hcl:"tools,optional"`
+	// MaxTurns is the hard cap on agent loop iterations. 0 means default
+	// (1 if no tools, 30 otherwise).
+	MaxTurns int `hcl:"max_turns,optional"`
+	// Wallclock is a duration string (e.g. "10m") setting an upper bound
+	// on the entire run. Empty means default ("10m"). Parsed via
+	// time.ParseDuration.
+	Wallclock string `hcl:"wallclock,optional"`
 }
 
 // Repo is the structure that defines a git repository
@@ -169,9 +181,32 @@ func (task *Task) Validate() error {
 		if task.Agent.Prompt == "" {
 			return ErrAgentPromptEmpty
 		}
+		for _, name := range task.Agent.Tools {
+			if !knownAgentTool(name) {
+				return fmt.Errorf("unknown agent tool %q (known: bash)", name)
+			}
+		}
+		if task.Agent.MaxTurns < 0 {
+			return errors.New("agent max_turns must be >= 0")
+		}
+		if task.Agent.Wallclock != "" {
+			if _, err := time.ParseDuration(task.Agent.Wallclock); err != nil {
+				return fmt.Errorf("agent wallclock parse: %w", err)
+			}
+		}
 	}
 
 	return nil
+}
+
+// knownAgentTool reports whether name is a recognized Anthropic-defined tool
+// in the current cronicle build. Extend as new tools (text_editor, etc.) land.
+func knownAgentTool(name string) bool {
+	switch name {
+	case "bash":
+		return true
+	}
+	return false
 }
 
 //Validate checks that schedule.Name is not empty and assigns task.ScheduleName

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -104,6 +104,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		Model:         task.Agent.Model,
 		MaxTokens:     task.Agent.MaxTokens,
 		BudgetUSD:     task.Agent.BudgetUSD,
+		MaxTurns:      task.Agent.MaxTurns,
 		TranscriptDir: TranscriptDir(), // "" unless --log-to-file
 		RunID:         runID,
 	}
@@ -126,8 +127,29 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		cfg.StreamHandler = NewAgentStreamRenderer(sw)
 	}
 
+	// Tools: bind to the task's workspace and stream writer so bash output
+	// flows into the agent's pretty block AND the cronicle execution
+	// context stays consistent (same cwd as a shell task would have).
+	var toolWriter io.Writer
+	if streaming {
+		toolWriter = sw
+	}
+	cfg.Tools = buildAgentTools(task.Agent.Tools, task.Path, task.Env, toolWriter)
+
+	// Wallclock bound: derive a context deadline from the HCL string. Default
+	// 10m if unset. Wallclock is enforced via context cancellation; the agent
+	// loop will return whatever's been gathered so far when the deadline fires.
+	wallclock := 10 * time.Minute
+	if task.Agent.Wallclock != "" {
+		if d, err := time.ParseDuration(task.Agent.Wallclock); err == nil {
+			wallclock = d
+		}
+	}
+	runCtx, cancel := context.WithTimeout(context.Background(), wallclock)
+	defer cancel()
+
 	startedAt := time.Now()
-	res, err := agent.Run(context.Background(), cfg)
+	res, err := agent.Run(runCtx, cfg)
 	durationMs := time.Since(startedAt).Milliseconds()
 
 	if streaming {

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -3,6 +3,7 @@ package cronicle
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -589,54 +590,69 @@ func WriteShellRunFooter(w io.Writer, exit int64, durationMs int64, transcriptPa
 
 // NewAgentStreamRenderer returns a StreamHandler that writes the body of an
 // agent run block to w. Text deltas pass through; thinking deltas render
-// dimmed and prefixed; tool_use events render as a structured indicator.
+// dimmed and prefixed; tool_use events render with the parsed command (for
+// bash) on tool_use_stop; tool_result events render an exit/duration line
+// (success green, error red).
+//
 // The caller is responsible for writing the header before the first event
 // and the footer after the run completes.
 func NewAgentStreamRenderer(w io.Writer) agent.StreamHandler {
 	dim := color.New(color.Faint).SprintFunc()
 	toolHi := color.New(color.FgYellow).SprintFunc()
+	ok := color.New(color.FgGreen, color.Faint).SprintFunc()
+	bad := color.New(color.FgRed, color.Faint).SprintFunc()
 
 	inThinking := false
-	inToolUse := false
 
-	closeMode := func() {
+	flushThinking := func() {
 		if inThinking {
 			fmt.Fprintln(w)
 			inThinking = false
-		}
-		if inToolUse {
-			fmt.Fprintln(w, toolHi(")"))
-			inToolUse = false
 		}
 	}
 
 	return func(e agent.StreamEvent) {
 		switch e.Type {
 		case agent.StreamEventTextDelta:
-			closeMode()
+			flushThinking()
 			fmt.Fprint(w, e.Text)
 		case agent.StreamEventThinkingDelta:
-			if inToolUse {
-				fmt.Fprintln(w, toolHi(")"))
-				inToolUse = false
-			}
 			if !inThinking {
 				fmt.Fprint(w, dim("\n┊ thinking: "))
 				inThinking = true
 			}
 			fmt.Fprint(w, dim(e.Text))
 		case agent.StreamEventToolUseStart:
-			closeMode()
-			fmt.Fprintf(w, "\n%s%s%s",
-				toolHi("→ tool: "), toolHi(e.ToolName), toolHi("("))
-			inToolUse = true
-		case agent.StreamEventToolUseDelta:
-			fmt.Fprint(w, toolHi(e.ToolInput))
-		case agent.StreamEventToolUseStop:
-			fmt.Fprintln(w, toolHi(")"))
-			inToolUse = false
+			flushThinking()
+			fmt.Fprintf(w, "\n%s%s%s %s\n",
+				toolHi("→ "), toolHi(e.ToolName), toolHi(":"),
+				formatToolInput(e.ToolInput))
+		case agent.StreamEventToolResult:
+			marker := ok("← exit=0")
+			if e.IsError {
+				marker = bad("← error")
+			}
+			fmt.Fprintf(w, "%s %s\n", marker, dim(formatDuration(e.DurationMs)))
+		case agent.StreamEventTurnStart:
+			fmt.Fprintln(w, dim(fmt.Sprintf("\n— turn %d —", e.TurnIndex+1)))
 		}
 	}
+}
+
+// formatToolInput renders the raw JSON tool input compactly for the pretty
+// stream. For bash specifically, it extracts the command and shows it
+// directly (no JSON wrapping). For unknown tools, the JSON is shown verbatim.
+func formatToolInput(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var args struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal([]byte(raw), &args); err == nil && args.Command != "" {
+		return args.Command
+	}
+	return raw
 }
 
 // renderShellRun renders a shell task as a block with the same shape as

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -5,12 +5,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/jshiv/cronicle/pkg/agent"
 	"github.com/jshiv/cronicle/pkg/exec"
 )
+
+// MaxToolOutputBytes caps how much bash output we feed back to the model in
+// a single tool_result. Outputs exceeding this are middle-truncated (head
+// + tail preserved, middle dropped with a marker). Matches Claude Code's
+// 30K default — keeps the next-turn context bounded against runaway commands.
+const MaxToolOutputBytes = 30 * 1024
+
+// ansiCSI matches ANSI CSI escape sequences (color codes, cursor moves).
+// Stripped from bash output before truncation so the byte count reflects
+// real content, not control bytes the model can't use anyway.
+var ansiCSI = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
 // BashTool implements agent.Tool by wrapping pkg/exec.ExecuteWithStream so
 // that bash invoked by an agent runs through the exact same execution path
@@ -41,6 +53,12 @@ func (b *BashTool) Definition() anthropic.ToolUnionParam {
 //	<stdout>
 //	--- stderr ---           (only when stderr non-empty)
 //	<stderr>
+//
+// The combined output is ANSI-stripped and middle-truncated to
+// MaxToolOutputBytes so a runaway command can't pollute the next turn's
+// context. Cancellation propagates: when ctx is done (typically because the
+// agent's wallclock fired), the bash process group is signalled SIGTERM and
+// then SIGKILL.
 func (b *BashTool) Execute(ctx context.Context, input json.RawMessage) (string, bool) {
 	var args struct {
 		Command string `json:"command"`
@@ -53,24 +71,49 @@ func (b *BashTool) Execute(ctx context.Context, input json.RawMessage) (string, 
 	}
 
 	cmd := []string{"/bin/sh", "-c", args.Command}
-	res := exec.ExecuteWithStream(cmd, b.Workspace, b.Env, b.StdoutW, b.StderrW)
+	res := exec.ExecuteWithStreamContext(ctx, cmd, b.Workspace, b.Env, b.StdoutW, b.StderrW)
+
+	stdout := stripANSI(res.Stdout)
+	stderr := stripANSI(res.Stderr)
 
 	var sb strings.Builder
 	if res.ExitStatus != 0 {
 		fmt.Fprintf(&sb, "exit_code: %d\n", res.ExitStatus)
 	}
-	if res.Stdout != "" {
-		sb.WriteString(res.Stdout)
+	if stdout != "" {
+		sb.WriteString(stdout)
 	}
-	if res.Stderr != "" {
+	if stderr != "" {
 		sb.WriteString("\n--- stderr ---\n")
-		sb.WriteString(res.Stderr)
+		sb.WriteString(stderr)
 	}
 	if sb.Len() == 0 {
-		// No output at all but exit=0 — still tell the model the command ran.
 		sb.WriteString("(no output)")
 	}
-	return sb.String(), res.ExitStatus != 0
+	return truncateOutput(sb.String(), MaxToolOutputBytes), res.ExitStatus != 0
+}
+
+// stripANSI removes ANSI CSI escape sequences from s.
+func stripANSI(s string) string {
+	if !strings.ContainsRune(s, 0x1b) {
+		return s
+	}
+	return ansiCSI.ReplaceAllString(s, "")
+}
+
+// truncateOutput returns s unchanged when it fits in max bytes; otherwise it
+// keeps the first and last halves of max with a marker noting how many
+// bytes were dropped from the middle. Middle-keep matters for shell
+// commands where both the start (the command framing) and the end (the
+// final lines, exit context) are usually the most informative.
+func truncateOutput(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	dropped := len(s) - max
+	half := max / 2
+	return fmt.Sprintf("%s\n\n... [%d bytes truncated] ...\n\n%s",
+		s[:half], dropped, s[len(s)-half:])
 }
 
 // buildAgentTools converts the HCL `tools` field into a slice of agent.Tool

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -1,0 +1,97 @@
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/jshiv/cronicle/pkg/agent"
+	"github.com/jshiv/cronicle/pkg/exec"
+)
+
+// BashTool implements agent.Tool by wrapping pkg/exec.ExecuteWithStream so
+// that bash invoked by an agent runs through the exact same execution path
+// as a shell task: cwd=workspace, env, stream-aware writers. Output flows
+// to the same stdoutW used by the agent's pretty-mode renderer when set,
+// otherwise it's just captured into the result string.
+type BashTool struct {
+	Workspace string
+	Env       []string
+	StdoutW   io.Writer // optional; for live pretty-mode streaming of bash output
+	StderrW   io.Writer // optional
+}
+
+// Name is "bash" (matches Anthropic-defined tool name).
+func (b *BashTool) Name() string { return "bash" }
+
+// Definition returns the SDK's bash_20250124 tool definition.
+func (b *BashTool) Definition() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfBashTool20250124: &anthropic.ToolBash20250124Param{},
+	}
+}
+
+// Execute runs the requested command and returns a tool_result string the
+// model can read on the next turn. Format:
+//
+//	exit_code: <n>          (only when non-zero)
+//	<stdout>
+//	--- stderr ---           (only when stderr non-empty)
+//	<stderr>
+func (b *BashTool) Execute(ctx context.Context, input json.RawMessage) (string, bool) {
+	var args struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return fmt.Sprintf("Error: invalid bash input: %v", err), true
+	}
+	if args.Command == "" {
+		return "Error: empty command", true
+	}
+
+	cmd := []string{"/bin/sh", "-c", args.Command}
+	res := exec.ExecuteWithStream(cmd, b.Workspace, b.Env, b.StdoutW, b.StderrW)
+
+	var sb strings.Builder
+	if res.ExitStatus != 0 {
+		fmt.Fprintf(&sb, "exit_code: %d\n", res.ExitStatus)
+	}
+	if res.Stdout != "" {
+		sb.WriteString(res.Stdout)
+	}
+	if res.Stderr != "" {
+		sb.WriteString("\n--- stderr ---\n")
+		sb.WriteString(res.Stderr)
+	}
+	if sb.Len() == 0 {
+		// No output at all but exit=0 — still tell the model the command ran.
+		sb.WriteString("(no output)")
+	}
+	return sb.String(), res.ExitStatus != 0
+}
+
+// buildAgentTools converts the HCL `tools` field into a slice of agent.Tool
+// implementations bound to the given workspace and stream writer (when in
+// pretty streaming mode). Unknown tools are filtered out (Validate has
+// already rejected them at parse time, so this is defensive).
+func buildAgentTools(names []string, workspace string, env []string, w io.Writer) []agent.Tool {
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]agent.Tool, 0, len(names))
+	for _, name := range names {
+		switch name {
+		case "bash":
+			out = append(out, &BashTool{
+				Workspace: workspace,
+				Env:       env,
+				StdoutW:   w,
+				StderrW:   w,
+			})
+		}
+	}
+	return out
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -38,6 +38,32 @@ type Config struct {
 	// is still returned by Run regardless. nil = silent (still streamed
 	// internally; no per-delta callback fired).
 	StreamHandler StreamHandler
+	// Tools is the set of tools the model can invoke. Each tool's
+	// Definition is sent on every turn; Execute is called when the model
+	// emits a matching tool_use block. When empty, the agent runs single
+	// turn (no tool dispatch).
+	Tools []Tool
+	// MaxTurns bounds the agent loop iterations. Default 1 when no Tools,
+	// otherwise treated as 30. The loop also exits naturally when the
+	// model's stop_reason != "tool_use".
+	MaxTurns int
+}
+
+// Tool is an executable tool the agent can invoke. Implementations live in
+// the cronicle wrapper (so they can use pkg/exec etc. without an import
+// cycle on this package).
+type Tool interface {
+	// Name is the tool name as the model sees it (e.g. "bash").
+	Name() string
+	// Definition returns the SDK tool param union (one of the Anthropic-
+	// defined tool variants like ToolBash20250124Param, or a custom
+	// ToolParam).
+	Definition() anthropic.ToolUnionParam
+	// Execute runs the tool with input from the model. The returned string
+	// becomes the tool_result content; isError reports whether the tool
+	// failed (the model gets a tool_result with is_error=true and can
+	// recover).
+	Execute(ctx context.Context, input json.RawMessage) (output string, isError bool)
 }
 
 // StreamEventType identifies the kind of streaming event.
@@ -49,15 +75,26 @@ const (
 	StreamEventToolUseStart  StreamEventType = "tool_use_start"
 	StreamEventToolUseDelta  StreamEventType = "tool_use_delta"
 	StreamEventToolUseStop   StreamEventType = "tool_use_stop"
+	// StreamEventToolResult fires after cronicle has executed a tool and
+	// has the result string ready. Not from the API stream — emitted by
+	// the agent loop itself.
+	StreamEventToolResult StreamEventType = "tool_result"
+	// StreamEventTurnStart fires at the top of each loop iteration after
+	// the first. Useful for renderers that want to delineate turns.
+	StreamEventTurnStart StreamEventType = "turn_start"
 )
 
 // StreamEvent is a single semantic event from an agent run.
 type StreamEvent struct {
-	Type      StreamEventType
-	Text      string // text_delta and thinking_delta carry the partial text here
-	ToolID    string // tool_use_* events
-	ToolName  string // tool_use_start
-	ToolInput string // tool_use_delta carries partial JSON here
+	Type       StreamEventType
+	Text       string // text_delta and thinking_delta carry the partial text here
+	ToolID     string // tool_use_* events
+	ToolName   string // tool_use_start; also tool_result
+	ToolInput  string // tool_use_delta carries partial JSON here
+	ToolOutput string // tool_result: the executed tool's output
+	IsError    bool   // tool_result: did the tool fail
+	DurationMs int64  // tool_result: execution time
+	TurnIndex  int    // turn_start: 0-based turn number
 }
 
 // StreamHandler is called with each StreamEvent as it arrives.
@@ -95,9 +132,13 @@ var pricing = map[string]modelPrice{
 // ErrBudgetExceeded is returned when the run's actual cost crosses cfg.BudgetUSD.
 var ErrBudgetExceeded = errors.New("agent run exceeded configured budget")
 
-// Run sends a single-turn message to Claude and returns the parsed result.
-// The transcript (request + response + accounting) is written to
-// cfg.TranscriptDir as JSONL when set.
+// Run drives the multi-turn agent loop: send conversation, stream the
+// response, dispatch any tool_use blocks to the configured Tools, append
+// tool_result blocks back into the conversation, and continue until the
+// model stops calling tools, MaxTurns is reached, the context is cancelled
+// (for wallclock bounds), or BudgetUSD is exceeded mid-run. With no Tools
+// configured, the loop terminates after one turn (single-turn behavior
+// preserved). The transcript captures every turn and tool result.
 func Run(ctx context.Context, cfg Config) (Result, error) {
 	model := cfg.Model
 	if model == "" {
@@ -119,122 +160,198 @@ func Run(ctx context.Context, cfg Config) (Result, error) {
 	}
 	client := anthropic.NewClient(opts...)
 
-	params := anthropic.MessageNewParams{
-		Model:     anthropic.Model(model),
-		MaxTokens: maxTokens,
-		Messages: []anthropic.MessageParam{
-			anthropic.NewUserMessage(anthropic.NewTextBlock(cfg.Prompt)),
-		},
+	toolMap := make(map[string]Tool, len(cfg.Tools))
+	var toolDefs []anthropic.ToolUnionParam
+	for _, t := range cfg.Tools {
+		toolMap[t.Name()] = t
+		toolDefs = append(toolDefs, t.Definition())
 	}
-	if cfg.System != "" {
-		params.System = []anthropic.TextBlockParam{{Text: cfg.System}}
+
+	maxTurns := cfg.MaxTurns
+	if maxTurns <= 0 {
+		if len(cfg.Tools) > 0 {
+			maxTurns = 30
+		} else {
+			maxTurns = 1
+		}
+	}
+
+	conversation := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock(cfg.Prompt)),
 	}
 
 	startedAt := time.Now().UTC()
-	stream := client.Messages.NewStreaming(ctx, params)
+	tw, _ := openTranscript(cfg, model, startedAt)
+	if tw != nil {
+		defer tw.close()
+		res.TranscriptPath = tw.path
+	}
 
 	var (
-		sb               strings.Builder
-		currentBlockType string
-		currentToolID    string
-		finalMsg         anthropic.Message
+		accText   strings.Builder
+		cumUsage  anthropic.Usage
+		finalStop anthropic.StopReason
+		turnsRun  int
+		runErr    error
 	)
 
-	for stream.Next() {
-		event := stream.Current()
-		switch event.Type {
-		case "message_start":
-			finalMsg = event.Message
-		case "content_block_start":
-			cb := event.ContentBlock
-			currentBlockType = cb.Type
-			currentToolID = cb.ID
-			if cb.Type == "tool_use" && cfg.StreamHandler != nil {
-				cfg.StreamHandler(StreamEvent{
-					Type:     StreamEventToolUseStart,
-					ToolID:   cb.ID,
-					ToolName: cb.Name,
-				})
+	for turn := 0; turn < maxTurns; turn++ {
+		if turn > 0 && cfg.StreamHandler != nil {
+			cfg.StreamHandler(StreamEvent{Type: StreamEventTurnStart, TurnIndex: turn})
+		}
+
+		params := anthropic.MessageNewParams{
+			Model:     anthropic.Model(model),
+			MaxTokens: maxTokens,
+			Messages:  conversation,
+		}
+		if cfg.System != "" {
+			params.System = []anthropic.TextBlockParam{{Text: cfg.System}}
+		}
+		if len(toolDefs) > 0 {
+			params.Tools = toolDefs
+		}
+
+		msg := anthropic.Message{}
+
+		stream := client.Messages.NewStreaming(ctx, params)
+		for stream.Next() {
+			event := stream.Current()
+			_ = msg.Accumulate(event)
+
+			// During the stream we only fire text / thinking deltas. Tool
+			// events fire later from the dispatch loop with the fully
+			// parsed input, so each tool's header / body / result renders
+			// as an atomic block even when the model emits multiple
+			// tool_use blocks in one turn.
+			if event.Type != "content_block_delta" {
+				continue
 			}
-		case "content_block_delta":
 			switch event.Delta.Type {
 			case "text_delta":
-				sb.WriteString(event.Delta.Text)
+				accText.WriteString(event.Delta.Text)
 				if cfg.StreamHandler != nil {
-					cfg.StreamHandler(StreamEvent{
-						Type: StreamEventTextDelta,
-						Text: event.Delta.Text,
-					})
+					cfg.StreamHandler(StreamEvent{Type: StreamEventTextDelta, Text: event.Delta.Text})
 				}
 			case "thinking_delta":
 				if cfg.StreamHandler != nil {
-					cfg.StreamHandler(StreamEvent{
-						Type: StreamEventThinkingDelta,
-						Text: event.Delta.Thinking,
-					})
-				}
-			case "input_json_delta":
-				if cfg.StreamHandler != nil {
-					cfg.StreamHandler(StreamEvent{
-						Type:      StreamEventToolUseDelta,
-						ToolID:    currentToolID,
-						ToolInput: event.Delta.PartialJSON,
-					})
+					cfg.StreamHandler(StreamEvent{Type: StreamEventThinkingDelta, Text: event.Delta.Thinking})
 				}
 			}
-		case "content_block_stop":
-			if currentBlockType == "tool_use" && cfg.StreamHandler != nil {
+		}
+
+		if streamErr := stream.Err(); streamErr != nil {
+			runErr = streamErr
+			res.Stderr = streamErr.Error()
+			if tw != nil {
+				tw.writeError(streamErr, time.Now().UTC())
+			}
+			break
+		}
+
+		turnsRun = turn + 1
+		finalStop = msg.StopReason
+
+		cumUsage.InputTokens += msg.Usage.InputTokens
+		cumUsage.OutputTokens += msg.Usage.OutputTokens
+		cumUsage.CacheCreationInputTokens += msg.Usage.CacheCreationInputTokens
+		cumUsage.CacheReadInputTokens += msg.Usage.CacheReadInputTokens
+
+		if tw != nil {
+			tw.writeResponse(turn, &msg, time.Now().UTC())
+		}
+
+		// Mid-run budget abort
+		currentCost := computeCost(model,
+			int(cumUsage.InputTokens), int(cumUsage.OutputTokens),
+			int(cumUsage.CacheCreationInputTokens), int(cumUsage.CacheReadInputTokens))
+		if cfg.BudgetUSD > 0 && currentCost > cfg.BudgetUSD {
+			runErr = fmt.Errorf("%w: $%.4f > $%.2f after turn %d",
+				ErrBudgetExceeded, currentCost, cfg.BudgetUSD, turn+1)
+			conversation = append(conversation, msg.ToParam())
+			break
+		}
+
+		conversation = append(conversation, msg.ToParam())
+
+		if msg.StopReason != "tool_use" {
+			break
+		}
+
+		// Dispatch tool_use blocks; assemble tool_result blocks.
+		var results []anthropic.ContentBlockParamUnion
+		for _, block := range msg.Content {
+			if block.Type != "tool_use" {
+				continue
+			}
+			tu := block.AsToolUse()
+			tool, ok := toolMap[tu.Name]
+
+			// Fire tool_use_start NOW (post-stream) so the renderer sees
+			// header → output → result as one atomic block per tool.
+			if cfg.StreamHandler != nil {
 				cfg.StreamHandler(StreamEvent{
-					Type:   StreamEventToolUseStop,
-					ToolID: currentToolID,
+					Type:      StreamEventToolUseStart,
+					ToolID:    tu.ID,
+					ToolName:  tu.Name,
+					ToolInput: string(tu.Input),
 				})
 			}
-			currentBlockType = ""
-			currentToolID = ""
-		case "message_delta":
-			finalMsg.StopReason = event.Delta.StopReason
-			finalMsg.Usage.InputTokens = event.Usage.InputTokens
-			finalMsg.Usage.OutputTokens = event.Usage.OutputTokens
-			finalMsg.Usage.CacheCreationInputTokens = event.Usage.CacheCreationInputTokens
-			finalMsg.Usage.CacheReadInputTokens = event.Usage.CacheReadInputTokens
+
+			var (
+				output  string
+				isError bool
+			)
+			var toolDurationMs int64
+			if !ok {
+				output = fmt.Sprintf("Error: tool %q not registered", tu.Name)
+				isError = true
+			} else {
+				toolStart := time.Now()
+				output, isError = tool.Execute(ctx, tu.Input)
+				toolDurationMs = time.Since(toolStart).Milliseconds()
+			}
+			if tw != nil {
+				tw.writeToolResult(turn, tu.ID, tu.Name, output, isError)
+			}
+			if cfg.StreamHandler != nil {
+				cfg.StreamHandler(StreamEvent{
+					Type:       StreamEventToolResult,
+					ToolID:     tu.ID,
+					ToolName:   tu.Name,
+					ToolOutput: output,
+					IsError:    isError,
+					DurationMs: toolDurationMs,
+				})
+			}
+			results = append(results, anthropic.NewToolResultBlock(tu.ID, output, isError))
 		}
+		if len(results) == 0 {
+			// Defensive: stop_reason said tool_use but no blocks present.
+			break
+		}
+		conversation = append(conversation, anthropic.NewUserMessage(results...))
 	}
+
 	finishedAt := time.Now().UTC()
 
-	if err := stream.Err(); err != nil {
-		res.Error = err
-		res.ExitStatus = 1
-		res.Stderr = err.Error()
-		writeTranscriptOnError(cfg, model, startedAt, finishedAt, err)
-		return res, err
-	}
-
-	// Synthesize a Message containing the aggregated text content for the
-	// transcript writer. Tool-use / thinking blocks aren't reconstructed here
-	// because today's transcript schema captures them as the API sees them
-	// (and we don't yet send tool definitions).
-	finalMsg.Content = []anthropic.ContentBlockUnion{
-		{Type: "text", Text: sb.String()},
-	}
-
-	res.Stdout = sb.String()
-	res.InputTokens = int(finalMsg.Usage.InputTokens)
-	res.OutputTokens = int(finalMsg.Usage.OutputTokens)
-	res.CacheReadIn = int(finalMsg.Usage.CacheReadInputTokens)
-	res.CacheWriteIn = int(finalMsg.Usage.CacheCreationInputTokens)
-	res.StopReason = string(finalMsg.StopReason)
+	res.Stdout = accText.String()
+	res.InputTokens = int(cumUsage.InputTokens)
+	res.OutputTokens = int(cumUsage.OutputTokens)
+	res.CacheReadIn = int(cumUsage.CacheReadInputTokens)
+	res.CacheWriteIn = int(cumUsage.CacheCreationInputTokens)
+	res.StopReason = string(finalStop)
 	res.CostUSD = computeCost(model, res.InputTokens, res.OutputTokens, res.CacheWriteIn, res.CacheReadIn)
 
-	if path, werr := writeTranscript(cfg, model, startedAt, finishedAt, &finalMsg, res); werr == nil {
-		res.TranscriptPath = path
+	if tw != nil {
+		tw.writeAccounting(turnsRun, res, finishedAt)
 	}
 
-	if cfg.BudgetUSD > 0 && res.CostUSD > cfg.BudgetUSD {
-		res.Error = fmt.Errorf("%w: $%.4f > $%.2f", ErrBudgetExceeded, res.CostUSD, cfg.BudgetUSD)
+	if runErr != nil {
+		res.Error = runErr
 		res.ExitStatus = 1
-		return res, res.Error
+		return res, runErr
 	}
-
 	return res, nil
 }
 
@@ -263,66 +380,94 @@ func transcriptPath(cfg Config) (string, error) {
 	return filepath.Join(cfg.TranscriptDir, name+".jsonl"), nil
 }
 
-func writeTranscript(cfg Config, model string, started, finished time.Time, msg *anthropic.Message, res Result) (string, error) {
+// transcriptWriter is a per-run JSONL writer that records every turn's
+// request/response, every tool result, and a final accounting line. The file
+// is opened at the start of Run and appended to incrementally so that even
+// crashed/aborted runs leave a partial transcript on disk.
+type transcriptWriter struct {
+	path string
+	f    *os.File
+	enc  *json.Encoder
+}
+
+func openTranscript(cfg Config, model string, started time.Time) (*transcriptWriter, error) {
 	path, err := transcriptPath(cfg)
 	if err != nil || path == "" {
-		return "", err
+		return nil, err
 	}
 	f, err := os.Create(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	_ = enc.Encode(map[string]any{
+	tw := &transcriptWriter{path: path, f: f, enc: json.NewEncoder(f)}
+	_ = tw.enc.Encode(map[string]any{
 		"type":       "request",
 		"started_at": started,
 		"model":      model,
 		"system":     cfg.System,
 		"prompt":     cfg.Prompt,
 		"max_tokens": cfg.MaxTokens,
+		"tools":      toolNames(cfg.Tools),
+		"max_turns":  cfg.MaxTurns,
 	})
-	_ = enc.Encode(map[string]any{
+	return tw, nil
+}
+
+func (tw *transcriptWriter) writeResponse(turn int, msg *anthropic.Message, finished time.Time) {
+	_ = tw.enc.Encode(map[string]any{
 		"type":        "response",
+		"turn":        turn,
 		"finished_at": finished,
 		"id":          msg.ID,
 		"stop_reason": msg.StopReason,
 		"content":     msg.Content,
 		"usage":       msg.Usage,
 	})
-	_ = enc.Encode(map[string]any{
+}
+
+func (tw *transcriptWriter) writeToolResult(turn int, toolUseID, name, output string, isError bool) {
+	_ = tw.enc.Encode(map[string]any{
+		"type":        "tool_result",
+		"turn":        turn,
+		"tool_use_id": toolUseID,
+		"tool_name":   name,
+		"output":      output,
+		"is_error":    isError,
+	})
+}
+
+func (tw *transcriptWriter) writeAccounting(turns int, res Result, finished time.Time) {
+	_ = tw.enc.Encode(map[string]any{
 		"type":          "accounting",
+		"turns":         turns,
+		"finished_at":   finished,
 		"input_tokens":  res.InputTokens,
 		"output_tokens": res.OutputTokens,
 		"cache_read":    res.CacheReadIn,
 		"cache_write":   res.CacheWriteIn,
 		"cost_usd":      res.CostUSD,
 	})
-	return path, nil
 }
 
-func writeTranscriptOnError(cfg Config, model string, started, finished time.Time, runErr error) {
-	path, err := transcriptPath(cfg)
-	if err != nil || path == "" {
-		return
-	}
-	f, err := os.Create(path)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	_ = enc.Encode(map[string]any{
-		"type":       "request",
-		"started_at": started,
-		"model":      model,
-		"system":     cfg.System,
-		"prompt":     cfg.Prompt,
-		"max_tokens": cfg.MaxTokens,
-	})
-	_ = enc.Encode(map[string]any{
+func (tw *transcriptWriter) writeError(err error, finished time.Time) {
+	_ = tw.enc.Encode(map[string]any{
 		"type":        "error",
 		"finished_at": finished,
-		"error":       runErr.Error(),
+		"error":       err.Error(),
 	})
+}
+
+func (tw *transcriptWriter) close() {
+	if tw == nil || tw.f == nil {
+		return
+	}
+	_ = tw.f.Close()
+}
+
+func toolNames(tools []Tool) []string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name()
+	}
+	return names
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -274,6 +274,14 @@ func Run(ctx context.Context, cfg Config) (Result, error) {
 
 		conversation = append(conversation, msg.ToParam())
 
+		// pause_turn: server-side tool flow asked us to continue without
+		// dispatching anything ourselves. Loop back without appending tool
+		// results — the next request lets the model keep going from where
+		// it paused.
+		if msg.StopReason == "pause_turn" {
+			continue
+		}
+
 		if msg.StopReason != "tool_use" {
 			break
 		}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -2,11 +2,13 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
 	goexec "os/exec"
 	"syscall"
+	"time"
 )
 
 //BashRun pulls from examples at https://zaiste.net/executing_external_commands_in_go/
@@ -67,6 +69,78 @@ func Execute(command []string, dir string, env []string) Result {
 		}
 	} else {
 		// Success
+		waitStatus = cmd.ProcessState.Sys().(syscall.WaitStatus)
+		result.ExitStatus = waitStatus.ExitStatus()
+	}
+
+	if result.Error == nil {
+		result.Error = exitStatusError(result)
+	}
+	return result
+}
+
+// ExecuteWithStreamContext is like ExecuteWithStream but ties the child
+// process lifetime to ctx: when ctx is cancelled (e.g. via the agent
+// runtime's wallclock deadline), the entire process group is signalled with
+// SIGTERM, escalating to SIGKILL after 2 seconds if needed. The child runs
+// in its own pgid so subprocesses spawned by the command (think
+// `bash -c "sleep 30 | cat"`) all die together — important for unattended
+// cronicle agents where a stuck bash invocation would otherwise outlive
+// the run.
+func ExecuteWithStreamContext(ctx context.Context, command []string, dir string, env []string, stdoutW, stderrW io.Writer) Result {
+	var result Result
+	result.Command = command
+	var cmd *goexec.Cmd
+	switch len(command) {
+	case 1:
+		cmd = goexec.CommandContext(ctx, command[0])
+	default:
+		cmd = goexec.CommandContext(ctx, command[0], command[1:]...)
+	}
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	for _, e := range env {
+		cmd.Env = append(cmd.Env, e)
+	}
+	// Run the child in its own process group so we can signal the whole
+	// group on cancellation instead of just the immediate child.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Override the default Cancel (which is cmd.Process.Kill on the leader)
+	// to signal the entire group, then let WaitDelay escalate to SIGKILL.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 2 * time.Second
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if stdoutW != nil {
+		cmd.Stdout = io.MultiWriter(&stdoutBuf, stdoutW)
+	} else {
+		cmd.Stdout = &stdoutBuf
+	}
+	if stderrW != nil {
+		cmd.Stderr = io.MultiWriter(&stderrBuf, stderrW)
+	} else {
+		cmd.Stderr = &stderrBuf
+	}
+
+	runErr := cmd.Run()
+	result.Stdout = stdoutBuf.String()
+	result.Stderr = stderrBuf.String()
+
+	var waitStatus syscall.WaitStatus
+	if runErr != nil {
+		if exitError, ok := runErr.(*goexec.ExitError); ok {
+			waitStatus = exitError.Sys().(syscall.WaitStatus)
+			result.ExitStatus = waitStatus.ExitStatus()
+			result.Error = errors.New(exitError.Error())
+		} else {
+			result.Error = runErr
+		}
+	} else if cmd.ProcessState != nil {
 		waitStatus = cmd.ProcessState.Sys().(syscall.WaitStatus)
 		result.ExitStatus = waitStatus.ExitStatus()
 	}

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,7 +1,9 @@
 package exec
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -44,5 +46,19 @@ var _ = Describe("exec", func() {
 		expected := Result{Command: command, Stdout: "", Stderr: "/bin/bash: not_a_script: No such file or directory\n", ExitStatus: 127, Error: exitError}
 		Expect(res).To(Equal(expected))
 		Expect(err).To(Equal(exitError))
+	})
+
+	It("ExecuteWithStreamContext should kill the process group when ctx is cancelled", func() {
+		// Spawn `bash -c "sleep 30 | sleep 30"` so there are subprocesses
+		// in the group, set a short timeout, and verify the call returns
+		// well before the sleep would have completed.
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		started := time.Now()
+		res := ExecuteWithStreamContext(ctx, []string{"/bin/sh", "-c", "sleep 30 | sleep 30"},
+			"./", nil, nil, nil)
+		elapsed := time.Since(started)
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second))
+		Expect(res.Error).NotTo(BeNil())
 	})
 })


### PR DESCRIPTION
## Summary

This is the foundation of cronicle as an agentic execution layer. The agent block now drives a real conversation: dispatch tool calls, feed their results back to the model, continue until the model stops requesting tools, max_turns is reached, the wallclock deadline fires, or the cumulative budget is exceeded mid-run. Single-turn behavior (no tools configured) is preserved unchanged.

## What it looks like

\`\`\`hcl
task "inspect" {
  agent {
    prompt     = "Use bash to inspect this directory and tell me about it. Today is \${date}."
    model      = "claude-haiku-4-5"
    tools      = ["bash"]
    max_turns  = 8
    wallclock  = "2m"
    budget_usd = 0.05
  }
}
\`\`\`

Pretty mode output:

\`\`\`
agent run · schedule=agent_bash · task=inspect · model=claude-haiku-4-5

I'll inspect the current directory for you.
→ bash: pwd && ls -la
/private/tmp/cronicle-agent-smoke
total 43448
drwxr-xr-x  ...
← exit=0 15ms

— turn 2 —
Let me also check the file types:
→ bash: file *
agent_bash.hcl: ASCII text
cronicle:       Mach-O 64-bit executable arm64
...
← exit=0 36ms

— turn 3 —
## Summary
This directory appears to be a testing environment for Cronicle...

[3691 in / 350 out tokens · \$0.005441 · 4328ms · stop=end_turn]
\`\`\`

## What changed

**pkg/agent — multi-turn loop**
- \`Run\` replaced with a streaming loop that uses the SDK's \`Message.Accumulate\` to build up each turn's full message, then dispatches any \`tool_use\` blocks to configured Tools and feeds back \`tool_result\` blocks as a user message.
- Cumulative usage and cost tracked across turns. Per-turn cost checked against \`BudgetUSD\` for mid-run abort. Context deadline (set by the cronicle wrapper from \`wallclock\`) cancels the loop.
- New \`Tool\` interface with \`Name() / Definition() / Execute(ctx, input)\`. Implementations live in cronicle to avoid pulling exec/HCL deps into pkg/agent.
- Stream events restructured: \`tool_use_start\` now fires from the dispatch loop (post-stream) with the fully parsed input, so each tool's header → output → result renders as one atomic block even when the model emits multiple tool_use blocks in a single turn. New \`tool_result\` event carries duration_ms.
- Transcript schema extended: one record per turn (\`response\`), one per tool result (\`tool_result\`), one final \`accounting\` summing across all turns. Single-turn runs still produce the same shape they did before, just with \`turn=0\` and \`turns=1\`.

**internal/cronicle — HCL surface**
- \`Agent\` struct gains \`Tools []string\`, \`MaxTurns int\`, \`Wallclock string\`.
- \`Validate\` rejects unknown tool names (only \`bash\` recognized in this PR), \`MaxTurns < 0\`, malformed wallclock durations.
- New \`tools.go\` with \`BashTool\` implementing \`agent.Tool\` by wrapping \`pkg/exec.ExecuteWithStream\` — **bash invoked by an agent and a shell task share the exact same execution primitive** (cwd=workspace, env, streaming writers). The wrappers above \`pkg/exec\` differ: shell tasks emit \`shell_run\` slog events and write shell transcripts; bash-tool invocations don't (the agent's single \`agent_run\` event covers the whole run, with per-call detail captured in the agent transcript via \`tool_result\` records).
- \`task.execAgent\` builds the Tools slice with workspace + stream-writer binding, parses Wallclock as a context deadline (default 10m), passes MaxTurns through.

**Pretty renderer**
- \`tool_use_start\` renders \`→ bash: <command>\` (yellow). Bash output then flows through the same writer in real time.
- \`tool_result\` renders \`← exit=0 234ms\` (green) or \`← error 234ms\` (red).
- \`turn_start\` renders \`— turn N —\` between turns.

## Composability with existing primitives

| primitive | how this PR composes |
|---|---|
| **cron** | agent tasks fire on schedules; nothing changed |
| **git** | \`task.Path\` from \`repo\` block becomes the bash tool's workspace cwd |
| **hcl** | new \`tools\` / \`max_turns\` / \`wallclock\` fields are pure declarative additions |
| **exec** | bash tool wraps \`ExecuteWithStream\` — single execution path for shell-task and agent-tool commands |
| **dag** | agent tasks are still first-class DAG nodes via \`depends\` |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/cronicle/...\` — 53 of 55 pass; the 2 failures are pre-existing GitHub-SSH-dependent tests, unrelated to this PR
- [x] Live API smoke test: 3-turn agent run with 2 bash calls, pretty mode renders cleanly with correct ordering for parallel tool calls in a single turn
- [x] Text mode: one structured event per agent run on stdout, transcript captures every turn + every tool result + accounting
- [x] \`--log-to-file\`: cronicle.jsonl gets one consolidated agent_run event; per-run transcript records the multi-turn conversation

## Sequencing

PR A in the agent runtime series:
1. **This PR** — multi-turn loop + bash tool + bounds
2. text_editor tool — file read/write/diff with workspace containment
3. Skills — SKILL.md loading via Anthropic's open standard, reusing the existing \`repo\` block
4. MCP server registration — open-ended tool integration (GitHub, Slack, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)