### PR TITLE
Code-review follow-ups: shadowed err, dated-model pricing, cost as Float64, opt-in web tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,13 @@ task "morning_brief" {
     model      = "claude-opus-4-7"
     system     = "You are a concise operational assistant."
 
-    // Tools available to the agent. Omit to default to all natives.
+    // Tools available to the agent. Omit to default to local-only:
     //   bash         — run shell commands in the task workspace
     //   text_editor  — view/create/edit files (workspace-confined)
-    //   web_search   — server-side web search (billed per call)
-    //   web_fetch    — server-side URL fetch  (billed per call)
-    tools = ["bash", "text_editor"]
+    // Opt-in (server-side, billed per call on Anthropic):
+    //   web_search   — server-side web search
+    //   web_fetch    — server-side URL fetch
+    tools = ["bash", "text_editor", "web_search"]
 
     // Anthropic Agent Skills (progressive disclosure). Each entry is a
     // SKILL.md (workspace-relative); only frontmatter name+description

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -247,7 +247,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		slog.Int("output_tokens", res.OutputTokens),
 		slog.Int("cache_read", res.CacheReadIn),
 		slog.Int("cache_write", res.CacheWriteIn),
-		slog.String("cost_usd", fmt.Sprintf("%.6f", res.CostUSD)),
+		slog.Float64("cost_usd", res.CostUSD),
 		slog.Int64("duration_ms", durationMs),
 		slog.String("stop_reason", res.StopReason),
 		slog.String("response", res.Stdout),

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -482,7 +482,9 @@ func (p *prettyHandler) renderAgentRun(r slog.Record) error {
 		case "response":
 			response = a.Value.String()
 		case "cost_usd":
-			costStr = a.Value.String()
+			// cost_usd is a Float64 attr (slog.Float64 in execAgent);
+			// fmt to a 6-decimal string for the pretty footer.
+			costStr = fmt.Sprintf("%.6f", a.Value.Float64())
 		case "duration_ms":
 			durationMs = a.Value.Int64()
 		case "input_tokens":

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -369,12 +369,17 @@ func (WebFetchTool) Execute(_ context.Context, _ json.RawMessage) (string, bool)
 }
 
 // defaultAgentToolNames is the tool universe an agent gets when the HCL
-// `tools` field is omitted. Matches the user expectation that an agent task
-// "just runs" with the full native toolkit. Note that web_search and
-// web_fetch are server-side and bill on Anthropic's side per call — set
-// `tools = ["bash", "text_editor"]` explicitly to opt out.
+// `tools` field is omitted. Local-only tools by default — bash and
+// text_editor run inside the task workspace and don't add per-call cost
+// beyond the model itself.
+//
+// web_search and web_fetch are deliberately excluded: they bill on
+// Anthropic's side per call, which is surprising for an unattended cron
+// job that "just runs" with the default toolkit. Add them explicitly:
+//
+//	tools = ["bash", "text_editor", "web_search", "web_fetch"]
 func defaultAgentToolNames() []string {
-	return []string{"bash", "text_editor", "web_search", "web_fetch"}
+	return []string{"bash", "text_editor"}
 }
 
 // buildAgentTools converts the HCL `tools` field into a slice of agent.Tool

--- a/internal/cronicle/tools_test.go
+++ b/internal/cronicle/tools_test.go
@@ -85,17 +85,18 @@ func TestResolveInWorkspace(t *testing.T) {
 	}
 }
 
