### PR TITLE
Release prep for v0.4.0: goreleaser v2 + Windows cross-compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /workspace.xml
 .idea/
 .vscode/
+# Test artifacts that the SSH-auth ginkgo tests leave behind
+internal/cronicle/test_clone_branch/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,29 +1,47 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+# goreleaser v2 config. https://goreleaser.com
+# Build matrix mirrors the v0.3.x release naming so the install.sh resolver
+# (and any existing automation that pins paths) keeps working: the asset
+# names look like cronicle_X.Y.Z_{Linux,Darwin,Windows}_{x86_64,arm64,i386}.tar.gz.
+version: 2
+
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod download
-    # you may remove this if you don't need go generate
     - go generate ./...
+
 builds:
   - env:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+    # ARM is rare on Windows historically; skip 386 on darwin (Apple dropped 32-bit).
+    ignore:
+      - goos: darwin
+        goarch: "386"
+
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}Darwin
+      {{- else if eq .Os "linux" }}Linux
+      {{- else if eq .Os "windows" }}Windows
+      {{- end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -109,17 +109,11 @@ func ExecuteWithStreamContext(ctx context.Context, command []string, dir string,
 	for _, e := range env {
 		cmd.Env = append(cmd.Env, e)
 	}
-	// Run the child in its own process group so we can signal the whole
-	// group on cancellation instead of just the immediate child.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	// Override the default Cancel (which is cmd.Process.Kill on the leader)
-	// to signal the entire group, then let WaitDelay escalate to SIGKILL.
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-	}
+	// Process-group handling is platform-specific. On unix, the child runs in
+	// its own pgid so cancellation signals the whole group (catches `bash -c
+	// "sleep 30 | cat"` style sub-fans). On windows, the goexec default
+	// (cmd.Process.Kill) is the best we have without spawning a Job Object.
+	configureProcessGroup(cmd)
 	cmd.WaitDelay = 2 * time.Second
 
 	var stdoutBuf, stderrBuf bytes.Buffer

--- a/pkg/exec/proc_unix.go
+++ b/pkg/exec/proc_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package exec
+
+import (
+	goexec "os/exec"
+	"syscall"
+)
+
+// configureProcessGroup runs the child in its own process group and replaces
+// goexec's default Cancel hook (which kills only the leader) with a SIGTERM
+// to the entire group. Combined with the cmd.WaitDelay set by the caller,
+// any non-exiting children get SIGKILL'd shortly after — important for
+// shell pipelines and unattended agent runs where a stuck subprocess would
+// otherwise outlive the wallclock deadline.
+func configureProcessGroup(cmd *goexec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+}

--- a/pkg/exec/proc_windows.go
+++ b/pkg/exec/proc_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package exec
+
+import (
+	goexec "os/exec"
+)
+
+// configureProcessGroup is a no-op on Windows: there's no POSIX process
+// group to set up. goexec's default Cancel calls cmd.Process.Kill on the
+// leader, which is the best we can do without spawning a Windows Job
+// Object — a heavier piece of machinery we'd add only if we found
+// cronicle running on Windows in production with stuck child trees.
+func configureProcessGroup(cmd *goexec.Cmd) {}


### PR DESCRIPTION
## Summary

Pre-release plumbing so v0.4.0 can ship via goreleaser:

- **\`.goreleaser.yml\`** — rewrite for goreleaser v2 (the v1 \`replacements\` key was removed). Build matrix and asset naming match the v0.3.x releases, so the install.sh resolver and any pinned URLs keep working.
- **\`pkg/exec\`** — split process-group setup into \`proc_unix.go\` (\`//go:build !windows\`) and \`proc_windows.go\` (no-op). \`syscall.Setpgid\` and \`syscall.Kill\` don't exist on Windows; gating them lets the Windows binary build with the default goexec cancellation as a fallback.
- **.gitignore** the \`test_clone_branch/\` directory that the SSH-auth ginkgo tests leave behind.

## Verified

\`goreleaser release --snapshot --clean --skip=publish\` produces 8 archives (Darwin/Linux/Windows × amd64/arm64/386, minus darwin-386). Asset names follow \`cronicle_X.Y.Z_{Os}_{Arch}.tar.gz\` matching install.sh's expectations.

\`go test ./...\` still passes on macOS; \`GOOS=windows go build ./...\` succeeds.

## Next
After merge, tag \`v0.4.0\` and run \`goreleaser release\` to publish artifacts to GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)