### PR TITLE
Make SSH deploy-key tests hermetic with in-process SSH git server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.41.0
 	github.com/fatih/color v1.19.0
 	github.com/gernest/kemi v0.0.0-20160708162426-04d6c23628c2
+	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-git/go-git/v5 v5.19.0
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/hashicorp/hcl/v2 v2.24.0
@@ -32,6 +33,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect

--- a/internal/cronicle/cronicle_suite_test.go
+++ b/internal/cronicle/cronicle_suite_test.go
@@ -21,6 +21,8 @@ func TestConfig(t *testing.T) {
 var croniclePath string
 var taskPath string
 var testRepoPath string
+var testSSHAddr string
+var testSSHStop func()
 
 var _ = BeforeSuite(func() {
 	croniclePath, _ = filepath.Abs("./testconfig/")
@@ -31,9 +33,18 @@ var _ = BeforeSuite(func() {
 	testRepoPath = filepath.Join(p, ".git")
 	kemi.Unpack("test_repo.tar.gz", "./")
 
+	serveRoot, _ := filepath.Abs("./")
+	keyPath, _ := filepath.Abs("./test/test_deploy_key.pub")
+	addr, stop, err := startTestSSHServer(serveRoot, keyPath)
+	Expect(err).To(BeNil())
+	testSSHAddr = addr
+	testSSHStop = stop
 })
 
 var _ = AfterSuite(func() {
+	if testSSHStop != nil {
+		testSSHStop()
+	}
 	os.RemoveAll("./testconfig")
 	os.RemoveAll("./test_repo/")
 	os.RemoveAll("./test_task/")

--- a/internal/cronicle/git_test.go
+++ b/internal/cronicle/git_test.go
@@ -1,6 +1,7 @@
 package cronicle_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -36,10 +37,11 @@ var _ = Describe("git", func() {
 		os.RemoveAll(path)
 	})
 
-	It("cronicle.Clone should authenticate, fetch and populate the a Git object into task.Path from git@github.com:jshiv/cronicle-sample.git", func() {
+	It("cronicle.Clone should authenticate, fetch and populate the a Git object into task.Path from a deploy-key SSH remote", func() {
 		conf := cronicle.Default()
 		path, _ := filepath.Abs("./test_ssh_auth")
-		conf.Schedules[0].Repo = &cronicle.Repo{URL: "git@github.com:jshiv/cronicle-sample.git", DeployKey: "./test/test_deploy_key"}
+		sshURL := fmt.Sprintf("ssh://git@%s/test_repo", testSSHAddr)
+		conf.Schedules[0].Repo = &cronicle.Repo{URL: sshURL, DeployKey: "./test/test_deploy_key"}
 
 		conf.PropigateTaskProperties(path)
 		task := conf.Schedules[0].Tasks[0]
@@ -52,10 +54,10 @@ var _ = Describe("git", func() {
 		err = g.Checkout(task.Repo.Branch, task.Repo.Commit)
 		Expect(err).To(BeNil())
 
-		Expect(task.Path).To(Equal(path + "/.cronicle/repos/jshiv/cronicle-sample.git/foo/bar"))
-		Expect(task.Repo.URL).To(Equal("git@github.com:jshiv/cronicle-sample.git"))
+		Expect(task.Path).To(Equal(path + "/.cronicle/repos/test_repo/foo/bar"))
+		Expect(task.Repo.URL).To(Equal(sshURL))
 		Expect(task.Git.Head.Name()).To(Equal(plumbing.NewBranchReferenceName("master")))
-		Expect(cronicle.DirExists(path + "/.cronicle/repos/jshiv/cronicle-sample.git/foo/bar/.git")).To(Equal(true))
+		Expect(cronicle.DirExists(path + "/.cronicle/repos/test_repo/foo/bar/.git")).To(Equal(true))
 		os.RemoveAll(path)
 	})
 

--- a/internal/cronicle/init_test.go
+++ b/internal/cronicle/init_test.go
@@ -1,6 +1,7 @@
 package cronicle_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -55,9 +56,10 @@ var _ = Describe("Init", func() {
 
 			})
 
-			It("conf.Init should authenticate, clone and checkout from git@github.com:jshiv/cronicle-sample.git", func() {
+			It("conf.Init should authenticate, clone and checkout from a deploy-key SSH remote", func() {
 				conf := cronicle.Default()
-				conf.Repo = &cronicle.Repo{URL: "git@github.com:jshiv/cronicle-sample.git", DeployKey: "./test/test_deploy_key", Branch: "feature/test-branch"}
+				sshURL := fmt.Sprintf("ssh://git@%s/test_repo", testSSHAddr)
+				conf.Repo = &cronicle.Repo{URL: sshURL, DeployKey: "./test/test_deploy_key", Branch: "test/checkout_specific_branch"}
 				path, _ := filepath.Abs("./test_conf_init_ssh_auth")
 
 				err := conf.Init(path)
@@ -72,7 +74,7 @@ var _ = Describe("Init", func() {
 				Expect(task.Path).To(Equal(path))
 				// Expect(task.CroniclePath).To(Equal(path))
 				Expect(task.Repo).To(BeNil())
-				Expect(g.Head.Name()).To(Equal(plumbing.NewBranchReferenceName("feature/test-branch")))
+				Expect(g.Head.Name()).To(Equal(plumbing.NewBranchReferenceName("test/checkout_specific_branch")))
 				Expect(cronicle.DirExists(path + "/.git")).To(Equal(true))
 				os.RemoveAll(path)
 			})

--- a/internal/cronicle/sshserver_test.go
+++ b/internal/cronicle/sshserver_test.go
@@ -1,0 +1,90 @@
+package cronicle_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// startTestSSHServer launches an in-process SSH server that serves git
+// repositories rooted at serveRoot. Only the public key from
+// authorizedKeyPath is accepted. Returns the listen address (host:port)
+// and a stop function.
+func startTestSSHServer(serveRoot string, authorizedKeyPath string) (string, func(), error) {
+	pubBytes, err := os.ReadFile(authorizedKeyPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read public key: %w", err)
+	}
+	allowed, _, _, _, err := gossh.ParseAuthorizedKey(pubBytes)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse public key: %w", err)
+	}
+
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate host key: %w", err)
+	}
+	signer, err := gossh.NewSignerFromKey(hostPriv)
+	if err != nil {
+		return "", nil, fmt.Errorf("host signer: %w", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, fmt.Errorf("listen: %w", err)
+	}
+
+	server := &gliderssh.Server{
+		PublicKeyHandler: func(_ gliderssh.Context, key gliderssh.PublicKey) bool {
+			return gliderssh.KeysEqual(key, allowed)
+		},
+		Handler: func(s gliderssh.Session) {
+			cmd := s.Command()
+			if len(cmd) < 2 {
+				fmt.Fprintln(s.Stderr(), "missing git command")
+				_ = s.Exit(1)
+				return
+			}
+			gitCmd := cmd[0]
+			if gitCmd != "git-upload-pack" && gitCmd != "git-receive-pack" {
+				fmt.Fprintln(s.Stderr(), "unsupported command")
+				_ = s.Exit(1)
+				return
+			}
+			// Strip surrounding quotes (some clients quote the path).
+			reqPath := strings.Trim(cmd[1], "'\"")
+			repoPath := filepath.Join(serveRoot, filepath.FromSlash(reqPath))
+			c := exec.Command(gitCmd, repoPath)
+			stdin, _ := c.StdinPipe()
+			stdout, _ := c.StdoutPipe()
+			stderr, _ := c.StderrPipe()
+			if err := c.Start(); err != nil {
+				fmt.Fprintln(s.Stderr(), "start:", err)
+				_ = s.Exit(1)
+				return
+			}
+			go func() { _, _ = io.Copy(stdin, s); stdin.Close() }()
+			go func() { _, _ = io.Copy(s.Stderr(), stderr) }()
+			_, _ = io.Copy(s, stdout)
+			if err := c.Wait(); err != nil {
+				_ = s.Exit(1)
+				return
+			}
+			_ = s.Exit(0)
+		},
+	}
+	server.AddHostKey(signer)
+
+	go func() { _ = server.Serve(listener) }()
+
+	return listener.Addr().String(), func() { _ = server.Close() }, nil
+}


### PR DESCRIPTION
## Summary
- Replaces the two GitHub-dependent SSH tests (`git_test.go:39`, `init_test.go:58`) with a local SSH server spawned in `BeforeSuite`.
- New `sshserver_test.go`: `gliderlabs/ssh` server with ephemeral ed25519 host key, accepts only `test/test_deploy_key.pub`, shells out to `git-upload-pack` to serve the already-extracted `test_repo`.
- Tests now use `ssh://git@127.0.0.1:<random-port>/test_repo` — no internet, no GitHub deploy-key configuration required.

Adds `gliderlabs/ssh` and `anmitsu/go-shlex` (indirect) to `go.mod`.

## Test plan
- [x] `go test ./...` — 57/57 specs pass (was 55/57)
- [x] `go build ./...` clean
- [ ] CI green on PR