### PR TITLE
Add Anthropic Agent Skills: progressive disclosure + bundled scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,25 +192,109 @@ retry {
 ```
 
 ### `agent` (optional)
-Run a Claude agent invocation in place of a shell command. A task may have an
-`agent` block or a `command`, but not both. `${date}`, `${datetime}`, and
-`${timestamp}` are substituted into `prompt` and `system` at execution time.
-With `--log-to-file`, each run writes a JSONL transcript (request, response,
-token usage, cost) to `.cronicle/runs/` next to the cronicle root. Requires
-`ANTHROPIC_API_KEY` in the environment.
+Run a Claude agent in place of a shell command. A task has an `agent` block
+*or* a `command`, never both. `${date}`, `${datetime}`, `${timestamp}`, and
+`${path}` are substituted into `prompt` and `system` at execution time. The
+agent runs as a multi-turn loop: it can think, call tools, observe results,
+and continue until it stops calling tools, hits `max_turns`, or the
+`wallclock` deadline fires. With `--log-to-file`, each run writes a JSONL
+transcript (request, response per turn, tool results, accounting) to
+`.cronicle/runs/`. Requires `ANTHROPIC_API_KEY` in the environment.
 
 ```hcl
-task "summarize" {
+task "morning_brief" {
   agent {
-    prompt     = "Summarize what changed today: ${date}"
+    prompt     = "Compose today's morning brief for ${date}."
     model      = "claude-opus-4-7"
-    system     = "You are a concise release-notes writer."
-    max_tokens = 2048
-    // abort the run if its actual cost exceeds this; 0 disables
-    budget_usd = 0.50
+    system     = "You are a concise operational assistant."
+
+    // Tools available to the agent. Omit to default to all natives.
+    //   bash         — run shell commands in the task workspace
+    //   text_editor  — view/create/edit files (workspace-confined)
+    //   web_search   — server-side web search (billed per call)
+    //   web_fetch    — server-side URL fetch  (billed per call)
+    tools = ["bash", "text_editor"]
+
+    // Anthropic Agent Skills (progressive disclosure). Each entry is a
+    // SKILL.md (workspace-relative); only frontmatter name+description
+    // is injected into the system prompt. The agent calls load_skill to
+    // fetch the body on demand. Skills ship bundled scripts/templates
+    // alongside SKILL.md.
+    skills = [
+      "skills/morning-brief/SKILL.md",
+      "skills/report-writer/SKILL.md",
+    ]
+
+    max_turns  = 12       // hard cap on loop iterations
+    wallclock  = "2m"     // duration; aborts the run when fired
+    max_tokens = 2000     // per-turn output cap
+    budget_usd = 0.10     // abort if cumulative cost exceeds this; 0 disables
   }
 }
 ```
+
+`prompt` is optional when `skills` is non-empty — the loaded skill drives
+the run on its own. Skill paths must resolve under the task workspace; `..`
+traversal and absolute paths are rejected at config load.
+
+#### Skill layout
+
+Skills follow the [Anthropic Agent Skills standard](https://docs.claude.com/en/docs/agents-and-tools/agent-skills):
+
+```
+skills/
+└── morning-brief/
+    ├── SKILL.md         # YAML frontmatter + markdown body
+    └── scripts/
+        └── today.sh     # bundled executable the body references
+```
+
+```markdown
+---
+name: morning-brief
+description: Compose a 3-bullet morning brief for today's date.
+allowed-tools:
+  - bash
+  - text_editor
+---
+
+# Morning Brief
+
+Use `scripts/today.sh` to get today's date, then list exactly three bullets
+and reply with `BRIEF COMPLETE`.
+```
+
+When the agent calls `load_skill` with `"morning-brief"`, the response
+carries a `DIRECTORY:` header (`skills/morning-brief/`) so the agent
+composes paths to bundled scripts correctly across multi-skill runs.
+
+#### Run shape
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+agent run · schedule=daily · task=morning_brief · model=claude-haiku-4-5 · skills=[morning-brief]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+I'll load the morning-brief skill and follow its instructions.
+→ skill: morning-brief
+← exit=0 0ms
+
+— turn 2 —
+→ bash: skills/morning-brief/scripts/today.sh
+2026-05-10
+← exit=0 20ms
+
+— turn 3 —
+- On 2026-05-10, ...
+- ...
+BRIEF COMPLETE
+
+[5742 in / 247 out tokens · $0.006977 · 3705ms · stop=end_turn]
+```
+
+The `agent_run` slog event carries `skills_available` (the catalog the agent
+saw) and `skills_loaded` (the subset whose bodies it actually fetched), so
+unattended runs are auditable: *did the 3am job actually use what it had?*
 
 ### `timezone` (optional)
 ```hcl

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	golang.org/x/crypto v0.51.0
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -81,5 +82,4 @@ require (
 	golang.org/x/tools v0.45.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/cronicle/agent_test.go
+++ b/internal/cronicle/agent_test.go
@@ -36,12 +36,12 @@ var _ = Describe("Agent", func() {
 		Expect(task.Validate()).To(Equal(cronicle.ErrCommandAndAgentBothGiven))
 	})
 
-	It("Validate rejects an agent with an empty prompt", func() {
+	It("Validate rejects an agent with neither prompt nor skills", func() {
 		task := cronicle.Task{
 			Name:  "blank",
 			Agent: &cronicle.Agent{},
 		}
-		Expect(task.Validate()).To(Equal(cronicle.ErrAgentPromptEmpty))
+		Expect(task.Validate()).To(Equal(cronicle.ErrAgentNeedsPromptOrSkills))
 	})
 
 	It("Validate accepts an agent-only task", func() {
@@ -50,5 +50,26 @@ var _ = Describe("Agent", func() {
 			Agent: &cronicle.Agent{Prompt: "hello"},
 		}
 		Expect(task.Validate()).To(BeNil())
+	})
+
+	It("Validate accepts a skills-only agent task (no prompt)", func() {
+		task := cronicle.Task{
+			Name:  "skill-only",
+			Agent: &cronicle.Agent{Skills: []string{"skills/x/SKILL.md"}},
+		}
+		Expect(task.Validate()).To(BeNil())
+	})
+
+	It("Validate rejects skill paths that escape the workspace", func() {
+		task := cronicle.Task{
+			Name: "bad-skill",
+			Agent: &cronicle.Agent{
+				Prompt: "x",
+				Skills: []string{"../escape/SKILL.md"},
+			},
+		}
+		err := task.Validate()
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("escapes task workspace"))
 	})
 })

--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -74,8 +75,10 @@ type Task struct {
 // to pkg/agent rather than exec'd as a shell process.
 type Agent struct {
 	// Prompt is the user message sent to the model. ${date}/${datetime}/
-	// ${timestamp}/${path} are substituted at execution time.
-	Prompt string `hcl:"prompt"`
+	// ${timestamp}/${path} are substituted at execution time. Optional when
+	// Skills is non-empty (the skill metadata can stand in for a literal
+	// prompt by describing the work).
+	Prompt string `hcl:"prompt,optional"`
 	// Model selects the Claude model id, e.g. "claude-opus-4-7". Empty uses
 	// the pkg/agent default.
 	Model string `hcl:"model,optional"`
@@ -87,9 +90,16 @@ type Agent struct {
 	// Checked after each turn for mid-run abort. 0 disables.
 	BudgetUSD float64 `hcl:"budget_usd,optional"`
 	// Tools is the allowlist of Anthropic-defined tools the agent can
-	// invoke. Empty means single-turn agent (current behavior). Known
-	// values: "bash". Unknown names cause Validate to fail.
+	// invoke. When empty/omitted, defaults to all native tools (bash,
+	// text_editor, web_search, web_fetch). Set explicitly to narrow the
+	// universe. Unknown names cause Validate to fail.
 	Tools []string `hcl:"tools,optional"`
+	// Skills lists paths to SKILL.md files (relative to task.Path) that
+	// describe Anthropic Agent Skills available for this run. Frontmatter
+	// (name+description) of each skill is injected into the system prompt;
+	// the body loads on demand via the load_skill tool (progressive
+	// disclosure, per the standard).
+	Skills []string `hcl:"skills,optional"`
 	// MaxTurns is the hard cap on agent loop iterations. 0 means default
 	// (1 if no tools, 30 otherwise).
 	MaxTurns int `hcl:"max_turns,optional"`
@@ -150,8 +160,10 @@ var (
 	//ErrCommandAndAgentBothGiven is thrown when a task has both a command and an agent block.
 	//A task is exec'd as one or the other, not both.
 	ErrCommandAndAgentBothGiven = errors.New("task can not have both command and agent")
-	//ErrAgentPromptEmpty is thrown when an agent block is present but its prompt is empty.
-	ErrAgentPromptEmpty = errors.New("agent block requires a non-empty prompt")
+	//ErrAgentNeedsPromptOrSkills is thrown when an agent block has neither a
+	//prompt nor any skills configured. At least one is required so the agent
+	//has direction.
+	ErrAgentNeedsPromptOrSkills = errors.New("agent block requires prompt or skills")
 )
 
 // Validate validates the fields and sets the default values.
@@ -178,12 +190,27 @@ func (task *Task) Validate() error {
 		if len(task.Command) > 0 {
 			return ErrCommandAndAgentBothGiven
 		}
-		if task.Agent.Prompt == "" {
-			return ErrAgentPromptEmpty
+		if task.Agent.Prompt == "" && len(task.Agent.Skills) == 0 {
+			return ErrAgentNeedsPromptOrSkills
 		}
 		for _, name := range task.Agent.Tools {
 			if !knownAgentTool(name) {
-				return fmt.Errorf("unknown agent tool %q (known: bash)", name)
+				return fmt.Errorf("unknown agent tool %q (known: bash, text_editor, web_search, web_fetch)", name)
+			}
+		}
+		// Skill paths are workspace-relative; reject absolute paths and
+		// `..` traversal at config time so a misconfigured task fails
+		// before any API calls are made.
+		for _, sp := range task.Agent.Skills {
+			if sp == "" {
+				return errors.New("agent skill path must not be empty")
+			}
+			if filepath.IsAbs(sp) {
+				return fmt.Errorf("agent skill path %q must be relative to task workspace", sp)
+			}
+			cleaned := filepath.Clean(sp)
+			if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("agent skill path %q escapes task workspace", sp)
 			}
 		}
 		if task.Agent.MaxTurns < 0 {

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -98,9 +98,45 @@ func (task *Task) gitMeta() (commit, email string) {
 func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	runID := fmt.Sprintf("%s-%s-%s", t.UTC().Format("20060102T150405Z"), task.ScheduleName, task.Name)
 
+	// Skills: load all listed SKILL.md files up-front so a misconfigured
+	// skill (missing file, bad frontmatter) fails the run before any API
+	// call. The frontmatter (name+description) builds the available-skills
+	// catalog appended to the system prompt; bodies stay out until the
+	// agent calls load_skill (progressive disclosure, per Anthropic's
+	// Skills standard).
+	skills, skillErr := LoadSkillsForTask(task.Path, task.Agent.Skills)
+	if skillErr != nil {
+		return exec.Result{
+			Command:    []string{"agent", task.Agent.Model},
+			Error:      skillErr,
+			Stderr:     skillErr.Error(),
+			ExitStatus: 1,
+		}
+	}
+	var skillTool *SkillTool
+	if len(skills) > 0 {
+		skillTool, skillErr = NewSkillTool(skills)
+		if skillErr != nil {
+			return exec.Result{
+				Command:    []string{"agent", task.Agent.Model},
+				Error:      skillErr,
+				Stderr:     skillErr.Error(),
+				ExitStatus: 1,
+			}
+		}
+	}
+
+	system := r.Replace(task.Agent.System)
+	if section := FormatAvailableSkillsSection(skills); section != "" {
+		if system != "" {
+			system += "\n\n"
+		}
+		system += section
+	}
+
 	cfg := agent.Config{
 		Prompt:        r.Replace(task.Agent.Prompt),
-		System:        r.Replace(task.Agent.System),
+		System:        system,
 		Model:         task.Agent.Model,
 		MaxTokens:     task.Agent.MaxTokens,
 		BudgetUSD:     task.Agent.BudgetUSD,
@@ -114,6 +150,10 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	if effectiveModel == "" {
 		effectiveModel = agent.DefaultModel
 	}
+	var skillsAvailable []string
+	if skillTool != nil {
+		skillsAvailable = skillTool.Available()
+	}
 	var sw *StreamingWriter
 	if streaming {
 		// Per-task writer: the leader streams live to stdout; followers
@@ -122,7 +162,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		// concurrently.
 		sw = NewStreamingWriter()
 		defer sw.Close()
-		WriteAgentRunHeader(sw, task.ScheduleName, task.Name, effectiveModel)
+		WriteAgentRunHeader(sw, task.ScheduleName, task.Name, effectiveModel, skillsAvailable)
 		fmt.Fprintln(sw)
 		cfg.StreamHandler = NewAgentStreamRenderer(sw)
 	}
@@ -135,6 +175,9 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		toolWriter = sw
 	}
 	cfg.Tools = buildAgentTools(task.Agent.Tools, task.Path, task.Env, toolWriter)
+	if skillTool != nil {
+		cfg.Tools = append(cfg.Tools, skillTool)
+	}
 
 	// Wallclock bound: derive a context deadline from the HCL string. Default
 	// 10m if unset. Wallclock is enforced via context cancellation; the agent
@@ -179,6 +222,14 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		slog.Int64("duration_ms", durationMs),
 		slog.String("stop_reason", res.StopReason),
 		slog.String("response", res.Stdout),
+	}
+	if skillTool != nil {
+		// skills_available: the catalog the agent saw.
+		// skills_loaded:    the subset whose bodies it actually fetched.
+		// Diff of the two answers "did the run use what it had?".
+		attrs = append(attrs,
+			slog.Any("skills_available", skillsAvailable),
+			slog.Any("skills_loaded", skillTool.Loaded()))
 	}
 	if res.TranscriptPath != "" {
 		attrs = append(attrs, slog.String("transcript", res.TranscriptPath))

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -469,6 +469,7 @@ func (p *prettyHandler) renderAgentRun(r slog.Record) error {
 		stop, transcript, errMsg                  string
 		durationMs, in, out                       int64
 		success                                   bool
+		skills                                    []string
 	)
 	r.Attrs(func(a slog.Attr) bool {
 		switch a.Key {
@@ -496,12 +497,16 @@ func (p *prettyHandler) renderAgentRun(r slog.Record) error {
 			errMsg = a.Value.String()
 		case "success":
 			success = a.Value.Bool()
+		case "skills_available":
+			if v, ok := a.Value.Any().([]string); ok {
+				skills = v
+			}
 		}
 		return true
 	})
 
 	var b bytes.Buffer
-	WriteAgentRunHeader(&b, schedule, task, model)
+	WriteAgentRunHeader(&b, schedule, task, model, skills)
 	b.WriteByte('\n')
 
 	footerColor := color.New(color.Faint).SprintFunc()
@@ -527,12 +532,17 @@ func (p *prettyHandler) renderAgentRun(r slog.Record) error {
 
 // WriteAgentRunHeader writes the bordered header for an agent run block.
 // Shared by the slog renderAgentRun path and the streaming dispatch path.
-func WriteAgentRunHeader(w io.Writer, schedule, task, model string) {
+// `skills` is the available-skills list to surface in the header (empty/nil
+// omits the segment).
+func WriteAgentRunHeader(w io.Writer, schedule, task, model string, skills []string) {
 	header := color.New(color.FgCyan, color.Bold).SprintFunc()
 	rule := color.New(color.FgCyan).SprintFunc()
 
 	headerLine := fmt.Sprintf("agent run · schedule=%s · task=%s · model=%s",
 		schedule, task, model)
+	if len(skills) > 0 {
+		headerLine += " · skills=[" + strings.Join(skills, ",") + "]"
+	}
 	bar := strings.Repeat("━", len(headerLine)+8)
 
 	fmt.Fprintln(w, rule(bar))
@@ -680,6 +690,10 @@ func formatToolInput(toolName, raw string) string {
 		if u, ok := args["url"].(string); ok {
 			return u
 		}
+	case "load_skill":
+		if n, ok := args["name"].(string); ok {
+			return n
+		}
 	}
 	return raw
 }
@@ -691,6 +705,8 @@ func displayToolName(name string) string {
 	switch name {
 	case "str_replace_based_edit_tool":
 		return "editor"
+	case "load_skill":
+		return "skill"
 	}
 	return name
 }

--- a/internal/cronicle/skill.go
+++ b/internal/cronicle/skill.go
@@ -1,0 +1,326 @@
+// Skill loading + the load_skill meta-tool. cronicle implements Anthropic's
+// Agent Skills open standard with progressive disclosure: SKILL.md frontmatter
+// (name + description) is injected into the system prompt as a catalog; the
+// body is fetched on demand by the agent calling the load_skill tool.
+//
+// File layout convention (per the standard):
+//
+//	<task workspace>/
+//	  skills/
+//	    <skill-name>/
+//	      SKILL.md              ← frontmatter + body
+//	      scripts/...           ← supporting executables / templates
+//
+// Each entry in agent.skills HCL is the path to a SKILL.md (workspace-
+// relative). The skill's directory is filepath.Dir(path) and bundled files
+// resolve against that — load_skill returns a DIRECTORY header so the agent
+// can compose paths to the skill's scripts when invoking bash/text_editor.
+
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"gopkg.in/yaml.v3"
+)
+
+// Skill is a parsed SKILL.md plus the workspace-relative directory it lives
+// in (used to compose paths to bundled scripts/templates).
+type Skill struct {
+	// Name is the skill identifier (frontmatter `name`). Required.
+	Name string
+	// Description tells the agent when to use the skill (frontmatter
+	// `description`). Required — without it the agent has nothing to match
+	// the task against.
+	Description string
+	// Dir is the skill's directory, workspace-relative (e.g. "skills/data-
+	// analysis"). The agent receives this in the load_skill response so it
+	// can resolve paths to scripts/foo.py against this prefix.
+	Dir string
+	// AllowedTools is the frontmatter `allowed-tools` list. Informational
+	// — the agent's actual tool universe is set by Agent.Tools at config
+	// time. Surfaced in the load_skill response so the agent knows what
+	// the skill expects to use.
+	AllowedTools []string
+	// Body is the markdown content after the YAML frontmatter, verbatim.
+	Body string
+}
+
+// skillFrontmatter mirrors the YAML frontmatter fields cronicle understands.
+// Other keys are accepted but ignored (forward-compatibility with the
+// evolving Skills standard).
+type skillFrontmatter struct {
+	Name         string   `yaml:"name"`
+	Description  string   `yaml:"description"`
+	AllowedTools []string `yaml:"allowed-tools"`
+}
+
+// LoadSkill reads the SKILL.md at skillAbs (an absolute path under taskRoot)
+// and returns the parsed Skill. Errors are surfaced verbatim — a misconfigured
+// skill should fail the run loudly, not silently produce a degraded prompt.
+func LoadSkill(skillAbs, taskRoot string) (*Skill, error) {
+	data, err := os.ReadFile(skillAbs)
+	if err != nil {
+		return nil, fmt.Errorf("read skill %s: %w", skillAbs, err)
+	}
+	fm, body, err := parseFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse skill %s: %w", skillAbs, err)
+	}
+	if fm.Name == "" {
+		return nil, fmt.Errorf("skill %s: frontmatter `name` is required", skillAbs)
+	}
+	if fm.Description == "" {
+		return nil, fmt.Errorf("skill %s: frontmatter `description` is required", skillAbs)
+	}
+	dirAbs := filepath.Dir(skillAbs)
+	dirRel, err := filepath.Rel(taskRoot, dirAbs)
+	if err != nil {
+		return nil, fmt.Errorf("skill %s: dir not under workspace: %w", skillAbs, err)
+	}
+	return &Skill{
+		Name:         fm.Name,
+		Description:  fm.Description,
+		Dir:          filepath.ToSlash(dirRel),
+		AllowedTools: fm.AllowedTools,
+		Body:         body,
+	}, nil
+}
+
+// parseFrontmatter splits a SKILL.md body into its YAML frontmatter and
+// markdown body. The frontmatter is delimited by `---` lines at the very
+// start of the file. Files without frontmatter return an error: skills
+// without name+description can't be advertised to the agent.
+func parseFrontmatter(data []byte) (skillFrontmatter, string, error) {
+	var fm skillFrontmatter
+	s := string(data)
+	// Tolerate a leading UTF-8 BOM (U+FEFF) and CRLF endings that come from
+	// editors on Windows or copy-paste from web pages.
+	s = strings.TrimPrefix(s, "\uFEFF")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	if !strings.HasPrefix(s, "---\n") {
+		return fm, "", errors.New("missing YAML frontmatter (file must start with `---`)")
+	}
+	rest := s[len("---\n"):]
+	end := strings.Index(rest, "\n---\n")
+	endLen := len("\n---\n")
+	if end < 0 {
+		// Allow a closing fence without trailing newline (file ends right
+		// after `---`).
+		if strings.HasSuffix(rest, "\n---") {
+			end = len(rest) - len("\n---")
+			endLen = len("\n---")
+		} else {
+			return fm, "", errors.New("unterminated YAML frontmatter (missing closing `---`)")
+		}
+	}
+	fmText := rest[:end]
+	body := ""
+	if end+endLen <= len(rest) {
+		body = rest[end+endLen:]
+	}
+	body = strings.TrimLeft(body, "\n")
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return fm, "", fmt.Errorf("yaml: %w", err)
+	}
+	return fm, body, nil
+}
+
+// SkillTool is the load_skill meta-tool: a custom Anthropic tool that takes
+// a skill name and returns the body + DIRECTORY header so the agent can read
+// instructions and resolve paths to bundled scripts. Progressive disclosure:
+// the system prompt only carries name+description for each skill; the agent
+// invokes load_skill when it decides a skill is relevant.
+//
+// SkillTool is bound to a specific run (a frozen map of available skills) and
+// records which skills the agent fetched, so the run's slog event can carry
+// skills_loaded for audit ("did the 3am job actually use the report-writer
+// skill, or did it just have it available?").
+type SkillTool struct {
+	skills map[string]*Skill // by Name
+	mu     sync.Mutex
+	loaded []string // names, in load order
+}
+
+// NewSkillTool constructs a load_skill tool from a slice of pre-parsed skills.
+// Duplicate names are rejected — having two skills with the same name in
+// available-skills would make load_skill ambiguous.
+func NewSkillTool(skills []*Skill) (*SkillTool, error) {
+	m := make(map[string]*Skill, len(skills))
+	for _, sk := range skills {
+		if _, dup := m[sk.Name]; dup {
+			return nil, fmt.Errorf("duplicate skill name %q (each skill must have a unique name)", sk.Name)
+		}
+		m[sk.Name] = sk
+	}
+	return &SkillTool{skills: m}, nil
+}
+
+// Loaded returns the names of skills the agent fetched via load_skill, in
+// the order they were first loaded. Safe to call after the run finishes.
+func (s *SkillTool) Loaded() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.loaded))
+	copy(out, s.loaded)
+	return out
+}
+
+// Available returns the names of all skills registered for this run, sorted
+// for deterministic logging.
+func (s *SkillTool) Available() []string {
+	out := make([]string, 0, len(s.skills))
+	for name := range s.skills {
+		out = append(out, name)
+	}
+	// Stable order without pulling in sort just for a small slice.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// Name returns "load_skill". Stable across runs so transcripts compare cleanly.
+func (s *SkillTool) Name() string { return "load_skill" }
+
+// Definition declares load_skill as a custom (Type=custom) tool with a single
+// required string input `name`. The description is intentionally directive —
+// it tells the model exactly when to use this tool, since the available-
+// skills section in the system prompt is the only signal the model gets that
+// these are the names to pass.
+func (s *SkillTool) Definition() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        "load_skill",
+			Type:        anthropic.ToolTypeCustom,
+			Description: anthropic.String("Load the full instructions for a skill listed in the Available Skills section of the system prompt. Returns the skill's body, working directory (for resolving paths to bundled scripts), and any allowed-tools metadata. Call this once per skill you decide to use."),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: map[string]any{
+					"name": map[string]any{
+						"type":        "string",
+						"description": "The skill name as listed in Available Skills.",
+					},
+				},
+				Required: []string{"name"},
+			},
+		},
+	}
+}
+
+// Execute resolves the requested skill name and returns the formatted body.
+// Records the load in s.loaded for the run-level audit field.
+func (s *SkillTool) Execute(_ context.Context, input json.RawMessage) (string, bool) {
+	var args struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return fmt.Sprintf("Error: invalid load_skill input: %v", err), true
+	}
+	if args.Name == "" {
+		return "Error: load_skill requires a skill name", true
+	}
+	sk, ok := s.skills[args.Name]
+	if !ok {
+		return fmt.Sprintf("Error: no skill named %q is available for this run (available: %s)",
+			args.Name, strings.Join(s.Available(), ", ")), true
+	}
+	s.recordLoaded(args.Name)
+	return s.format(sk), false
+}
+
+func (s *SkillTool) recordLoaded(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, n := range s.loaded {
+		if n == name {
+			return
+		}
+	}
+	s.loaded = append(s.loaded, name)
+}
+
+// format returns the load_skill response text the model receives. The
+// DIRECTORY header is the load-bearing piece for multi-skill runs: each
+// skill's response carries its own directory so paths in different skill
+// bodies don't collide when both bodies are in the conversation.
+func (s *SkillTool) format(sk *Skill) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "SKILL: %s\n", sk.Name)
+	fmt.Fprintf(&b, "DIRECTORY: %s\n", sk.Dir)
+	if len(sk.AllowedTools) > 0 {
+		fmt.Fprintf(&b, "ALLOWED_TOOLS: %s\n", strings.Join(sk.AllowedTools, ", "))
+	}
+	b.WriteString("\n")
+	b.WriteString(sk.Body)
+	if !strings.HasSuffix(sk.Body, "\n") {
+		b.WriteString("\n")
+	}
+	b.WriteString("\nNote: paths in this skill are relative to DIRECTORY above. When invoking scripts, prefix the path (e.g. ")
+	b.WriteString(sk.Dir)
+	b.WriteString("/scripts/foo.py).\n")
+	return b.String()
+}
+
+// LoadSkillsForTask resolves and loads each path in agent.Skills against
+// taskRoot, returning the parsed skills. Path traversal is re-checked here
+// (defense in depth — Validate already rejected `..`/abs paths at config
+// time, but task.Path can change between Validate and Execute if a repo is
+// cloned, so we verify containment again with the live taskRoot).
+func LoadSkillsForTask(taskRoot string, paths []string) ([]*Skill, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	wsAbs, err := filepath.Abs(taskRoot)
+	if err != nil {
+		return nil, fmt.Errorf("task root abs: %w", err)
+	}
+	out := make([]*Skill, 0, len(paths))
+	for _, p := range paths {
+		abs := filepath.Clean(filepath.Join(wsAbs, p))
+		rel, err := filepath.Rel(wsAbs, abs)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("skill path %q escapes task workspace", p)
+		}
+		sk, err := LoadSkill(abs, wsAbs)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sk)
+	}
+	return out, nil
+}
+
+// FormatAvailableSkillsSection returns the Available Skills block to append
+// to the system prompt. Empty input yields the empty string so the caller
+// can unconditionally concatenate. The format is intentionally compact —
+// long descriptions inflate every-turn context without proportional value.
+func FormatAvailableSkillsSection(skills []*Skill) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Available Skills (call load_skill with the skill name to fetch full instructions):\n")
+	for _, sk := range skills {
+		fmt.Fprintf(&b, "  - %s: %s\n", sk.Name, oneLine(sk.Description))
+	}
+	return b.String()
+}
+
+// oneLine collapses a description to a single line so the available-skills
+// section stays a tight catalog. Skill bodies (the load_skill response)
+// preserve original formatting.
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -368,13 +368,23 @@ func (WebFetchTool) Execute(_ context.Context, _ json.RawMessage) (string, bool)
 	return "Error: web_fetch is a server-side tool; should not be dispatched client-side", true
 }
 
+// defaultAgentToolNames is the tool universe an agent gets when the HCL
+// `tools` field is omitted. Matches the user expectation that an agent task
+// "just runs" with the full native toolkit. Note that web_search and
+// web_fetch are server-side and bill on Anthropic's side per call — set
+// `tools = ["bash", "text_editor"]` explicitly to opt out.
+func defaultAgentToolNames() []string {
+	return []string{"bash", "text_editor", "web_search", "web_fetch"}
+}
+
 // buildAgentTools converts the HCL `tools` field into a slice of agent.Tool
 // implementations bound to the given workspace and stream writer (when in
-// pretty streaming mode). Unknown tools are filtered out (Validate has
-// already rejected them at parse time, so this is defensive).
+// pretty streaming mode). Empty/nil names defaults to the full native
+// toolkit (defaultAgentToolNames). Unknown names are filtered out (Validate
+// has already rejected them at parse time, so this is defensive).
 func buildAgentTools(names []string, workspace string, env []string, w io.Writer) []agent.Tool {
 	if len(names) == 0 {
-		return nil
+		names = defaultAgentToolNames()
 	}
 	out := make([]agent.Tool, 0, len(names))
 	for _, name := range names {


### PR DESCRIPTION
## Summary

Implements the [Anthropic Agent Skills open standard](https://docs.claude.com/en/docs/agents-and-tools/agent-skills) for cronicle.

- **`skills = [...]` HCL field** on the agent block — list of SKILL.md paths (workspace-relative).
- **Progressive disclosure**: only frontmatter `name` + `description` are injected into the system prompt; bodies fetch on demand via a built-in `load_skill` tool.
- **Bundled scripts/templates**: `load_skill` response carries a `DIRECTORY:` header so the agent composes paths to skill-local files (verified end-to-end — agent ran `skills/morning-brief/scripts/today.sh` after loading the skill).
- **`tools` default change**: omitting `tools` now defaults to all native tools (`bash`, `text_editor`, `web_search`, `web_fetch`). Set `tools = [...]` explicitly to narrow.
- **`prompt` optional** when `skills` is non-empty.
- **slog audit fields**: `skills_available` (catalog the agent saw) + `skills_loaded` (subset whose bodies it fetched).
- **Pretty header** shows `· skills=[name1,name2]`; per-load lines render as `→ skill: <name>`.

## HCL example

```hcl
schedule "agent_skill" {
  cron = "@daily"
  task "brief" {
    agent {
      prompt = "Compose today's morning brief."
      skills = ["skills/morning-brief/SKILL.md"]
      tools  = ["bash", "text_editor"]   // omit = all natives
    }
  }
}
```

Skill layout (per the standard):
```
skills/morning-brief/
├── SKILL.md         # YAML frontmatter (name, description, allowed-tools) + body
└── scripts/today.sh # bundled executable
```

## Smoke run

```
agent run · schedule=agent_skill · task=brief · model=claude-haiku-4-5 · skills=[morning-brief]

I'll load the morning-brief skill and follow its instructions.
→ skill: morning-brief
← exit=0 0ms

— turn 2 —
Now I'll get today's date using the provided script and compose the morning brief.
→ bash: skills/morning-brief/scripts/today.sh
2026-05-10
← exit=0 20ms

— turn 3 —
- On 2026-05-10, ...
- ...
BRIEF COMPLETE
```

slog event:
```
skills_available=[morning-brief] skills_loaded=[morning-brief] success=true
```

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — 55 pass (same 2 pre-existing SSH-auth failures as master)
- [x] New tests: skills-only agent task validates; `..` skill path rejected at config time
- [x] End-to-end smoke (`/tmp/cronicle-agent-smoke/agent_skill.hcl`) — skill loads via `load_skill`, agent invokes bundled `scripts/today.sh` using the DIRECTORY header
- [x] Pretty + text log modes both render correctly

## Next
MCP server registration — `mcp "github" { ... }` per-task, or skill (in-tree skills can declare MCP requirements once the skill loader sees them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)