### PR TITLE
Fix release-blocking issues from agent-runtime code review

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -52,9 +52,16 @@ Multipule workers can be started, they will take turns consuming from the queue.
 		queueType, _ := cmd.Flags().GetString("queue")
 		queueName, _ := cmd.Flags().GetString("queue-name")
 		addr, _ := cmd.Flags().GetString("addr")
+		logToFile, _ := cmd.Flags().GetBool("log-to-file")
 
 		slog.Info("Starting Worker from: " + path)
-		runOptions := cronicle.RunOptions{RunWorker: true, QueueType: queueType, QueueName: queueName, Addr: addr}
+		runOptions := cronicle.RunOptions{
+			RunWorker: true,
+			QueueType: queueType,
+			QueueName: queueName,
+			Addr:      addr,
+			LogToFile: logToFile,
+		}
 		cronicle.StartWorker(path, runOptions)
 	},
 }
@@ -81,6 +88,7 @@ func init() {
 	Configurable via the queue.addr field in cronicle.hcl
 	`
 	workerCmd.Flags().String("addr", "", addrDesc)
+	workerCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); per-run agent transcripts go to path/.cronicle/runs/")
 
 	// Here you will define your flags and configuration settings.
 

--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -140,8 +140,12 @@ type Repo struct {
 	// DeployKey is the path to the rsa private key that enables pull access to a
 	// private remote repository.
 	DeployKey string `hcl:"key,optional"`
-	Commit    string `hcl:"branch,optional"`
-	Branch    string `hcl:"commit,optional"`
+	// Branch and Commit are mutually exclusive. ErrBranchAndCommitGiven
+	// rejects HCL that sets both. Historical bug: these fields had their
+	// HCL tags crossed (`branch` populated Commit and vice versa) — fixed
+	// here so the struct field name matches the HCL key.
+	Branch string `hcl:"branch,optional"`
+	Commit string `hcl:"commit,optional"`
 }
 
 //Retry defines the retry count and delay in number and seconds.

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -87,7 +87,12 @@ type RunOptions struct {
 }
 
 // StartWorker listens to a vice transport queue for schedules
-// produced by cronicle run
+// produced by cronicle run.
+//
+// File logging is honored on workers too — they're exactly where you want
+// per-run agent transcripts and the rotated cronicle.jsonl, since the work
+// happens here, not on the producer. Without this, distributed runs leave
+// no audit trail on disk.
 func StartWorker(path string, runOptions RunOptions) {
 
 	pathAbs, err := filepath.Abs(path)
@@ -98,6 +103,13 @@ func StartWorker(path string, runOptions RunOptions) {
 	if runOptions.QueueType == "" {
 		slog.Error("--queue must be specified in distributed mode. [Options: redis, nsq]")
 	}
+
+	if runOptions.LogToFile {
+		if err := EnableFileLog(pathAbs); err != nil {
+			Fatal(err)
+		}
+	}
+
 	transport := MakeViceTransport(runOptions.QueueType, runOptions.Addr)
 	schedules := transport.Receive(runOptions.QueueName)
 	var wg sync.WaitGroup

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -18,6 +18,15 @@ import (
 //with time t given in the bash command. If task.Agent is set, the task is
 //dispatched to pkg/agent instead.
 func (task *Task) Exec(t time.Time) exec.Result {
+	// Reset per-attempt state. Execute() loops on retry by re-calling Exec
+	// on the same *Task, so without this any field that an early-return
+	// path leaves unset would carry forward from the previous attempt
+	// (e.g. a transcript path from a successful first run leaking into a
+	// failing-then-skipped retry's log).
+	task.lastTranscript = ""
+	task.lastDurationMs = 0
+	task.shellStreamed = false
+
 	r := strings.NewReplacer(
 		"${date}", t.Format(TimeArgumentFormatMap["${date}"]),
 		"${datetime}", t.Format(TimeArgumentFormatMap["${datetime}"]),

--- a/internal/cronicle/mcp.go
+++ b/internal/cronicle/mcp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -97,7 +98,11 @@ func LaunchMCPServers(ctx context.Context, mcps []MCP, taskEnv []string, w io.Wr
 }
 
 func launchOne(ctx context.Context, m MCP, taskEnv []string, w io.Writer) (*MCPHandle, []agent.Tool, error) {
-	cmd := exec.Command(m.Command[0], m.Command[1:]...)
+	// CommandContext (vs plain Command) ensures a panic between launch
+	// and the deferred Close still tears down the subprocess when ctx
+	// cancels (wallclock, parent ctx, etc.). Under normal flow Close
+	// handles teardown via stdin-close + SIGTERM grace period.
+	cmd := exec.CommandContext(ctx, m.Command[0], m.Command[1:]...)
 	cmd.Env = mcpProcessEnv(m.Env, taskEnv)
 	// Server stderr is forwarded to the agent's pretty-mode writer (or
 	// discarded when nil) so npm/install chatter and runtime logs appear
@@ -261,19 +266,25 @@ func mcpContentToString(contents []mcpsdk.Content) string {
 // are compatible. Invalid/missing schemas degrade to an empty
 // `{type: object}` schema so the tool is still callable with no args
 // rather than rejected outright.
+//
+// `additionalProperties` and other JSON Schema keywords beyond
+// properties+required are passed through ExtraFields so non-trivial
+// schemas (anyOf, default, format, etc.) survive verbatim — this is the
+// difference between "agent can call the tool" and "agent calls the tool
+// and the server gets the input it actually expects".
 func mcpSchemaToAnthropic(in any) (anthropic.ToolInputSchemaParam, error) {
+	out := anthropic.ToolInputSchemaParam{}
 	if in == nil {
-		return anthropic.ToolInputSchemaParam{}, nil
+		return out, nil
 	}
 	raw, err := json.Marshal(in)
 	if err != nil {
-		return anthropic.ToolInputSchemaParam{}, err
+		return out, err
 	}
 	var asMap map[string]any
 	if err := json.Unmarshal(raw, &asMap); err != nil {
-		return anthropic.ToolInputSchemaParam{}, err
+		return out, err
 	}
-	out := anthropic.ToolInputSchemaParam{}
 	if props, ok := asMap["properties"]; ok {
 		out.Properties = props
 	}
@@ -283,6 +294,19 @@ func mcpSchemaToAnthropic(in any) (anthropic.ToolInputSchemaParam, error) {
 				out.Required = append(out.Required, s)
 			}
 		}
+	}
+	// Forward any additional schema keywords (additionalProperties,
+	// description, $defs, etc.) so the server sees its own schema.
+	// `type` and `properties`/`required` are already handled above.
+	for k, v := range asMap {
+		switch k {
+		case "type", "properties", "required":
+			continue
+		}
+		if out.ExtraFields == nil {
+			out.ExtraFields = map[string]any{}
+		}
+		out.ExtraFields[k] = v
 	}
 	return out, nil
 }
@@ -297,10 +321,6 @@ func MCPServerNames(handles []*MCPHandle) []string {
 	for _, h := range handles {
 		out = append(out, h.Name)
 	}
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }

--- a/internal/cronicle/repo_hcl_test.go
+++ b/internal/cronicle/repo_hcl_test.go
@@ -1,0 +1,51 @@
+package cronicle_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+)
+
+// Locks in the fix for the Repo HCL tag swap that crossed Branch/Commit.
+// Before the fix, `branch = "main"` populated Repo.Commit and `commit = "abc"`
+// populated Repo.Branch. Validate also called Checkout(Branch, Commit) so
+// the swap was double-wrong but mostly invisible because git can resolve
+// "main" as either a branch or a commit-ish.
+var _ = Describe("Repo HCL tags", func() {
+	It("`branch` populates Repo.Branch", func() {
+		var conf cronicle.Config
+		err := hclsimple.DecodeFile("./test/repo.hcl", &cronicle.CommandEvalContext, &conf)
+		Expect(err).To(BeNil())
+
+		var withBranch *cronicle.Schedule
+		for i := range conf.Schedules {
+			if conf.Schedules[i].Name == "with_branch" {
+				withBranch = &conf.Schedules[i]
+			}
+		}
+		Expect(withBranch).NotTo(BeNil())
+		Expect(withBranch.Tasks[0].Repo).NotTo(BeNil())
+		Expect(withBranch.Tasks[0].Repo.Branch).To(Equal("main"))
+		Expect(withBranch.Tasks[0].Repo.Commit).To(Equal(""))
+	})
+
+	It("`commit` populates Repo.Commit", func() {
+		var conf cronicle.Config
+		err := hclsimple.DecodeFile("./test/repo.hcl", &cronicle.CommandEvalContext, &conf)
+		Expect(err).To(BeNil())
+
+		var withCommit *cronicle.Schedule
+		for i := range conf.Schedules {
+			if conf.Schedules[i].Name == "with_commit" {
+				withCommit = &conf.Schedules[i]
+			}
+		}
+		Expect(withCommit).NotTo(BeNil())
+		Expect(withCommit.Tasks[0].Repo).NotTo(BeNil())
+		Expect(withCommit.Tasks[0].Repo.Commit).To(Equal("abc1234"))
+		Expect(withCommit.Tasks[0].Repo.Branch).To(Equal(""))
+	})
+})

--- a/internal/cronicle/skill.go
+++ b/internal/cronicle/skill.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -181,12 +182,7 @@ func (s *SkillTool) Available() []string {
 	for name := range s.skills {
 		out = append(out, name)
 	}
-	// Stable order without pulling in sort just for a small slice.
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/cronicle/test/repo.hcl
+++ b/internal/cronicle/test/repo.hcl
@@ -1,0 +1,24 @@
+// Fixture for the Repo HCL field test. Asserts that `branch` populates
+// Repo.Branch and `commit` populates Repo.Commit (these were crossed in
+// an earlier version of the struct tags).
+schedule "with_branch" {
+  cron = ""
+  task "t" {
+    command = ["/bin/echo", "hi"]
+    repo {
+      url    = "https://example.com/x.git"
+      branch = "main"
+    }
+  }
+}
+
+schedule "with_commit" {
+  cron = ""
+  task "t" {
+    command = ["/bin/echo", "hi"]
+    repo {
+      url    = "https://example.com/x.git"
+      commit = "abc1234"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bug fixes from the pre-release code review. Lifts six issues, anchors a regression test for the most consequential one.

| # | Severity | What |
|---|---|---|
| 1 | **must-fix** | Repo HCL tag swap — \`branch\` populated Repo.Commit, \`commit\` populated Repo.Branch. Masked because git resolves "main" as both a branch and commit-ish. Anyone setting \`commit = ...\` was getting their value sent into the branch arg of \`Checkout\`. |
| 2 | **must-fix** | \`cronicle worker\` had no \`--log-to-file\` flag. Distributed runs (the place you most want audit trails and per-run transcripts) couldn't write any. |
| 3 | should-fix | MCP \`exec.Command\` → \`exec.CommandContext\`. Panic between launch and deferred Close would leak the subprocess; with CommandContext, ctx cancel still kills it. |
| 4 | should-fix | \`mcpSchemaToAnthropic\` was dropping JSON-Schema keywords beyond type/properties/required. Now forwards \`additionalProperties\`, \`\$defs\`, \`format\`, etc. via ExtraFields so MCP servers see their own schema verbatim. |
| 5 | should-fix | \`Task.Exec\` didn't reset \`lastTranscript\`/\`lastDurationMs\`/\`shellStreamed\` between retry attempts. State could leak from a successful prior attempt into a later log entry. |
| 6 | minor | Replaced two hand-rolled bubble-sorts (\`SkillTool.Available\`, \`MCPServerNames\`) with \`sort.Strings\`. |

## Regression test

\`internal/cronicle/repo_hcl_test.go\` decodes a fixture with one \`branch = "main"\` block and one \`commit = "abc1234"\` block, asserts each value lands on the named field. Pins the fix.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/cronicle/\` — 57/57 pass (was 55/57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)