### PR TITLE
Add MCP server registration to agent block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/matryer/vice v1.0.1-0.20190210090722-660007f4486b
 	github.com/mattn/go-isatty v0.0.22
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.34.1
@@ -45,6 +46,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -59,6 +61,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -72,10 +76,12 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -82,6 +84,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQNvHSdIE7iqsQxK1P41mySCvssg=
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
@@ -121,6 +125,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/nsqio/go-nsq v1.1.0 h1:PQg+xxiUjA7V+TLdXw7nVrJ5Jbl3sN86EhGCQj4+FYE=
 github.com/nsqio/go-nsq v1.1.0/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
@@ -150,6 +156,10 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -191,6 +201,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/zclconf/go-cty v1.18.1 h1:yEGE8M4iIZlyKQURZNb2SnEyZlZHUcBCnx6KF81KuwM=
 github.com/zclconf/go-cty v1.18.1/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
@@ -210,6 +222,8 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=

--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -100,6 +100,13 @@ type Agent struct {
 	// the body loads on demand via the load_skill tool (progressive
 	// disclosure, per the standard).
 	Skills []string `hcl:"skills,optional"`
+	// MCPs lists Model Context Protocol servers to spawn for this agent
+	// run. Each server is launched as a subprocess; cronicle speaks
+	// JSON-RPC over its stdin/stdout, lists its tools, and registers
+	// them with the agent (namespaced as `<server-name>__<tool-name>` so
+	// names from different servers don't collide). Servers shut down
+	// when the run ends.
+	MCPs []MCP `hcl:"mcp,block"`
 	// MaxTurns is the hard cap on agent loop iterations. 0 means default
 	// (1 if no tools, 30 otherwise).
 	MaxTurns int `hcl:"max_turns,optional"`
@@ -107,6 +114,23 @@ type Agent struct {
 	// on the entire run. Empty means default ("10m"). Parsed via
 	// time.ParseDuration.
 	Wallclock string `hcl:"wallclock,optional"`
+}
+
+// MCP is a Model Context Protocol server definition. Cronicle launches the
+// command as a subprocess and speaks JSON-RPC over its stdin/stdout to
+// discover and invoke tools. Each MCP block on an agent contributes its
+// tools to the agent's tool universe, namespaced by the block label
+// (e.g. `mcp "github" {...}` exposes tools as `github__create_issue`).
+type MCP struct {
+	// Name labels this server in the namespace. Tools from this server
+	// appear to the model as `<Name>__<tool-name>`.
+	Name string `hcl:"name,label"`
+	// Command is the argv used to spawn the server. The first element is
+	// the executable, the rest are arguments. Required and non-empty.
+	Command []string `hcl:"command"`
+	// Env is the list of env-var names to forward from cronicle's process
+	// to the server (e.g. ["GITHUB_TOKEN"]). Empty inherits nothing.
+	Env []string `hcl:"env,optional"`
 }
 
 // Repo is the structure that defines a git repository
@@ -213,6 +237,20 @@ func (task *Task) Validate() error {
 				return fmt.Errorf("agent skill path %q escapes task workspace", sp)
 			}
 		}
+		// MCP servers: each block needs a non-empty name and command. The
+		// name has to be a valid tool-name component since we namespace
+		// tools as `<name>__<tool>` and Anthropic enforces ^[a-zA-Z0-9_-]{1,128}$.
+		for i, m := range task.Agent.MCPs {
+			if m.Name == "" {
+				return fmt.Errorf("agent mcp[%d]: name (block label) is required", i)
+			}
+			if !isValidToolNamePart(m.Name) {
+				return fmt.Errorf("agent mcp %q: name must match ^[a-zA-Z0-9_-]+$", m.Name)
+			}
+			if len(m.Command) == 0 {
+				return fmt.Errorf("agent mcp %q: command is required", m.Name)
+			}
+		}
 		if task.Agent.MaxTurns < 0 {
 			return errors.New("agent max_turns must be >= 0")
 		}
@@ -224,6 +262,26 @@ func (task *Task) Validate() error {
 	}
 
 	return nil
