### PR TITLE
Resolve skill paths from cronicle config dir when not in workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 # Test artifacts that the SSH-auth ginkgo tests leave behind
 internal/cronicle/test_clone_branch/
+dist/

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -113,7 +113,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	// catalog appended to the system prompt; bodies stay out until the
 	// agent calls load_skill (progressive disclosure, per Anthropic's
 	// Skills standard).
-	skills, skillErr := LoadSkillsForTask(task.Path, task.Agent.Skills)
+	skills, skillErr := LoadSkillsForTask(task.Path, task.CroniclePath, task.Agent.Skills)
 	if skillErr != nil {
 		return exec.Result{
 			Command:    []string{"agent", task.Agent.Model},

--- a/internal/cronicle/skill.go
+++ b/internal/cronicle/skill.go
@@ -267,12 +267,24 @@ func (s *SkillTool) format(sk *Skill) string {
 	return b.String()
 }
 
-// LoadSkillsForTask resolves and loads each path in agent.Skills against
-// taskRoot, returning the parsed skills. Path traversal is re-checked here
-// (defense in depth — Validate already rejected `..`/abs paths at config
-// time, but task.Path can change between Validate and Execute if a repo is
-// cloned, so we verify containment again with the live taskRoot).
-func LoadSkillsForTask(taskRoot string, paths []string) ([]*Skill, error) {
+// LoadSkillsForTask resolves and loads each path in agent.Skills.
+// Resolution order, first-hit wins:
+//
+//  1. taskRoot/<path> — co-located with the task workspace (typical when
+//     no `repo` block is set, so taskRoot == configRoot).
+//  2. configRoot/<path> — alongside cronicle.hcl. Lets skills be operational
+//     config that doesn't live inside a cloned repo.
+//
+// The skill's Dir is computed relative to whichever root resolved it. If the
+// resolution root differs from taskRoot, Dir is recorded as an absolute path
+// — the agent's bash tool can use it directly; text_editor stays workspace-
+// confined to taskRoot, so bundled-file editing requires the skill to live
+// inside the workspace.
+//
+// Path traversal is re-checked here as defense in depth (Validate rejected
+// `..`/abs paths at config time, but the resolution root may have changed
+// between Validate and Execute if a repo was cloned).
+func LoadSkillsForTask(taskRoot, configRoot string, paths []string) ([]*Skill, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
@@ -280,20 +292,58 @@ func LoadSkillsForTask(taskRoot string, paths []string) ([]*Skill, error) {
 	if err != nil {
 		return nil, fmt.Errorf("task root abs: %w", err)
 	}
+	cfgAbs := wsAbs
+	if configRoot != "" {
+		cfgAbs, err = filepath.Abs(configRoot)
+		if err != nil {
+			return nil, fmt.Errorf("config root abs: %w", err)
+		}
+	}
+
 	out := make([]*Skill, 0, len(paths))
 	for _, p := range paths {
-		abs := filepath.Clean(filepath.Join(wsAbs, p))
-		rel, err := filepath.Rel(wsAbs, abs)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return nil, fmt.Errorf("skill path %q escapes task workspace", p)
-		}
-		sk, err := LoadSkill(abs, wsAbs)
+		abs, root, err := resolveSkillPath(wsAbs, cfgAbs, p)
 		if err != nil {
 			return nil, err
+		}
+		sk, err := LoadSkill(abs, root)
+		if err != nil {
+			return nil, err
+		}
+		// When the skill lives outside the task workspace, the relative
+		// Dir computed in LoadSkill (from `root`) makes sense only if the
+		// agent knows that root. Easier: switch Dir to absolute so the
+		// agent always has a usable path for bash invocations of bundled
+		// scripts.
+		if root != wsAbs {
+			sk.Dir = filepath.Dir(abs)
 		}
 		out = append(out, sk)
 	}
 	return out, nil
+}
+
+// resolveSkillPath tries taskRoot first, then configRoot. Either root can
+// reject paths that try to `..` out of it — a skill must end up under one
+// of the two registered roots.
+func resolveSkillPath(taskRoot, configRoot, p string) (abs, root string, err error) {
+	for _, candidate := range []string{taskRoot, configRoot} {
+		if candidate == "" {
+			continue
+		}
+		full := filepath.Clean(filepath.Join(candidate, p))
+		rel, relErr := filepath.Rel(candidate, full)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if _, statErr := os.Stat(full); statErr == nil {
+			return full, candidate, nil
+		}
+	}
+	if taskRoot == configRoot || configRoot == "" {
+		return "", "", fmt.Errorf("skill path %q not found under task workspace %s", p, taskRoot)
+	}
+	return "", "", fmt.Errorf("skill path %q not found under task workspace (%s) or config dir (%s)", p, taskRoot, configRoot)
 }
 
 // FormatAvailableSkillsSection returns the Available Skills block to append

--- a/internal/cronicle/skill_test.go
+++ b/internal/cronicle/skill_test.go
@@ -107,7 +107,7 @@ func TestLoadSkillsForTask(t *testing.T) {
 	body := []byte("---\nname: x\ndescription: x desc\n---\nbody\n")
 	_ = os.WriteFile(filepath.Join(dir, "SKILL.md"), body, 0o644)
 
-	skills, err := LoadSkillsForTask(root, []string{"skills/x/SKILL.md"})
+	skills, err := LoadSkillsForTask(root, root, []string{"skills/x/SKILL.md"})
 	if err != nil {
 		t.Fatalf("LoadSkillsForTask: %v", err)
 	}
@@ -116,8 +116,39 @@ func TestLoadSkillsForTask(t *testing.T) {
 	}
 
 	// `..` traversal blocked.
-	if _, err := LoadSkillsForTask(root, []string{"../escape/SKILL.md"}); err == nil {
+	if _, err := LoadSkillsForTask(root, root, []string{"../escape/SKILL.md"}); err == nil {
 		t.Fatalf("`..` traversal allowed")
+	}
+}
+
+// LoadSkillsForTask falls back to configRoot when the skill isn't co-located
+// with the task workspace. This is the typical case when a `repo` block
+// makes task.Path the cloned repo dir and the skill lives alongside
+// cronicle.hcl instead.
+func TestLoadSkillsForTaskFallbackToConfigRoot(t *testing.T) {
+	cfg := t.TempDir()
+	taskWS := t.TempDir() // separate workspace, like a cloned-repo dir
+
+	// Skill lives under cfg, not under the task workspace.
+	dir := filepath.Join(cfg, "skills", "report")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("---\nname: report\ndescription: a report skill\n---\nbody\n")
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skills, err := LoadSkillsForTask(taskWS, cfg, []string{"skills/report/SKILL.md"})
+	if err != nil {
+		t.Fatalf("LoadSkillsForTask fallback: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Name != "report" {
+		t.Fatalf("expected report skill, got %+v", skills)
+	}
+	// Skill is outside the workspace, so Dir should be absolute.
+	if !filepath.IsAbs(skills[0].Dir) {
+		t.Fatalf("expected absolute Dir for skill outside workspace, got %q", skills[0].Dir)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a task has a \`repo\` block, \`task.Path\` becomes the cloned repo dir, and the existing skill resolver only looked there. So a skill defined alongside \`cronicle.hcl\` (the natural place for operational skills) wasn't found — forcing users to either ship skills inside the cloned codebase (awkward; skills are operational config, not source) or skip skills on tasks that need a clone.

This PR adds a fallback: \`LoadSkillsForTask\` now accepts both \`taskRoot\` and \`configRoot\` (\`task.CroniclePath\`). Resolution order:

1. \`taskRoot/<path>\` — preserves the prior behavior for skills bundled inside a workspace
2. \`configRoot/<path>\` — falls back to the dir where \`cronicle.hcl\` lives

When a skill resolves via \`configRoot\` (i.e. lives outside the agent's workspace), its \`Dir\` field is recorded as an absolute path so the agent can compose paths to bundled scripts via bash directly. \`text_editor\` stays workspace-confined; bundled-file editing still requires the skill to live inside the workspace.

## Why this came up

While running two pre-release user stories:

1. **Clone repo + agent reads git history + writes changelog** — clone via \`repo\` block, agent runs \`git log\` via bash, writes summary. Wanted a \`changelog-summary\` skill alongside \`cronicle.hcl\`. Failed pre-fix.
2. **Clone repo + agent applies a "ticket" code edit + commits + writes PR body** — same setup, with a \`ticket-resolver\` skill alongside the config. Failed pre-fix.

Both stories now work end-to-end. The agent in story 2 even runs \`go vet\` to verify its edit before committing.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all pass
- [x] New test \`TestLoadSkillsForTaskFallbackToConfigRoot\` pins the fallback semantics
- [x] Smoke story 1 (clone cronicle + summarize commits) succeeds with skill from configRoot
- [x] Smoke story 2 (clone cronicle + ticket-driven edit + branch + commit + PR body) succeeds; commit \`8db222a\` on branch \`ticket/doc-agent-test-header\`, PR_BODY.md written

🤖 Generated with [Claude Code](https://claude.com/claude-code)