### PR TITLE
Cross-task context via ${scratch} + daily-report demo

### DIFF
--- a/deploy/daily-report/README.md
+++ b/deploy/daily-report/README.md
@@ -1,0 +1,77 @@
+# Daily Report
+
+A canonical multi-agent workflow: 4 crawlers fan out to read team state from different sources, a composer fans in to merge them into a unified daily report.
+
+## Shape
+
+```
+                       ┌──────────────────┐
+                       │ crawl_slack      │ ─┐
+                       └──────────────────┘  │
+                       ┌──────────────────┐  │
+                       │ crawl_discord    │ ─┤
+                       └──────────────────┘  │   ┌─────────────┐
+                       ┌──────────────────┐  ├──▶│  compose    │
+                       │ crawl_email      │ ─┤   └─────────────┘
+                       └──────────────────┘  │
+                       ┌──────────────────┐  │
+                       │ crawl_code       │ ─┘
+                       └──────────────────┘
+```
+
+Each crawler writes a markdown file to a schedule-scoped scratch dir; the composer reads them and produces `REPORT.md` (and optionally posts to Slack via MCP).
+
+## How tasks share data
+
+The `${scratch}` template variable resolves to a per-schedule, per-run shared dir at `<croniclePath>/.cronicle/scratch/<schedule>/<run-id>/`. All tasks in one schedule run see the same dir. cronicle creates it before walking the DAG, so even fan-out tasks running in parallel can write into it without coordination beyond filename.
+
+The slog `schedule_start` event records the scratch path for audit:
+
+```
+schedule started ... scratch=/.../scratch/daily_report/20260510T160000Z
+```
+
+## Run it
+
+This demo's crawlers produce mock data (so it runs without real Slack/Discord/Gmail credentials) but `crawl_code` exercises the built-in git tool against the real cronicle repo:
+
+```bash
+cronicle exec --schedule daily_report --path deploy/daily-report/cronicle.hcl
+```
+
+After it finishes, check the scratch dir:
+
+```bash
+ls $(pwd)/.cronicle/scratch/daily_report/*/
+# slack.md  discord.md  email.md  code.md  REPORT.md
+```
+
+`REPORT.md` is the merged output.
+
+## Productionizing
+
+Replace each crawler's mock prompt with a real MCP server invocation:
+
+```hcl
+task "crawl_slack" {
+  agent {
+    prompt = "Use the slack MCP to query channels #engineering, #incidents over the last 24h. Summarize as 3-5 bullets. Save to ${scratch}/slack.md."
+    tools  = ["text_editor"]
+
+    mcp "slack" {
+      command = ["npx", "-y", "@modelcontextprotocol/server-slack"]
+      env     = ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]
+    }
+  }
+}
+```
+
+For posting back to Slack, add the same `mcp "slack"` block on the composer task and instruct the prompt to call the post-message tool with the rendered `REPORT.md` content.
+
+## What this demonstrates
+
+- **Cron-driven multi-agent DAG** — `cron = "0 9 * * *"` + `depends = [...]`
+- **Cross-task context** — `${scratch}` shared dir
+- **Per-task tool universes** — each crawler gets only what it needs
+- **Per-task cost ceilings** — `budget_usd` per agent caps damage from a runaway turn
+- **Mixed primitives** — `repo` clone (code crawler) + MCP servers (data crawlers) + skill (composer) all in one schedule