+}
+
+// isValidToolNamePart reports whether s is a legal MCP server label. Used
+// to namespace MCP tools as `<server>__<tool>` — Anthropic's tool name
+// regex is ^[a-zA-Z0-9_-]{1,128}$ and we want the prefix to fit cleanly.
+func isValidToolNamePart(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // knownAgentTool reports whether name is a recognized Anthropic-defined tool

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -191,6 +191,26 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	runCtx, cancel := context.WithTimeout(context.Background(), wallclock)
 	defer cancel()
 
+	// MCP servers: launch under runCtx so wallclock cancellation also tears
+	// them down. Failures here abort the run before any API call. We close
+	// handles in the deferred path below regardless of how the run exits,
+	// so a panic or budget abort still cleans up subprocesses.
+	mcpHandles, mcpTools, mcpErr := LaunchMCPServers(runCtx, task.Agent.MCPs, task.Env, toolWriter)
+	if mcpErr != nil {
+		return exec.Result{
+			Command:    []string{"agent", task.Agent.Model},
+			Error:      mcpErr,
+			Stderr:     mcpErr.Error(),
+			ExitStatus: 1,
+		}
+	}
+	defer func() {
+		for _, h := range mcpHandles {
+			_ = h.Close()
+		}
+	}()
+	cfg.Tools = append(cfg.Tools, mcpTools...)
+
 	startedAt := time.Now()
 	res, err := agent.Run(runCtx, cfg)
 	durationMs := time.Since(startedAt).Milliseconds()
@@ -230,6 +250,9 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		attrs = append(attrs,
 			slog.Any("skills_available", skillsAvailable),
 			slog.Any("skills_loaded", skillTool.Loaded()))
+	}
+	if names := MCPServerNames(mcpHandles); len(names) > 0 {
+		attrs = append(attrs, slog.Any("mcp_servers", names))
 	}
 	if res.TranscriptPath != "" {
 		attrs = append(attrs, slog.String("transcript", res.TranscriptPath))

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -704,18 +704,43 @@ func formatToolInput(toolName, raw string) string {
 			return n
 		}
 	}
+	// MCP tools (server__tool) — show the args as compact JSON, but trim
+	// to keep the line readable. Generic since tool schemas vary widely.
+	if strings.Contains(toolName, MCPNameSep) {
+		return truncate(compactJSON(raw), 80)
+	}
 	return raw
+}
+
+// compactJSON rewraps a JSON blob to its compact form. Returns the original
+// string on any parse error so we don't lose information when the model
+// emits unusual content.
+func compactJSON(s string) string {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return s
+	}
+	return string(b)
 }
 
 // displayToolName maps the API tool name to a friendlier label for pretty
 // rendering. The model invokes tools by their API name (e.g.
 // "str_replace_based_edit_tool"); the user just wants to see "editor".
+// MCP tools come in as `<server>__<tool>` and render as `<server>.<tool>`
+// so the server boundary is obvious in the stream.
 func displayToolName(name string) string {
 	switch name {
 	case "str_replace_based_edit_tool":
 		return "editor"
 	case "load_skill":
 		return "skill"
+	}
+	if i := strings.Index(name, MCPNameSep); i > 0 {
+		return name[:i] + "." + name[i+len(MCPNameSep):]
 	}
 	return name
 }

