### PR TITLE
Phase 2a: POST /v1/events ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ set `CRONICLE_LISTEN_TOKEN` in the environment.
 | POST   | `/v1/schedules/{name}/tasks/{task}/trigger`            | Fire one task (depends stripped)     |
 | GET    | `/v1/runs`                                             | List recent runs (filterable)        |
 | GET    | `/v1/runs/{run_id}`                                    | Single run + per-task detail         |
+| POST   | `/v1/events`                                           | JSONL ingest (batched events)        |
 
 Auth is bearer-token (`Authorization: Bearer <token>`). Rotate by
 restarting the process.
@@ -528,6 +529,36 @@ Response shape (list):
 `cronicle exec` uses an in-memory projection (the run is foreground, you
 are watching it; nothing later queries the DB). `cronicle run` opens
 `.cronicle/state.db` in WAL mode and persists across restarts.
+
+### Posting events directly (POST /v1/events)
+
+External producers — distributed workers (Phase 2 onwards), debug
+shippers, integration tests — can write events into the projection
+directly. Body is JSONL (one event per line, same shape as
+`cronicle.jsonl` on disk):
+
+```bash
+# Replay the local log file into a remote producer:
+tail -F .cronicle/log/cronicle.jsonl | \
+  curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    --data-binary @- \
+    http://producer.internal:8765/v1/events
+
+# Or post a one-off batch:
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-binary @batch.jsonl \
+  http://localhost:8765/v1/events
+# -> {"accepted":4,"dropped":0}
+```
+
+Lines that don't parse, or that lack `entry_type` / `run_id`, are counted
+as `dropped` but the rest still apply (the projection is happy to ignore
+unknown fields, so the JSONL log format is the only contract). Body
+limit is 16 MiB per request; oversized bodies return 413. The endpoint
+is idempotent at the row level — re-POSTing the same events updates
+the same projection rows monotonically.
 
 ---
 

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -23,6 +23,7 @@
 package cronicle
 
 import (
+	"bufio"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -77,6 +78,7 @@ func startListener(addr, token string, queue chan<- []byte) {
 	mux.HandleFunc("/v1/schedules/", s.handleScheduleRoute)
 	mux.HandleFunc("/v1/runs", s.handleListRuns)
 	mux.HandleFunc("/v1/runs/", s.handleGetRun)
+	mux.HandleFunc("/v1/events", s.handleIngestEvents)
 
 	srv := &http.Server{
 		Addr:              addr,
@@ -426,5 +428,92 @@ func (s *listenServer) currentStore() *state.Store {
 		return s.stateSrc()
 	}
 	return StateStore()
+}
+
+// ---- /v1/events -------------------------------------------------------------
+
+// maxEventBatchBytes caps a single ingest body so a misbehaving worker
+// can't OOM the producer with one giant POST. 16 MiB is generous: a typical
+// event is ~500 bytes, so 16 MiB is ~30k events — far more than any real
+// batch should carry.
+const maxEventBatchBytes = 16 << 20
+
+// ingestResponse is the shape returned by POST /v1/events. Callers can
+// reconcile partial-success cases: a worker that POSTs 100 events and
+// gets accepted=98, dropped=2 has enough info to retry the dropped ones
+// (we don't echo which ones failed; simplest API is "retry the whole
+// batch" since Apply is idempotent at the projection level).
+type ingestResponse struct {
+	Accepted int `json:"accepted"`
+	Dropped  int `json:"dropped"`
+}
+
+// handleIngestEvents receives a JSONL body and folds each event into the
+// projection. One event per line — same shape as cronicle.jsonl on disk,
+// so workers can literally POST tail bytes with no transformation.
+//
+// Auth: bearer token, same as other endpoints. Workers will use the same
+// CRONICLE_LISTEN_TOKEN we already use for triggers; tighter per-worker
+// scoping can land later if it ever matters.
+//
+// Body limit: 16 MiB. Empty body → 200 with accepted=0. Lines that don't
+// parse or that DecodeEvent rejects (no entry_type, no run_id) are
+// counted as dropped — they're benign for the projection but the count
+// surfaces malformed shippers.
+func (s *listenServer) handleIngestEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authed(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	store := s.currentStore()
+	if store == nil {
+		http.Error(w, "state store not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	body := http.MaxBytesReader(w, r.Body, maxEventBatchBytes)
+	defer body.Close()
+
+	var (
+		accepted int
+		dropped  int
+	)
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxEventBatchBytes)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 || line[0] == '\n' {
+			continue
+		}
+		ev, ok := state.DecodeEvent(line)
+		if !ok {
+			dropped++
+			continue
+		}
+		if err := store.Apply(ev); err != nil {
+			slog.Warn("event apply failed", "run_id", ev.RunID, "entry_type", ev.EntryType, "error", err.Error())
+			dropped++
+			continue
+		}
+		accepted++
+	}
+	if err := scanner.Err(); err != nil {
+		// MaxBytesReader returns http.MaxBytesError when over the limit.
+		// bufio.ErrTooLong fires when a single line exceeds our scanner
+		// buffer — same end-user fault (oversized payload), so map both
+		// to 413 rather than spraying internal-error statuses.
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) || errors.Is(err, bufio.ErrTooLong) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		slog.Error("events ingest read failed", "error", err.Error())
+		http.Error(w, "ingest read failed", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, ingestResponse{Accepted: accepted, Dropped: dropped})
 }
 

--- a/internal/cronicle/listen_events_test.go
+++ b/internal/cronicle/listen_events_test.go
@@ -1,0 +1,168 @@
+package cronicle
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// eventsHarness wires a real in-memory state store to a listenServer
+// so ingest tests exercise the full path: HTTP → DecodeEvent → Apply →
+// projection.
+func eventsHarness(t *testing.T) (*listenServer, *state.Store) {
+	t.Helper()
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return &listenServer{
+		token:    "secret",
+		stateSrc: func() *state.Store { return store },
+	}, store
+}
+
+func ingestRequest(body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer secret")
+	return req
+}
+
+// TestIngest_AuthRequired: bearer token check applies.
+func TestIngest_AuthRequired(t *testing.T) {
+	srv, _ := eventsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", strings.NewReader(""))
+	srv.handleIngestEvents(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", rr.Code)
+	}
+}
+
+// TestIngest_MethodNotAllowed: only POST is accepted.
+func TestIngest_MethodNotAllowed(t *testing.T) {
+	srv, _ := eventsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/events", nil)
+	srv.handleIngestEvents(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("got %d, want 405", rr.Code)
+	}
+}
+
+// TestIngest_HappyPath: a JSONL batch lands in the projection. Reuses
+// the same shape that cronicle.jsonl already produces — the wire and
+// the file are identical, by intent.
+func TestIngest_HappyPath(t *testing.T) {
+	srv, store := eventsHarness(t)
+	body := strings.Join([]string{
+		`{"time":"2026-05-10T12:00:00Z","entry_type":"schedule_start","run_id":"R1","schedule":"daily","tasks":["a"]}`,
+		`{"time":"2026-05-10T12:00:01Z","entry_type":"task_start","run_id":"R1","schedule":"daily","task":"a","attempt":1}`,
+		`{"time":"2026-05-10T12:00:02Z","entry_type":"shell_run","run_id":"R1","schedule":"daily","task":"a","exit":0,"duration_ms":50,"success":true}`,
+		`{"time":"2026-05-10T12:00:03Z","entry_type":"schedule_complete","run_id":"R1","schedule":"daily","task_count":1,"duration_ms":80,"success":true}`,
+	}, "\n")
+
+	rr := httptest.NewRecorder()
+	srv.handleIngestEvents(rr, ingestRequest(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp ingestResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Accepted != 4 || resp.Dropped != 0 {
+		t.Fatalf("counts: %+v", resp)
+	}
+	r, err := store.GetRun("R1")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if r.Status != "succeeded" || len(r.Tasks) != 1 || r.Tasks[0].Status != "succeeded" {
+		t.Fatalf("projection state wrong: %+v", r)
+	}
+}
+
+// TestIngest_PartialBadLines: malformed lines are counted dropped, the
+// rest still apply. Empty lines at EOF or between entries are ignored.
+func TestIngest_PartialBadLines(t *testing.T) {
+	srv, store := eventsHarness(t)
+	body := strings.Join([]string{
+		`{"time":"2026-05-10T12:00:00Z","entry_type":"schedule_start","run_id":"R2","schedule":"x","tasks":["only"]}`,
+		``, // empty line — ignored
+		`{not valid json`,                                         // dropped (parse fail)
+		`{"msg":"no entry_type but valid json","level":"INFO"}`,   // dropped (no entry_type)
+		`{"entry_type":"task_start","schedule":"x","task":"only"}`, // dropped (no run_id)
+		`{"time":"2026-05-10T12:00:01Z","entry_type":"task_start","run_id":"R2","schedule":"x","task":"only","attempt":1}`,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	srv.handleIngestEvents(rr, ingestRequest(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d", rr.Code)
+	}
+	var resp ingestResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.Accepted != 2 {
+		t.Fatalf("accepted: got %d, want 2", resp.Accepted)
+	}
+	if resp.Dropped != 3 {
+		t.Fatalf("dropped: got %d, want 3", resp.Dropped)
+	}
+	if n, _ := store.CountRuns(); n != 1 {
+		t.Fatalf("runs created: got %d, want 1", n)
+	}
+}
+
+// TestIngest_EmptyBody: zero events is a 200 with accepted=0; no error.
+func TestIngest_EmptyBody(t *testing.T) {
+	srv, _ := eventsHarness(t)
+	rr := httptest.NewRecorder()
+	srv.handleIngestEvents(rr, ingestRequest(""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rr.Code)
+	}
+	var resp ingestResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.Accepted != 0 || resp.Dropped != 0 {
+		t.Fatalf("expected zeros, got %+v", resp)
+	}
+}
+
+// TestIngest_BodyTooLarge: a body over 16 MiB should be rejected with
+// 413 — protects the producer from a misbehaving worker. We don't ship
+// a 16 MiB payload here; instead we exercise the limit by faking the
+// request body size with a wrapped reader.
+func TestIngest_BodyTooLarge(t *testing.T) {
+	srv, _ := eventsHarness(t)
+	// One line, but we crank up MaxBytesReader's bound by sending a body
+	// that's too big to fit. Simpler approach: synthesize 17 MiB of 'a's
+	// — they all parse-fail individually but the scanner trips the limit
+	// first because each line is 17 MiB long and exceeds the buffer.
+	huge := bytes.Repeat([]byte("a"), 17<<20)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewReader(huge))
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleIngestEvents(rr, req)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want 413; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestIngest_ServiceUnavailable: when the projection isn't available,
+// surface 503 honestly rather than silently dropping events.
+func TestIngest_ServiceUnavailable(t *testing.T) {
+	srv := &listenServer{
+		token:    "secret",
+		stateSrc: func() *state.Store { return nil },
+	}
+	rr := httptest.NewRecorder()
+	srv.handleIngestEvents(rr, ingestRequest(`{"entry_type":"schedule_start","run_id":"R","schedule":"x"}`))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503", rr.Code)
+	}
+}


### PR DESCRIPTION
First slice of Phase 2 from #84. Adds an HTTP ingest endpoint so external producers can fold events into the projection — the worker-to-producer transport plumbing for the rest of Phase 2.

## What's in
- **POST /v1/events**: JSONL body, same shape as cronicle.jsonl on disk. Decodes each line, calls `state.Store.Apply()`. Returns `{"accepted":N,"dropped":M}`.
- **Body limit 16 MiB** (`http.MaxBytesReader` + `bufio.ErrTooLong` both → 413). Empty body is a valid 200 with accepted=0.
- **Forward-compat**: lines failing `DecodeEvent` (no entry_type, no run_id, malformed) count as `dropped` but the rest still apply. Apply errors `slog.Warn` but don't fail the batch.
- **Same auth model** as triggers / runs API.

## Why this enables the rest of Phase 2
Workers in Phase 2b will execute jobs and POST their event stream back here. The shape is intentionally the JSONL log — there is no separate "worker protocol", just the event format the producer's own slog handler chain already emits to disk. Single source of truth for "what an event looks like."

## End-to-end smoke
```bash
cronicle run --listen :8790 --listen-token tok
cat batch.jsonl | curl -s -X POST -H "Authorization: Bearer tok" \
    --data-binary @- http://localhost:8790/v1/events
# -> {"accepted":4,"dropped":0}
curl -s -H "Authorization: Bearer tok" http://localhost:8790/v1/runs
# -> shows the injected run with full task detail
```

## Tests
7 new handler tests: auth, method, happy path (4-event batch), partial bad lines (2 accepted, 3 dropped), empty body, oversize body (413), service-unavailable. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)