--- a/deploy/daily-report/README.md
+++ b/deploy/daily-report/README.md
@@ -31,6 +31,14 @@ The slog `schedule_start` event records the scratch path for audit:
 schedule started ... scratch=/.../scratch/daily_report/20260510T160000Z
 ```
 
+### Distributed mode (workers consuming over Redis/NSQ)
+
+`${scratch}` works in distributed mode without any extra config. Cronicle's queue model is *one schedule message → one worker → all tasks in that DAG*: when a worker pulls a schedule off the queue it runs `ExecuteTasks` locally, computing one scratch dir under that worker's own `--path`. All tasks in the run share that path because they all run in the same worker process.
+
+Different cron firings of the same schedule may land on different workers (each picks up the next message off the queue). Each firing gets its own scratch dir on whichever worker handled it — different runs don't share state, which is the right semantics for cron. If you want state to persist across invocations, use durable storage (an MCP-served KV store, a database, etc.) rather than `${scratch}`.
+
+Verified end-to-end: producer pushes to Redis, worker pulls, both `produce` and `consume` tasks read/write the same `<worker-path>/.cronicle/scratch/<schedule>/<run-id>/` dir, the consumer's `HANDOFF: ...` line round-trips the file the producer wrote.
+
 ## Run it
 
 This demo's crawlers produce mock data (so it runs without real Slack/Discord/Gmail credentials) but `crawl_code` exercises the built-in git tool against the real cronicle repo:

--- a/deploy/daily-report/cronicle.hcl
+++ b/deploy/daily-report/cronicle.hcl
@@ -1,0 +1,139 @@
+// Daily report demo: 4 crawler agents (Slack, Discord, email, code) fan
+// out into a shared scratch dir; one composer agent fans in, reads them,
+// and writes a unified REPORT.md (and optionally posts to Slack via MCP).
+//
+// This file demonstrates the cross-task context pattern via ${scratch}.
+// In a real deployment:
+//   - Each crawler's `mcp` block points at the source-of-truth integration:
+//       slack:   @modelcontextprotocol/server-slack
+//       discord: @modelcontextprotocol/server-discord (or a community one)
+//       email:   @modelcontextprotocol/server-gmail (or imap variant)
+//       code:    use the built-in git tool against a `repo` block
+//   - Each `env` whitelists only the credentials the server needs.
+//   - The composer's mcp "slack" reuses the slack MCP for posting.
+//
+// For this demo the crawlers produce mock data (they just write a fixed
+// template to ${scratch}/<source>.md) so the pattern can be smoke-tested
+// without real credentials. Swap in real MCP servers + real prompts to
+// make it production.
+
+schedule "daily_report" {
+  cron     = "0 9 * * *"   // every day at 09:00 local
+  timezone = "America/Los_Angeles"
+
+  task "crawl_slack" {
+    agent {
+      prompt = <<-EOT
+        Today is ${date}. (Production: query the slack MCP for messages in
+        channels #engineering, #incidents, #product over the last 24h.
+        For this demo, compose 3 plausible bullet points.)
+
+        Write the result to ${scratch}/slack.md as markdown bullets.
+        Reply: SLACK CRAWLED.
+      EOT
+      model      = "claude-haiku-4-5"
+      tools      = ["text_editor"]
+      max_turns  = 5
+      wallclock  = "1m"
+      budget_usd = 0.05
+      max_tokens = 800
+
+      // Production:
+      // mcp "slack" {
+      //   command = ["npx", "-y", "@modelcontextprotocol/server-slack"]
+      //   env     = ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]
+      // }
+    }
+  }
+
+  task "crawl_discord" {
+    agent {
+      prompt = <<-EOT
+        Today is ${date}. (Production: query a discord MCP for the team
+        server's channel digests over the last 24h. For this demo,
+        compose 2 plausible bullet points.)
+
+        Write the result to ${scratch}/discord.md as markdown bullets.
+        Reply: DISCORD CRAWLED.
+      EOT
+      model      = "claude-haiku-4-5"
+      tools      = ["text_editor"]
+      max_turns  = 5
+      wallclock  = "1m"
+      budget_usd = 0.05
+      max_tokens = 800
+    }
+  }
+
+  task "crawl_email" {
+    agent {
+      prompt = <<-EOT
+        Today is ${date}. (Production: query the gmail MCP for unread
+        threads in label "team-updates" since yesterday. For this demo,
+        compose 3 plausible bullet points.)
+
+        Write the result to ${scratch}/email.md as markdown bullets.
+        Reply: EMAIL CRAWLED.
+      EOT
+      model      = "claude-haiku-4-5"
+      tools      = ["text_editor"]
+      max_turns  = 5
+      wallclock  = "1m"
+      budget_usd = 0.05
+      max_tokens = 800
+    }
+  }
+
+  task "crawl_code" {
+    // Real code crawl: clone the team's repo, summarize commits via the
+    // built-in git tool. We point at jshiv/cronicle as a stand-in so the
+    // demo runs against a real repo end-to-end.
+    repo {
+      url = "https://github.com/jshiv/cronicle.git"
+    }
+    agent {
+      prompt = <<-EOT
+        Today is ${date}. Use the built-in git tool to look at commits
+        merged in the last 7 days. Pick the 3 most interesting and
+        summarize each in one sentence focused on user-visible impact.
+
+        Write the result to ${scratch}/code.md as markdown bullets.
+        Reply: CODE CRAWLED.
+      EOT
+      model      = "claude-haiku-4-5"
+      tools      = ["git", "text_editor"]
+      max_turns  = 12
+      wallclock  = "2m"
+      budget_usd = 0.10
+      max_tokens = 1500
+    }
+  }
+
+  task "compose" {
+    depends = ["crawl_slack", "crawl_discord", "crawl_email", "crawl_code"]
+    agent {
+      prompt = <<-EOT
+        Compose today's daily team report. Today is ${date}. Read the
+        crawler outputs in ${scratch}/ and follow the daily-composer
+        skill's instructions.
+
+        (Production: post the rendered REPORT.md to #daily-report via
+        the slack MCP. For this demo, just leave the file in scratch —
+        the orchestrator will pick it up.)
+      EOT
+      model      = "claude-haiku-4-5"
+      tools      = ["text_editor", "bash"]
+      skills     = ["skills/daily-composer/SKILL.md"]
+      max_turns  = 10
+      wallclock  = "2m"
+      budget_usd = 0.10
+      max_tokens = 2500
+
+      // Production:
+      // mcp "slack" {
+      //   command = ["npx", "-y", "@modelcontextprotocol/server-slack"]
+      //   env     = ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]
+      // }
+    }
+  }
+}

--- a/deploy/daily-report/skills/daily-composer/SKILL.md
+++ b/deploy/daily-report/skills/daily-composer/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: daily-composer
+description: Compose a unified daily team report from per-source markdown files in a scratch directory. Use when the prompt asks to merge crawler outputs (slack, discord, email, code) into a single morning brief.
+allowed-tools:
+  - text_editor
+  - bash
+---
+
+# Daily Composer
+
+You will receive a scratch directory path containing per-source markdown files produced by upstream crawler tasks. Read each one and compose a single unified daily report.
+
+Steps:
+
+1. List the scratch dir to see which sources produced output. Expected files (any subset is fine; the others are crawlers that didn't run or didn't have content):
+   - `slack.md` — what happened in Slack
+   - `discord.md` — what happened in Discord
+   - `email.md` — what came through email
+   - `code.md` — code changes / merged PRs
+
+2. For each present file, read it via `text_editor view`.
+
+3. Compose a unified report at `${scratch}/REPORT.md` with this shape:
+
+   ```markdown
+   # Daily Report — <YYYY-MM-DD>
+
+   ## TL;DR
+   - one-line summary of what mattered today across all channels
+
+   ## Slack
+   - bullet
+   - bullet
+
+   ## Discord
+   - bullet
+   - bullet
+
+   ## Email
+   - bullet
+   - bullet
+
+   ## Code
+   - bullet
+   - bullet
+   ```
+
+   Skip sections whose source file is missing or empty rather than emitting a "no data" placeholder. The TL;DR is required.
+
+4. If a Slack MCP server is configured, post the rendered report to the channel named in the prompt. Otherwise, just leave the file in the scratch dir.
+
+5. Reply with the literal lines:
+   ```
+   REPORT: ${scratch}/REPORT.md
+   COMPOSED.
+   ```

--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -81,6 +81,11 @@ type Task struct {
 	lastTranscript string
 	lastDurationMs int64
 	shellStreamed  bool
+	// ScratchDir is the schedule-scoped shared dir all tasks in one
+	// schedule run can read/write. Set by Schedule.ExecuteTasks before
+	// walking the DAG; substituted into prompts/commands as `${scratch}`.
+	// Survives the run for transcript/audit access.
+	ScratchDir string
 }
 
 // Agent is the configuration structure that defines an LLM agent invocation.

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -384,6 +384,15 @@ func ExecTasks(cronicleFile string, taskName string, scheduleName string, now ti
 		taskMap := schedule.TaskMap()
 		if taskName != "" {
 			if task, ok := taskMap[taskName]; ok {
+				// Set the schedule-scoped scratch dir so single-task
+				// `cronicle exec --task X` produces the same ${scratch}
+				// artifacts as a full schedule run. The dir is created
+				// best-effort; ${scratch} substitution silently no-ops on
+				// failure.
+				if scratch := schedule.scratchDirFor(nowInLoc); scratch != "" {
+					_ = os.MkdirAll(scratch, 0o755)
+					task.ScratchDir = scratch
+				}
 				task.Execute(nowInLoc)
 			}
 		} else {

--- a/internal/cronicle/dag.go
+++ b/internal/cronicle/dag.go
@@ -3,6 +3,8 @@ package cronicle
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -39,8 +41,24 @@ func (schedule Schedule) ExecuteTasks() {
 	}
 	taskMap = schedule.TaskMap()
 
+	// Schedule-scoped scratch dir: a single dir per schedule run, shared by
+	// every task within it via task.ScratchDir (substituted into prompts as
+	// ${scratch}). The cronicle-native pattern for cross-task context: an
+	// upstream task writes a file, a downstream task reads it. Survives the
+	// run so transcripts and post-hoc audits can reference produced
+	// artifacts. Created best-effort — if mkdir fails, tasks just see an
+	// empty ScratchDir and ${scratch} substitution is a no-op.
+	scratchDir := schedule.scratchDirFor(now)
+	if scratchDir != "" {
+		_ = os.MkdirAll(scratchDir, 0o755)
+		for name, t := range taskMap {
+			t.ScratchDir = scratchDir
+			taskMap[name] = t
+		}
+	}
+
 	startedAt := time.Now()
-	slog.Info("schedule started",
+	startAttrs := []any{
 		"entry_type", "schedule_start",
 		"run_id", schedule.RunID,
 		"schedule", schedule.Name,
@@ -49,7 +67,11 @@ func (schedule Schedule) ExecuteTasks() {
 		"date", now.Format(time.RFC850),
 		"tasks", taskNames,
 		"dag", dagString(deps),
-	)
+	}
+	if scratchDir != "" {
+		startAttrs = append(startAttrs, "scratch", scratchDir)
+	}
+	slog.Info("schedule started", startAttrs...)
 
 	walkErr := walkDAG(deps, func(name string) error {
 		task := taskMap[name]
@@ -133,6 +155,24 @@ func walkDAG(deps map[string][]string, fn func(string) error) error {
 	}
 
 	return firstErr
+}
+
+// scratchDirFor computes the absolute scratch dir for one schedule run.
+// Lives under <croniclePath>/.cronicle/scratch/<schedule>/<utc-runid>/ so
+// concurrent runs of the same schedule don't collide and each run is
+// addressable by timestamp. Returns "" if the schedule has no tasks (no
+// croniclePath to resolve), in which case dag.go skips the mkdir and
+// ${scratch} substitution becomes a no-op.
+func (schedule *Schedule) scratchDirFor(now time.Time) string {
+	if len(schedule.Tasks) == 0 {
+		return ""
+	}
+	croniclePath := schedule.Tasks[0].CroniclePath
+	if croniclePath == "" {
+		return ""
+	}
+	runID := now.UTC().Format("20060102T150405Z")
+	return filepath.Join(croniclePath, ".cronicle", "scratch", schedule.Name, runID)
 }
 
 // dagString produces a human-readable representation of the DAG for logging.

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -33,6 +33,12 @@ func (task *Task) Exec(t time.Time) exec.Result {
 		"${datetime}", t.Format(TimeArgumentFormatMap["${datetime}"]),
 		"${timestamp}", t.Format(TimeArgumentFormatMap["${timestamp}"]),
 		"${path}", task.Path,
+		// ${scratch} is the schedule-scoped shared dir tasks use to pass
+		// artifacts to downstream tasks (set by Schedule.ExecuteTasks).
+		// Empty string when the schedule wasn't routed through ExecuteTasks
+		// (e.g. one-off `cronicle exec`) — the substitution leaves the
+		// literal in place, which is loud enough to debug.
+		"${scratch}", task.ScratchDir,
 	)
 
 	if task.Agent != nil {
@@ -193,7 +199,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 			gitAuth = a
 		}
 	}
-	cfg.Tools = buildAgentTools(task.Agent.Tools, task.Path, task.Env, gitAuth, toolWriter)
+	cfg.Tools = buildAgentTools(task.Agent.Tools, task.Path, task.Env, gitAuth, task.ScratchDir, toolWriter)
 	if skillTool != nil {
 		cfg.Tools = append(cfg.Tools, skillTool)
 	}

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -35,6 +35,10 @@ var (
 			"date":      cty.StringVal("${date}"),
 			"datetime":  cty.StringVal("${datetime}"),
 			"timestamp": cty.StringVal("${timestamp}"),
+			// scratch survives HCL parse as the literal "${scratch}"
+			// token, then exec.go substitutes the schedule-scoped
+			// scratch dir path at run time.
+			"scratch": cty.StringVal("${scratch}"),
 		},
 	}
 

--- a/internal/cronicle/parse_test.go
+++ b/internal/cronicle/parse_test.go
@@ -20,13 +20,14 @@ import (
 
 var _ = Describe("Parse", func() {
 
-	It("cronicle.CommandEvalContext should contain date, datetime, and timestamp as an argument", func() {
+	It("cronicle.CommandEvalContext should contain date, datetime, timestamp, and scratch as arguments", func() {
 
 		expected := hcl.EvalContext{
 			Variables: map[string]cty.Value{
 				"date":      cty.StringVal("${date}"),
 				"datetime":  cty.StringVal("${datetime}"),
 				"timestamp": cty.StringVal("${timestamp}"),
+				"scratch":   cty.StringVal("${scratch}"),
 			},
 		}
 		Expect(cronicle.CommandEvalContext).To(Equal(expected))
@@ -78,7 +79,7 @@ var _ = Describe("Parse", func() {
 		conf := cronicle.Default()
 		schedule := conf.Schedules[0]
 		// schedule.Now = time.Now().In(time.Local)
-		s := `{"Name":"foo","Cron":"@every 5s","Timezone":"","StartDate":"","EndDate":"","Repo":null,"Tasks":[{"Name":"bar","Command":["/bin/echo","Hello World --date=${date}"],"Depends":null,"Repo":null,"Retry":null,"Agent":null,"Env":null,"Path":"","CronicleRepo":null,"CroniclePath":"","Git":{"Worktree":null,"Repository":null,"Head":null,"Hash":null,"Commit":null,"ReferenceName":""},"ScheduleName":"","RunID":""}],"Now":"0001-01-01T00:00:00Z","CronicleRepo":null,"RunID":"","Source":""}`
+		s := `{"Name":"foo","Cron":"@every 5s","Timezone":"","StartDate":"","EndDate":"","Repo":null,"Tasks":[{"Name":"bar","Command":["/bin/echo","Hello World --date=${date}"],"Depends":null,"Repo":null,"Retry":null,"Agent":null,"Env":null,"Path":"","CronicleRepo":null,"CroniclePath":"","Git":{"Worktree":null,"Repository":null,"Head":null,"Hash":null,"Commit":null,"ReferenceName":""},"ScheduleName":"","RunID":"","ScratchDir":""}],"Now":"0001-01-01T00:00:00Z","CronicleRepo":null,"RunID":"","Source":""}`
 
 		Expect(schedule.JSON()).To(Equal([]byte(s)))
 	})

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -134,6 +134,13 @@ func truncateOutput(s string, max int) string {
 // the next turn's context.
 type TextEditorTool struct {
 	Workspace string
+	// AllowedRoots is the set of additional dirs (besides Workspace) that
+	// text_editor will accept paths under. Used to grant access to the
+	// schedule-scoped scratch dir when the task's main workspace is a
+	// cloned repo — the cross-task context pattern (${scratch}) needs the
+	// composer to read crawler outputs that live outside the workspace.
+	// Empty means "workspace only" (the historical behavior).
+	AllowedRoots []string
 }
 
 func (t *TextEditorTool) Name() string { return "str_replace_based_edit_tool" }
@@ -157,7 +164,7 @@ func (t *TextEditorTool) Execute(ctx context.Context, input json.RawMessage) (st
 	if err := json.Unmarshal(input, &args); err != nil {
 		return fmt.Sprintf("Error: invalid editor input: %v", err), true
 	}
-	abs, err := resolveInWorkspace(t.Workspace, args.Path)
+	abs, err := t.resolvePath(args.Path)
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err), true
 	}
@@ -282,6 +289,30 @@ func (t *TextEditorTool) insert(absPath string, insertLine int, newStr string) (
 	return fmt.Sprintf("Inserted at line %d in %s", insertLine, filepath.Base(absPath)), false
 }
 
+// resolvePath gates each text_editor operation. It accepts paths under the
+// primary workspace OR any of the additional AllowedRoots (scratch dir is
+// the canonical extra). The first root that contains the resolved path
+// wins; rejection means no root matched. Path-traversal `..` is checked
+// against each root, so the agent can't break out via the additional
+// roots either.
+func (t *TextEditorTool) resolvePath(p string) (string, error) {
+	if t == nil || t.Workspace == "" {
+		return resolveInWorkspace(t.Workspace, p)
+	}
+	if abs, err := resolveInWorkspace(t.Workspace, p); err == nil {
+		return abs, nil
+	}
+	for _, root := range t.AllowedRoots {
+		if root == "" {
+			continue
+		}
+		if abs, err := resolveInWorkspace(root, p); err == nil {
+			return abs, nil
+		}
+	}
+	return "", fmt.Errorf("path %s outside workspace and allowed roots", p)
+}
+
 // resolveInWorkspace turns a model-supplied path (relative or absolute) into
 // an absolute path *guaranteed* to live under workspace, or an error. Used
 // by every text_editor operation as the workspace-containment gate.
@@ -393,9 +424,13 @@ func defaultAgentToolNames() []string {
 // pretty streaming mode). Empty/nil names defaults to the full native
 // toolkit (defaultAgentToolNames). Unknown names are filtered out (Validate
 // has already rejected them at parse time, so this is defensive).
-func buildAgentTools(names []string, workspace string, env []string, gitAuth transport.AuthMethod, w io.Writer) []agent.Tool {
+func buildAgentTools(names []string, workspace string, env []string, gitAuth transport.AuthMethod, scratchDir string, w io.Writer) []agent.Tool {
 	if len(names) == 0 {
 		names = defaultAgentToolNames()
+	}
+	var editorAllowed []string
+	if scratchDir != "" {
+		editorAllowed = append(editorAllowed, scratchDir)
 	}
 	out := make([]agent.Tool, 0, len(names))
 	for _, name := range names {
@@ -409,7 +444,8 @@ func buildAgentTools(names []string, workspace string, env []string, gitAuth tra
 			})
 		case "text_editor":
 			out = append(out, &TextEditorTool{
-				Workspace: workspace,
+				Workspace:    workspace,
+				AllowedRoots: editorAllowed,
 			})
 		case "git":
 			out = append(out, &GitTool{

--- a/internal/cronicle/tools_test.go
+++ b/internal/cronicle/tools_test.go
@@ -104,15 +104,15 @@ func TestDefaultAgentToolNamesContents(t *testing.T) {
 // buildAgentTools defaults to the native universe when names is empty.
 // Empty list and nil should both expand. Explicit list narrows.
 func TestBuildAgentTools(t *testing.T) {
-	tools := buildAgentTools(nil, t.TempDir(), nil, nil, nil)
+	tools := buildAgentTools(nil, t.TempDir(), nil, nil, "", nil)
 	if len(tools) != len(defaultAgentToolNames()) {
 		t.Fatalf("nil tools: got %d, want %d", len(tools), len(defaultAgentToolNames()))
 	}
-	tools = buildAgentTools([]string{}, t.TempDir(), nil, nil, nil)
+	tools = buildAgentTools([]string{}, t.TempDir(), nil, nil, "", nil)
 	if len(tools) != len(defaultAgentToolNames()) {
 		t.Fatalf("empty slice tools: got %d, want %d", len(tools), len(defaultAgentToolNames()))
 	}
-	tools = buildAgentTools([]string{"bash"}, t.TempDir(), nil, nil, nil)
+	tools = buildAgentTools([]string{"bash"}, t.TempDir(), nil, nil, "", nil)
 	if len(tools) != 1 {
 		t.Fatalf("explicit narrow: got %d tools, want 1", len(tools))
 	}


### PR DESCRIPTION
## Summary

The cronicle-native answer to passing context between agent tasks in a DAG: a schedule-scoped shared dir, exposed as \`\${scratch}\`. An upstream task writes a file, a downstream task reads it. The file system is the channel — no magical post-run substitution, no inherited transcripts; just the same primitives cronicle already has (text_editor, bash, the workspace), composing.

```hcl
task "crawl_slack"   { agent { prompt = "... save to \${scratch}/slack.md" } }
task "crawl_discord" { agent { prompt = "... save to \${scratch}/discord.md" } }
task "compose" {
  depends = ["crawl_slack", "crawl_discord"]
  agent { prompt = "Read \${scratch}/{slack,discord}.md and post the unified summary." }
}
```

\`\${scratch}\` resolves to \`<croniclePath>/.cronicle/scratch/<schedule>/<utc-runid>/\` for the duration of one schedule run. cronicle creates the dir before walking the DAG; tasks running in parallel can write into it without coordination beyond filename. Survives the run for transcript / audit access.

## Implementation notes

- **\`Task.ScratchDir\` is a public field** so it survives the JSON wire format used in distributed mode — workers see the same scratch path the producer set.
- **HCL eval context** gains \`scratch\` as a passthrough StringVal so the literal \`\${scratch}\` token survives HCL parse and exec.go's strings.NewReplacer substitutes the real path at run time. Same trick \`\${date}\` etc. use.
- **\`schedule_start\` slog event** carries the scratch path:
  \`schedule started ... scratch=/.../scratch/daily_report/20260510T160000Z\`
- **TextEditorTool gains \`AllowedRoots\`** populated with \`\${scratch}\` so a task with a \`repo\` block (whose primary workspace is the cloned repo dir) can still read/write scratch. Caught during the demo: the code crawler couldn't reach scratch via text_editor before this fix.
- **\`cronicle exec --task X\`** (single-task mode) also stamps \`ScratchDir\` so partial workflows behave the same as full schedule runs.

## Daily-report demo (\`deploy/daily-report/\`)

The canonical fan-out / fan-in workflow:

```
crawl_slack  ─┐
crawl_discord ─┤
crawl_email  ─┼─▶  compose ─▶ REPORT.md (and optionally → Slack via MCP)
crawl_code   ─┘
```

- 4 crawlers write \`{slack,discord,email,code}.md\` to \`\${scratch}\`
- composer reads them, follows the \`daily-composer\` skill, emits \`REPORT.md\`
- \`crawl_code\` exercises a real \`repo\` block + the built-in git tool
- other crawlers use mock prompts (no real Slack/Discord auth here); README explains the MCP swap-in for production

End-to-end smoke (\`cronicle exec --schedule daily_report\`): completed in ~25s for ~\$0.10 total cost; \`REPORT.md\` contains accurate per-source bullets covering the actual recent commits the code crawler picked up.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 59 specs pass (parse_test fixture updated for new ScratchDir field + new \`scratch\` eval-context var)
- [x] Two-task scratch smoke (produce → consume) verified end-to-end
- [x] Five-task daily-report demo verified end-to-end with cross-workspace text_editor access

🤖 Generated with [Claude Code](https://claude.com/claude-code)