### PR TITLE
Add text_editor + web_search + web_fetch tools to agent

### DIFF
--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -200,10 +200,13 @@ func (task *Task) Validate() error {
 }
 
 // knownAgentTool reports whether name is a recognized Anthropic-defined tool
-// in the current cronicle build. Extend as new tools (text_editor, etc.) land.
+// in the current cronicle build.
+//
+// Client-side (cronicle implements execution): bash, text_editor.
+// Server-side (Anthropic runs them; we just declare): web_search, web_fetch.
 func knownAgentTool(name string) bool {
 	switch name {
-	case "bash":
+	case "bash", "text_editor", "web_search", "web_fetch":
 		return true
 	}
 	return false

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -625,8 +625,8 @@ func NewAgentStreamRenderer(w io.Writer) agent.StreamHandler {
 		case agent.StreamEventToolUseStart:
 			flushThinking()
 			fmt.Fprintf(w, "\n%s%s%s %s\n",
-				toolHi("→ "), toolHi(e.ToolName), toolHi(":"),
-				formatToolInput(e.ToolInput))
+				toolHi("→ "), toolHi(displayToolName(e.ToolName)), toolHi(":"),
+				formatToolInput(e.ToolName, e.ToolInput))
 		case agent.StreamEventToolResult:
 			marker := ok("← exit=0")
 			if e.IsError {
@@ -640,19 +640,59 @@ func NewAgentStreamRenderer(w io.Writer) agent.StreamHandler {
 }
 
 // formatToolInput renders the raw JSON tool input compactly for the pretty
-// stream. For bash specifically, it extracts the command and shows it
-// directly (no JSON wrapping). For unknown tools, the JSON is shown verbatim.
-func formatToolInput(raw string) string {
+// stream. Per-tool formatting:
+//
+//	bash                          → command string
+//	str_replace_based_edit_tool   → "<command> <path>"  (e.g. "view foo.go")
+//	web_search                    → query
+//	web_fetch                     → url
+//
+// Unknown tools fall through to the raw JSON.
+func formatToolInput(toolName, raw string) string {
 	if raw == "" {
 		return ""
 	}
-	var args struct {
-		Command string `json:"command"`
+	var args map[string]any
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		return raw
 	}
-	if err := json.Unmarshal([]byte(raw), &args); err == nil && args.Command != "" {
-		return args.Command
+	switch toolName {
+	case "bash":
+		if cmd, ok := args["command"].(string); ok {
+			return cmd
+		}
+	case "str_replace_based_edit_tool":
+		cmd, _ := args["command"].(string)
+		path, _ := args["path"].(string)
+		switch {
+		case cmd != "" && path != "":
+			return cmd + " " + path
+		case path != "":
+			return path
+		case cmd != "":
+			return cmd
+		}
+	case "web_search":
+		if q, ok := args["query"].(string); ok {
+			return q
+		}
+	case "web_fetch":
+		if u, ok := args["url"].(string); ok {
+			return u
+		}
 	}
 	return raw
+}
+
+// displayToolName maps the API tool name to a friendlier label for pretty
+// rendering. The model invokes tools by their API name (e.g.
+// "str_replace_based_edit_tool"); the user just wants to see "editor".
+func displayToolName(name string) string {
+	switch name {
+	case "str_replace_based_edit_tool":
+		return "editor"
+	}
+	return name
 }
 
 // renderShellRun renders a shell task as a block with the same shape as

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -116,6 +118,256 @@ func truncateOutput(s string, max int) string {
 		s[:half], dropped, s[len(s)-half:])
 }
 
+// TextEditorTool implements agent.Tool for str_replace_based_edit_tool. All
+// path operations are confined to Workspace via resolveInWorkspace; absolute
+// paths or `..` traversal that escape the workspace are rejected. Supported
+// commands match Anthropic's text_editor_20250728 schema:
+//
+//	view         — show file contents (with line numbers) or directory listing
+//	create       — write a new file; refuses to overwrite
+//	str_replace  — replace exact unique match in a file
+//	insert       — splice text at a 0-based line position
+//
+// view output is ANSI-stripped and middle-truncated to MaxToolOutputBytes,
+// same as bash output, so a `view` of a giant generated file can't poison
+// the next turn's context.
+type TextEditorTool struct {
+	Workspace string
+}
+
+func (t *TextEditorTool) Name() string { return "str_replace_based_edit_tool" }
+
+func (t *TextEditorTool) Definition() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfTextEditor20250728: &anthropic.ToolTextEditor20250728Param{},
+	}
+}
+
+func (t *TextEditorTool) Execute(ctx context.Context, input json.RawMessage) (string, bool) {
+	var args struct {
+		Command    string `json:"command"`
+		Path       string `json:"path"`
+		FileText   string `json:"file_text,omitempty"`
+		OldStr     string `json:"old_str,omitempty"`
+		NewStr     string `json:"new_str,omitempty"`
+		InsertLine int    `json:"insert_line,omitempty"`
+		ViewRange  []int  `json:"view_range,omitempty"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return fmt.Sprintf("Error: invalid editor input: %v", err), true
+	}
+	abs, err := resolveInWorkspace(t.Workspace, args.Path)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	switch args.Command {
+	case "view":
+		return t.view(abs, args.ViewRange)
+	case "create":
+		return t.create(abs, args.FileText)
+	case "str_replace":
+		return t.strReplace(abs, args.OldStr, args.NewStr)
+	case "insert":
+		return t.insert(abs, args.InsertLine, args.NewStr)
+	default:
+		return fmt.Sprintf("Error: unknown editor command %q", args.Command), true
+	}
+}
+
+func (t *TextEditorTool) view(absPath string, viewRange []int) (string, bool) {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	if info.IsDir() {
+		entries, err := os.ReadDir(absPath)
+		if err != nil {
+			return fmt.Sprintf("Error: %v", err), true
+		}
+		var sb strings.Builder
+		rel, _ := filepath.Rel(t.Workspace, absPath)
+		if rel == "" {
+			rel = "."
+		}
+		fmt.Fprintf(&sb, "Directory %s:\n", rel)
+		for _, e := range entries {
+			marker := ""
+			if e.IsDir() {
+				marker = "/"
+			}
+			fmt.Fprintf(&sb, "  %s%s\n", e.Name(), marker)
+		}
+		return truncateOutput(sb.String(), MaxToolOutputBytes), false
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	if isBinary(data) {
+		return fmt.Sprintf("Error: %s appears to be a binary file", filepath.Base(absPath)), true
+	}
+	lines := strings.Split(string(data), "\n")
+	start, end := 1, len(lines)
+	if len(viewRange) == 2 {
+		if viewRange[0] >= 1 {
+			start = viewRange[0]
+		}
+		if viewRange[1] >= 1 && viewRange[1] <= len(lines) {
+			end = viewRange[1]
+		}
+	}
+	var sb strings.Builder
+	for i := start - 1; i < end && i < len(lines); i++ {
+		fmt.Fprintf(&sb, "%6d\t%s\n", i+1, lines[i])
+	}
+	return truncateOutput(stripANSI(sb.String()), MaxToolOutputBytes), false
+}
+
+func (t *TextEditorTool) create(absPath, content string) (string, bool) {
+	if _, err := os.Stat(absPath); err == nil {
+		return fmt.Sprintf("Error: %s already exists; use str_replace or insert to modify",
+			filepath.Base(absPath)), true
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	return fmt.Sprintf("Created %s (%d bytes)", filepath.Base(absPath), len(content)), false
+}
+
+func (t *TextEditorTool) strReplace(absPath, oldStr, newStr string) (string, bool) {
+	if oldStr == "" {
+		return "Error: old_str must not be empty", true
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	content := string(data)
+	count := strings.Count(content, oldStr)
+	if count == 0 {
+		return fmt.Sprintf("Error: old_str not found in %s", filepath.Base(absPath)), true
+	}
+	if count > 1 {
+		return fmt.Sprintf("Error: old_str matches %d times in %s; must be unique",
+			count, filepath.Base(absPath)), true
+	}
+	newContent := strings.Replace(content, oldStr, newStr, 1)
+	if err := os.WriteFile(absPath, []byte(newContent), 0o644); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	return fmt.Sprintf("Edited %s", filepath.Base(absPath)), false
+}
+
+func (t *TextEditorTool) insert(absPath string, insertLine int, newStr string) (string, bool) {
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	lines := strings.Split(string(data), "\n")
+	if insertLine < 0 || insertLine > len(lines) {
+		return fmt.Sprintf("Error: insert_line %d out of range (file has %d lines)",
+			insertLine, len(lines)), true
+	}
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, lines[:insertLine]...)
+	out = append(out, strings.Split(newStr, "\n")...)
+	out = append(out, lines[insertLine:]...)
+	if err := os.WriteFile(absPath, []byte(strings.Join(out, "\n")), 0o644); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	return fmt.Sprintf("Inserted at line %d in %s", insertLine, filepath.Base(absPath)), false
+}
+
+// resolveInWorkspace turns a model-supplied path (relative or absolute) into
+// an absolute path *guaranteed* to live under workspace, or an error. Used
+// by every text_editor operation as the workspace-containment gate.
+func resolveInWorkspace(workspace, p string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("path required")
+	}
+	wsAbs, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", fmt.Errorf("workspace abs: %w", err)
+	}
+	var abs string
+	if filepath.IsAbs(p) {
+		abs = p
+	} else {
+		abs = filepath.Join(wsAbs, p)
+	}
+	abs = filepath.Clean(abs)
+	rel, err := filepath.Rel(wsAbs, abs)
+	if err != nil {
+		return "", fmt.Errorf("path %s outside workspace", p)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %s escapes workspace", p)
+	}
+	return abs, nil
+}
+
+// isBinary reports whether the data looks like binary (any null byte in the
+// first 4KB). Cheap heuristic that catches most binary files (executables,
+// images, archives) without false positives on normal text/UTF-8.
+func isBinary(data []byte) bool {
+	sample := data
+	if len(sample) > 4096 {
+		sample = sample[:4096]
+	}
+	for _, b := range sample {
+		if b == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// WebSearchTool exposes Anthropic's server-side web_search tool. The model
+// invokes it; Anthropic runs it on their infrastructure and returns results
+// as content blocks in the assistant message. Execute is never called by
+// the cronicle dispatcher because server_tool_use blocks aren't routed
+// through the client-side tool map — defining Execute here is a defensive
+// stub for the agent.Tool contract.
+type WebSearchTool struct{}
+
+func (WebSearchTool) Name() string { return "web_search" }
+
+func (WebSearchTool) Definition() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfWebSearchTool20260209: &anthropic.WebSearchTool20260209Param{
+			// "direct" lets the model invoke this tool without needing
+			// the code_execution wrapper. Required for models without
+			// programmatic tool calling (e.g. claude-haiku-4-5).
+			AllowedCallers: []string{"direct"},
+		},
+	}
+}
+
+func (WebSearchTool) Execute(_ context.Context, _ json.RawMessage) (string, bool) {
+	return "Error: web_search is a server-side tool; should not be dispatched client-side", true
+}
+
+// WebFetchTool exposes Anthropic's server-side web_fetch tool. Same model
+// as WebSearchTool — server-side, no client dispatch.
+type WebFetchTool struct{}
+
+func (WebFetchTool) Name() string { return "web_fetch" }
+
+func (WebFetchTool) Definition() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfWebFetchTool20260309: &anthropic.WebFetchTool20260309Param{
+			AllowedCallers: []string{"direct"},
+		},
+	}
+}
+
+func (WebFetchTool) Execute(_ context.Context, _ json.RawMessage) (string, bool) {
+	return "Error: web_fetch is a server-side tool; should not be dispatched client-side", true
+}
+
 // buildAgentTools converts the HCL `tools` field into a slice of agent.Tool
 // implementations bound to the given workspace and stream writer (when in
 // pretty streaming mode). Unknown tools are filtered out (Validate has
@@ -134,6 +386,14 @@ func buildAgentTools(names []string, workspace string, env []string, w io.Writer
 				StdoutW:   w,
 				StderrW:   w,
 			})
+		case "text_editor":
+			out = append(out, &TextEditorTool{
+				Workspace: workspace,
+			})
+		case "web_search":
+			out = append(out, WebSearchTool{})
+		case "web_fetch":
+			out = append(out, WebFetchTool{})
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary

Three new tools available in the HCL agent block. Bash now has company.

\`\`\`hcl
agent {
  tools = ["bash", "text_editor", "web_search", "web_fetch"]
  ...
}
\`\`\`

## What each tool does

**text_editor** — client-side, implements Anthropic's \`str_replace_based_edit_tool\` (\`text_editor_20250728\`). Commands: \`view\` / \`create\` / \`str_replace\` / \`insert\`. All paths resolved against \`task.Path\` via a \`resolveInWorkspace\` helper that rejects absolute paths outside the workspace and any \`..\` escapes — agents can't scribble outside their assigned directory. \`view\` output is ANSI-stripped and middle-truncated to 30K. Binary files (null byte in first 4KB) are refused.

**web_search** / **web_fetch** — server-side. Anthropic runs them; cronicle just declares them in \`params.Tools\`. Results come back as content blocks already filled in by the time the assistant message arrives. Both set \`AllowedCallers=["direct"]\` so models without programmatic tool calling (e.g. claude-haiku-4-5) can invoke them.

## Pretty rendering

Each tool gets its own compact display:
- \`→ bash: ls -la\`
- \`→ editor: view foo.go\`
- \`→ editor: str_replace foo.go\`
- \`→ web_search: golang current version\`
- \`→ web_fetch: https://...\`

\`displayToolName\` maps the API name \`str_replace_based_edit_tool\` to the friendlier \`editor\` label. \`formatToolInput\` knows each tool's input shape.

## Smoke tested

| test | result |
|---|---|
| text_editor 4-turn run that creates a file then \`str_replace\`s into it | ✅ workspace containment blocked a \`view /\` attempt |
| web_search 1-turn answer about Go version | ✅ $0.003, 2.5s |

## What this PR does NOT add

- \`code_execution\` (server-side Python sandbox) — pricing implications worth understanding before exposing
- \`memory\` (server-side persistent memory) — needs a design conversation about trust model and reproducibility (server-side state is not git-versioned)
- Pretty rendering of server-side tool calls — currently \`web_search\` invocations have no \`→\` marker because they emit \`server_tool_use\` content blocks the renderer doesn't route. Model's answer references what it found, which is fine for v1.

## Sequencing

Continuing the agent runtime series:
1. ✅ slog migration (#62)
2. ✅ unified transcripts (#63)
3. ✅ pretty everywhere (#64)
4. ✅ streaming (#65)
5. ✅ multi-turn loop + bash (#66)
6. **This PR** — text_editor + web tools
7. Next: skills (\`SKILL.md\` loading via the existing \`repo\` block)
8. Then: MCP servers
9. Then: prompt caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)