--- a/internal/cronicle/mcp.go
+++ b/internal/cronicle/mcp.go
@@ -1,0 +1,306 @@
+// MCP (Model Context Protocol) integration: launch MCP servers as
+// subprocesses, list their tools, and wrap them as agent.Tool so the model
+// can invoke them through cronicle's existing dispatch loop.
+//
+// Tools are namespaced as `<server-name>__<tool-name>` so multiple servers
+// can be configured on a single agent without name collisions. cronicle
+// translates between MCP's JSON-Schema input definitions and Anthropic's
+// ToolInputSchemaParam by round-tripping through JSON — the wire formats
+// are compatible.
+//
+// Each server runs for the lifetime of one agent run: it's spawned at the
+// start of execAgent and torn down (stdin closed, then SIGTERM after a
+// grace period via the SDK's CommandTransport.TerminateDuration) when the
+// run completes.
+
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/jshiv/cronicle/pkg/agent"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MCPNameSep is the separator between server name and tool name in the
+// namespaced form the model sees (e.g. `github__create_issue`). Two
+// underscores avoids confusion with tools whose own names contain a single
+// underscore (most do).
+const MCPNameSep = "__"
+
+// mcpClientName/mcpClientVersion identify cronicle to the MCP server in
+// the initialize handshake. The MCP standard recommends a stable client
+// name and a semver-ish version.
+const (
+	mcpClientName    = "cronicle"
+	mcpClientVersion = "0.4.0"
+)
+
+// MCPHandle is the live state of a launched MCP server: the SDK session
+// (used for tool calls and shutdown), the server name (for logs), and the
+// tools it advertised at startup. Held by execAgent for the duration of a
+// run so it can defer Close.
+type MCPHandle struct {
+	Name    string
+	Session *mcpsdk.ClientSession
+	Tools   []*mcpsdk.Tool
+}
+
+// Close shuts down the underlying session, which closes stdin on the
+// subprocess and then SIGTERMs it after the SDK's grace period.
+func (h *MCPHandle) Close() error {
+	if h == nil || h.Session == nil {
+		return nil
+	}
+	return h.Session.Close()
+}
+
+// LaunchMCPServers spawns each configured MCP server, performs the
+// initialize handshake, lists its tools, and returns wrapped agent.Tool
+// values plus handles for shutdown. If any server fails to start or list,
+// already-launched handles are closed and the error is returned — partial
+// MCP state would be confusing for the agent ("which tools are real?")
+// and lossy for accounting.
+//
+// taskEnv is the task's HCL `env` (already in KEY=VALUE form). For each
+// MCP, only env vars listed in mcp.env are forwarded (looked up in the
+// caller's environment). PATH is always inherited so `npx` / `python` /
+// the server binary itself can be located.
+func LaunchMCPServers(ctx context.Context, mcps []MCP, taskEnv []string, w io.Writer) ([]*MCPHandle, []agent.Tool, error) {
+	if len(mcps) == 0 {
+		return nil, nil, nil
+	}
+	var (
+		handles []*MCPHandle
+		tools   []agent.Tool
+	)
+	for _, m := range mcps {
+		h, ts, err := launchOne(ctx, m, taskEnv, w)
+		if err != nil {
+			for _, prior := range handles {
+				_ = prior.Close()
+			}
+			return nil, nil, fmt.Errorf("mcp %q: %w", m.Name, err)
+		}
+		handles = append(handles, h)
+		tools = append(tools, ts...)
+	}
+	return handles, tools, nil
+}
+
+func launchOne(ctx context.Context, m MCP, taskEnv []string, w io.Writer) (*MCPHandle, []agent.Tool, error) {
+	cmd := exec.Command(m.Command[0], m.Command[1:]...)
+	cmd.Env = mcpProcessEnv(m.Env, taskEnv)
+	// Server stderr is forwarded to the agent's pretty-mode writer (or
+	// discarded when nil) so npm/install chatter and runtime logs appear
+	// in-context with the rest of the run.
+	if w != nil {
+		cmd.Stderr = w
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+
+	transport := &mcpsdk.CommandTransport{Command: cmd}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{
+		Name:    mcpClientName,
+		Version: mcpClientVersion,
+	}, nil)
+
+	// Bound the handshake — a hung server should fail fast rather than
+	// stall the whole run.
+	connectCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	session, err := client.Connect(connectCtx, transport, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connect: %w", err)
+	}
+	listCtx, cancel2 := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel2()
+	listRes, err := session.ListTools(listCtx, nil)
+	if err != nil {
+		_ = session.Close()
+		return nil, nil, fmt.Errorf("list_tools: %w", err)
+	}
+
+	wrappers := make([]agent.Tool, 0, len(listRes.Tools))
+	for _, t := range listRes.Tools {
+		wrap, err := newMCPToolWrapper(m.Name, t, session)
+		if err != nil {
+			_ = session.Close()
+			return nil, nil, fmt.Errorf("tool %q: %w", t.Name, err)
+		}
+		wrappers = append(wrappers, wrap)
+	}
+
+	return &MCPHandle{
+		Name:    m.Name,
+		Session: session,
+		Tools:   listRes.Tools,
+	}, wrappers, nil
+}
+
+// mcpProcessEnv builds the env slice for an MCP subprocess: PATH from the
+// parent (so `npx`/`python`/binaries resolve), each name listed in mcp.env
+// looked up from cronicle's process env, plus the task's HCL env passed
+// through verbatim. We never forward the entire parent env wholesale —
+// that's how secrets leak into untrusted server processes.
+func mcpProcessEnv(envNames, taskEnv []string) []string {
+	out := []string{"PATH=" + os.Getenv("PATH")}
+	for _, name := range envNames {
+		if v, ok := os.LookupEnv(name); ok {
+			out = append(out, name+"="+v)
+		}
+	}
+	out = append(out, taskEnv...)
+	return out
+}
+
+// mcpToolWrapper adapts a single MCP tool to cronicle's agent.Tool
+// interface. The Anthropic-facing name is namespaced (`<server>__<tool>`);
+// Execute strips the prefix back off and dispatches to session.CallTool.
+type mcpToolWrapper struct {
+	server   string
+	mcpName  string // un-namespaced, as the server knows it
+	apiName  string // namespaced, as the model sees it
+	desc     string
+	schema   anthropic.ToolInputSchemaParam
+	session  *mcpsdk.ClientSession
+}
+
+func newMCPToolWrapper(server string, t *mcpsdk.Tool, session *mcpsdk.ClientSession) (*mcpToolWrapper, error) {
+	apiName := server + MCPNameSep + t.Name
+	if len(apiName) > 128 {
+		return nil, fmt.Errorf("namespaced name %q exceeds 128 chars", apiName)
+	}
+	schema, err := mcpSchemaToAnthropic(t.InputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("input_schema: %w", err)
+	}
+	desc := t.Description
+	if desc == "" {
+		desc = fmt.Sprintf("MCP tool %q from server %q", t.Name, server)
+	}
+	return &mcpToolWrapper{
+		server:  server,
+		mcpName: t.Name,
+		apiName: apiName,
+		desc:    desc,
+		schema:  schema,
+		session: session,
+	}, nil
+}
+
+func (m *mcpToolWrapper) Name() string { return m.apiName }
+
+func (m *mcpToolWrapper) Definition() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        m.apiName,
+			Type:        anthropic.ToolTypeCustom,
+			Description: anthropic.String(m.desc),
+			InputSchema: m.schema,
+		},
+	}
+}
+
+func (m *mcpToolWrapper) Execute(ctx context.Context, input json.RawMessage) (string, bool) {
+	var args any
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &args); err != nil {
+			return fmt.Sprintf("Error: invalid arguments JSON: %v", err), true
+		}
+	}
+	res, err := m.session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      m.mcpName,
+		Arguments: args,
+	})
+	if err != nil {
+		return fmt.Sprintf("Error: mcp %s.%s: %v", m.server, m.mcpName, err), true
+	}
+	out := mcpContentToString(res.Content)
+	return out, res.IsError
+}
+
+// mcpContentToString flattens the MCP CallToolResult content list into a
+// single string for the model's tool_result. Text content is concatenated
+// verbatim; non-text content (images, embedded resources) is summarized
+// with a placeholder so the model knows something was returned but doesn't
+// need to handle the binary payload. Future work: pass through image
+// content as image blocks once we have a tool_result block builder that
+// supports them.
+func mcpContentToString(contents []mcpsdk.Content) string {
+	if len(contents) == 0 {
+		return "(no content)"
+	}
+	var b strings.Builder
+	for i, c := range contents {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		switch v := c.(type) {
+		case *mcpsdk.TextContent:
+			b.WriteString(v.Text)
+		default:
+			fmt.Fprintf(&b, "[non-text content of type %T omitted]", c)
+		}
+	}
+	return b.String()
+}
+
+// mcpSchemaToAnthropic converts an MCP tool's InputSchema (any value that
+// JSON-marshals to a JSON Schema object) to an
+// [anthropic.ToolInputSchemaParam]. Round-trips via JSON — the wire formats
+// are compatible. Invalid/missing schemas degrade to an empty
+// `{type: object}` schema so the tool is still callable with no args
+// rather than rejected outright.
+func mcpSchemaToAnthropic(in any) (anthropic.ToolInputSchemaParam, error) {
+	if in == nil {
+		return anthropic.ToolInputSchemaParam{}, nil
+	}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		return anthropic.ToolInputSchemaParam{}, err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(raw, &asMap); err != nil {
+		return anthropic.ToolInputSchemaParam{}, err
+	}
+	out := anthropic.ToolInputSchemaParam{}
+	if props, ok := asMap["properties"]; ok {
+		out.Properties = props
+	}
+	if req, ok := asMap["required"].([]any); ok {
+		for _, r := range req {
+			if s, ok := r.(string); ok {
+				out.Required = append(out.Required, s)
+			}
+		}
+	}
+	return out, nil
+}
+
+// MCPServerNames returns the names of the launched servers, sorted for
+// stable slog output.
+func MCPServerNames(handles []*MCPHandle) []string {
+	if len(handles) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(handles))
+	for _, h := range handles {
+		out = append(out, h.Name)
+	}
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Adds [Model Context Protocol](https://modelcontextprotocol.io) server registration as a per-agent HCL block. cronicle launches the configured MCP server as a subprocess, lists its tools, and exposes them to the model — with namespacing, lifecycle, and observability that match the rest of the agent stack.

```hcl
task "issue_triage" {
  agent {
    prompt = "Triage open issues; close stale ones older than 90 days"

    mcp "github" {
      command = ["npx", "-y", "@modelcontextprotocol/server-github"]
      env     = ["GITHUB_TOKEN"]
    }

    mcp "fs" {
      command = ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/data"]
    }
  }
}
```

- **Tool namespacing**: `<server>__<tool>` keeps names from different servers distinct (`github__create_issue`, `fs__read_text_file`). Anthropic's tool-name regex (`^[a-zA-Z0-9_-]{1,128}$`) is enforced at config load on the server name.
- **Lifecycle**: servers launch under the agent's run context (so wallclock cancellation tears them down). The SDK's `CommandTransport` closes stdin on shutdown then SIGTERMs after 5s. If any server fails during launch, already-running peers are closed before the run aborts — never a partial-MCP state.
- **Env handling**: only env-var names listed in `mcp.env` are forwarded from cronicle's environment, plus PATH so the binary resolves. The task's HCL `env` is also passed through. Wholesale env forwarding would leak secrets to untrusted server processes.
- **Pretty rendering**: `→ fs.list_directory: {"path":"/data"}` — server.tool with compact JSON args (truncated to 80 chars).
- **Audit field**: `agent_run` slog event carries `mcp_servers=[fs,github]` so unattended runs are traceable.

## Implementation

- `internal/cronicle/mcp.go` (new, ~280 LoC):
  - `LaunchMCPServers` — spawns each server, lists tools, returns `agent.Tool` wrappers + handles for shutdown
  - `mcpToolWrapper` — adapts a single MCP tool to the existing `agent.Tool` interface; round-trips MCP's JSON-Schema input through Anthropic's `ToolInputSchemaParam`
  - `MCPHandle.Close()` — defers in execAgent; runs even on panic / budget abort
- `internal/cronicle/config.go` — new `MCP` struct + validation
- `internal/cronicle/exec.go` — wires `LaunchMCPServers` between Wallclock-context creation and `agent.Run`
- `internal/cronicle/log.go` — `displayToolName` recognizes `<server>__<tool>`; `formatToolInput` falls through to compact-JSON for MCP tools

Uses [official Go MCP SDK](https://github.com/modelcontextprotocol/go-sdk) (`v1.6.0`) for the protocol — same library Anthropic's SDK uses internally.

## Smoke

```hcl
mcp "fs" {
  command = ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp/cronicle-mcp-smoke"]
}
```

Pretty mode:
```
→ fs.list_directory: {"path":"/tmp/cronicle-mcp-smoke"}
← exit=0 3ms
→ fs.read_text_file: {"path":"/tmp/cronicle-mcp-smoke/greeting.txt"}
← exit=0 1ms
...
MCP READ COMPLETE
[2193 in / 448 out tokens · cached=13122 · $0.027833 · 11988ms · stop=end_turn]
```

slog (text mode):
```
mcp_servers=[fs] success=true
```

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — same 55/57 pass (2 pre-existing SSH failures)
- [x] End-to-end smoke with `@modelcontextprotocol/server-filesystem` — agent listed dir, read file, completed; subprocess teardown verified by shell `ps`
- [x] Pretty mode renders `<server>.<tool>` with compact JSON args
- [x] Cache breakpoint compounds: cache_read=8748 on the multi-turn run

## Next
That closes the planned 8-PR series (HCL agent block → logging → multi-turn → tool hardening → text_editor/web_search/web_fetch → skills → caching → MCP). Open items deferred earlier: `code_execution` sandbox (needs pricing review), `memory` server-side tool (needs trust/reproducibility design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)