-// defaultAgentToolNames returns all four natives. Build the corresponding
-// agent.Tool slice and confirm names round-trip.
+// defaultAgentToolNames is local-only by default (bash + text_editor).
+// web_search / web_fetch bill per call and are opt-in — adding them by
+// default would surprise unattended cron jobs.
 func TestDefaultAgentToolNamesContents(t *testing.T) {
 	names := defaultAgentToolNames()
-	want := map[string]bool{"bash": true, "text_editor": true, "web_search": true, "web_fetch": true}
+	want := map[string]bool{"bash": true, "text_editor": true}
 	if len(names) != len(want) {
-		t.Fatalf("default tools count: got %d, want %d", len(names), len(want))
+		t.Fatalf("default tools count: got %d, want %d (%v)", len(names), len(want), names)
 	}
 	for _, n := range names {
 		if !want[n] {
-			t.Fatalf("unexpected default tool %q", n)
+			t.Fatalf("unexpected default tool %q (web_search and web_fetch should be opt-in)", n)
 		}
 	}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -421,7 +421,7 @@ func applyCacheBreakpoint(params *anthropic.MessageNewParams) {
 }
 
 func computeCost(model string, in, out, cacheWrite, cacheRead int) float64 {
-	p, ok := pricing[model]
+	p, ok := pricing[priceKey(model)]
 	if !ok {
 		return 0
 	}
@@ -429,6 +429,33 @@ func computeCost(model string, in, out, cacheWrite, cacheRead int) float64 {
 		float64(out)*p.out +
 		float64(cacheWrite)*p.cacheWrite +
 		float64(cacheRead)*p.cacheRead) / 1_000_000
+}
+
+// priceKey resolves an Anthropic model id to its alias entry in the pricing
+// table. Dated ids like "claude-opus-4-7-20251022" are stripped of the
+// trailing -YYYYMMDD so they resolve to the alias's price. Without this,
+// any time the API rolls a new dated revision the run would be costed at
+// $0 silently — a big problem for unattended cron jobs with cost ceilings.
+func priceKey(model string) string {
+	if _, ok := pricing[model]; ok {
+		return model
+	}
+	// Strip a trailing -YYYYMMDD (8 digits) if present.
+	if len(model) > 9 && model[len(model)-9] == '-' {
+		stem := model[:len(model)-9]
+		date := model[len(model)-8:]
+		allDigits := true
+		for _, r := range date {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			return stem
+		}
+	}
+	return model
 }
 
 func transcriptPath(cfg Config) (string, error) {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import "testing"
+
+// priceKey strips a trailing -YYYYMMDD revision so dated ids cost the same
+// as their named alias — without this, any new dated revision would silently
+// cost $0 in the run accounting.
+func TestPriceKey(t *testing.T) {
+	cases := map[string]string{
+		// Direct hit.
+		"claude-opus-4-7":   "claude-opus-4-7",
+		"claude-sonnet-4-6": "claude-sonnet-4-6",
+		// Dated revision → strip to alias.
+		"claude-opus-4-7-20260301": "claude-opus-4-7",
+		// Already in the table verbatim — no strip.
+		"claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
+		// Not a date — passthrough (cost falls back to $0).
+		"unknown-model":        "unknown-model",
+		"claude-3-5-not-a-date": "claude-3-5-not-a-date",
+		// Short string — passthrough.
+		"x": "x",
+	}
+	for in, want := range cases {
+		if got := priceKey(in); got != want {
+			t.Fatalf("priceKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// computeCost yields a positive number for known models and zero for
+// unknown ones (no panic, no negative).
+func TestComputeCostKnownAndUnknown(t *testing.T) {
+	if got := computeCost("claude-opus-4-7", 1000, 500, 0, 0); got <= 0 {
+		t.Fatalf("known model cost should be > 0, got %f", got)
+	}
+	if got := computeCost("not-a-model", 1000, 500, 0, 0); got != 0 {
+		t.Fatalf("unknown model cost should be 0, got %f", got)
+	}
+	// Dated revision routes through priceKey.
+	if got := computeCost("claude-opus-4-7-20260301", 1000, 500, 0, 0); got <= 0 {
+		t.Fatalf("dated revision cost should be > 0, got %f", got)
+	}
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -40,24 +40,31 @@ func Execute(command []string, dir string, env []string) Result {
 	for _, e := range env {
 		cmd.Env = append(cmd.Env, e)
 	}
-	// cmd := goexec.Command("/bin/bash", "-c", command)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		result.Error = err
 		return result
 	}
 	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		result.Error = err
+		return result
+	}
 	if err := cmd.Start(); err != nil {
 		result.Error = err
 		return result
 	}
 
 	bb := bytes.NewBuffer([]byte{})
-	_, err = bb.ReadFrom(stdout)
+	if _, err := bb.ReadFrom(stdout); err != nil {
+		result.Error = err
+	}
 	result.Stdout = bb.String()
 
 	be := bytes.NewBuffer([]byte{})
-	_, err = be.ReadFrom(stderr)
+	if _, err := be.ReadFrom(stderr); err != nil && result.Error == nil {
+		result.Error = err
+	}
 	result.Stderr = be.String()
 
 	var waitStatus syscall.WaitStatus


### PR DESCRIPTION
## Summary

The remaining items from the pre-release code review, plus a verified end-to-end distributed-mode smoke run with Redis.

| | What | Why |
|---|---|---|
| 1 | \`pkg/exec.Execute\` shadowed err from StderrPipe | Errors were silently dropped. Pipe-read errors now propagate too. |
| 2 | Dated model ids cost \$0 | \`priceKey()\` strips trailing \`-YYYYMMDD\` so any new dated revision routes to its alias's price. Without this, \`budget_usd\` ceilings stop working when Anthropic publishes a new dated model. |
| 3 | \`cost_usd\` slog was a string | \`slog.String("cost_usd", "0.001050")\` → \`slog.Float64\`. JSON consumers see a number, not a stringified float. Pretty handler reads via \`Value.Float64()\`. |
| 4 | \`web_search\` / \`web_fetch\` were on by default | Server-side, billed per call. Surprising for unattended cron jobs. Default is now \`["bash", "text_editor"]\` (local-only). Add explicitly when needed. |

## Distributed-mode smoke (Redis)

With docker (colima) up, ran the full stack from \`deploy/redis/\`:

```
docker-compose -f deploy/redis/docker-compose.yaml up -d
cronicle worker --path ./worker --queue redis --addr 127.0.0.1:6379 --log-to-file
cronicle run --path ./cronicle.hcl --worker=false --queue redis --addr 127.0.0.1:6379
```

Worker output (3 agent runs over the wire):

```
agent run · schedule=brief · task=compose · model=claude-haiku-4-5 ·
  input_tokens=15279 output_tokens=225 cost_usd=0.016404
  mcp_servers=[fs] success=true
  transcript=worker/.cronicle/runs/20260510T040724Z-brief-compose.jsonl
```

Confirmed working:
- Schedule JSON survives Redis transit with Agent block intact
- Worker spawns MCP filesystem server per agent run; tears it down on completion
- \`mcp_servers=[fs]\` slog audit field reaches the worker's log
- \`--log-to-file\` on the worker writes per-run agent transcripts (this PR's bug fix from #74 doing its job)
- \`cost_usd=0.016404\` — numeric in the slog text output, no quotes

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all pass
- [x] New tests: \`TestPriceKey\` (alias resolution + dated stripping), \`TestComputeCostKnownAndUnknown\`, default-tools test updated to assert local-only
- [x] End-to-end Redis smoke with docker — agent task with MCP executed on worker, schedule re-pushed every 30s, all runs successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)