### PR TITLE
Phase 2b: producer-served queue + HTTP worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ set `CRONICLE_LISTEN_TOKEN` in the environment.
 | GET    | `/v1/runs`                                             | List recent runs (filterable)        |
 | GET    | `/v1/runs/{run_id}`                                    | Single run + per-task detail         |
 | POST   | `/v1/events`                                           | JSONL ingest (batched events)        |
+| GET    | `/v1/jobs?worker=&block=`                              | Long-poll job claim                  |
+| POST   | `/v1/jobs/{run_id}/ack`                                | Worker reports completion            |
+| POST   | `/v1/jobs/{run_id}/heartbeat`                          | Visibility-timeout renewal           |
 
 Auth is bearer-token (`Authorization: Bearer <token>`). Rotate by
 restarting the process.
@@ -559,6 +562,41 @@ unknown fields, so the JSONL log format is the only contract). Body
 limit is 16 MiB per request; oversized bodies return 413. The endpoint
 is idempotent at the row level — re-POSTing the same events updates
 the same projection rows monotonically.
+
+---
+
+## Distributed mode without a broker (`--queue self`)
+
+Run `cronicle run --queue self` and the producer becomes its own queue.
+Cron-tick fires + HTTP triggers enqueue into the SQLite jobs table at
+`<cronicle-path>/.cronicle/state.db`. Workers — local goroutines or
+remote `cronicle worker` processes — claim jobs over HTTP long-poll,
+execute, ship events back, and ack. No Redis, no NSQ, no Sentinel.
+
+```bash
+# Producer: state plane + queue + listener, in-process worker disabled
+cronicle run \
+  --path cronicle.hcl \
+  --listen :8765 --listen-token "$TOKEN" \
+  --queue self \
+  --worker=false
+
+# Remote worker: long-polls /v1/jobs, executes, posts events back
+cronicle worker \
+  --path /local/repo \
+  --producer http://producer:8765 \
+  --producer-token "$TOKEN" \
+  --worker-id node-1
+```
+
+How it works:
+
+- **Atomic claim**: `BEGIN IMMEDIATE; UPDATE jobs SET status='claimed', claimed_by=? WHERE id=? AND status='pending'`. SQLite WAL serializes writers, so two concurrent workers cannot both acquire the same row. The losing worker's long-poll sees no row and reconnects.
+- **Visibility timeout**: claimed jobs expire after 5 minutes. A janitor goroutine sweeps every 10 seconds, moving expired claims back to `pending`. A worker dies → its job is re-dispatched. Long agent runs `POST /v1/jobs/{id}/heartbeat` to extend the deadline.
+- **Event shipping**: workers tee their slog event stream to the producer via `POST /v1/events` (JSONL, batched every 500ms or 64 events). Producer's projection reflects what the worker actually did. Events also write to the worker's local `cronicle.jsonl` for on-host audit.
+- **Two persistent connections per worker**: the rolling `GET /v1/jobs` long-poll and the slog→events shipper. Plus short-lived `POST /v1/jobs/{id}/ack` and `/heartbeat`. No SSE control channel yet (that's Phase 3, for cancel signals).
+
+For comparison: legacy `--queue redis` and `--queue nsq` still work but are scheduled for removal.
 
 ---
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -81,11 +81,13 @@ func init() {
 	runCmd.Flags().String("path", "./cronicle.hcl", "Path to a cronicle.hcl file")
 	runCmd.Flags().Bool("worker", true, "start a worker thread to consume tasks in distributed mode")
 	queueDesc := `
-	message broker technology for distributed schedule execution, 
-	Options: 
+	message broker technology for distributed schedule execution,
+	Options:
+		self  [producer-served queue; workers long-poll /v1/jobs over HTTP]
 		redis [distributed on localhost:6379]
 		nsq [run on cluster with nsqd:4150]
-	Configurable via the queue.type field in cronicle.hcl
+	Configurable via the queue.type field in cronicle.hcl.
+	"self" is the recommended path going forward — Redis/NSQ will be removed in a future release.
 	`
 	runCmd.Flags().String("queue", "", queueDesc)
 	runCmd.Flags().String("queue-name", "cronicle", "Name of the queue to message schedules over.")

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -16,7 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/jshiv/cronicle/internal/cronicle"
 	"github.com/spf13/cobra"
@@ -53,6 +57,33 @@ Multipule workers can be started, they will take turns consuming from the queue.
 		queueName, _ := cmd.Flags().GetString("queue-name")
 		addr, _ := cmd.Flags().GetString("addr")
 		logToFile, _ := cmd.Flags().GetBool("log-to-file")
+		producerURL, _ := cmd.Flags().GetString("producer")
+		producerToken, _ := cmd.Flags().GetString("producer-token")
+		workerID, _ := cmd.Flags().GetString("worker-id")
+
+		// HTTP-mode worker: long-polls a cronicle run --queue self
+		// process. Replaces vice transport entirely once Phase 2c
+		// removes Redis/NSQ.
+		if producerURL != "" {
+			if producerToken == "" {
+				producerToken = os.Getenv("CRONICLE_LISTEN_TOKEN")
+			}
+			ctx, cancel := signal.NotifyContext(context.Background(),
+				syscall.SIGINT, syscall.SIGTERM)
+			defer cancel()
+			err := cronicle.StartHTTPWorker(ctx, cronicle.HTTPWorkerOptions{
+				ProducerURL: producerURL,
+				Token:       producerToken,
+				WorkerID:    workerID,
+				Path:        path,
+				LogToFile:   logToFile,
+			})
+			if err != nil && err != context.Canceled {
+				slog.Error("worker exited", "error", err.Error())
+				os.Exit(1)
+			}
+			return
+		}
 
 		slog.Info("Starting Worker from: " + path)
 		runOptions := cronicle.RunOptions{
@@ -77,7 +108,10 @@ func init() {
 	Configurable via the queue.type field in cronicle.hcl
 	`
 	workerCmd.Flags().String("queue", "", queueDesc)
-	cobra.MarkFlagRequired(workerCmd.Flags(), "queue")
+	// Note: --queue is required for vice modes (redis|nsq) but not when
+	// --producer is set (HTTP long-poll path). We validate at runtime
+	// rather than via MarkFlagRequired so both modes coexist on the
+	// same command.
 	workerCmd.Flags().String("queue-name", "cronicle", "Name of the queue to message schedules over.")
 
 	addrDesc := `
@@ -89,6 +123,9 @@ func init() {
 	`
 	workerCmd.Flags().String("addr", "", addrDesc)
 	workerCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); per-run agent transcripts go to path/.cronicle/runs/")
+	workerCmd.Flags().String("producer", "", "URL of a cronicle run --queue self producer (e.g. http://producer:8765). When set, the worker long-polls /v1/jobs over HTTP instead of using a vice broker.")
+	workerCmd.Flags().String("producer-token", "", "bearer token for the producer's HTTP API. Falls back to $CRONICLE_LISTEN_TOKEN.")
+	workerCmd.Flags().String("worker-id", "", "stable identifier for this worker in the producer's claim/ack records. Default: <hostname>-<pid>.")
 
 	// Here you will define your flags and configuration settings.
 

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -77,12 +77,29 @@ func Run(cronicleFile string, runOptions RunOptions) {
 	// fires, so triggered and cron-fired runs are identical from the
 	// consumer's perspective — same JSON, same DAG walk, same logs.
 	var triggerQueue chan<- []byte
-	if runOptions.QueueType == "" {
+	switch runOptions.QueueType {
+	case "":
 		queue := make(chan []byte)
 		triggerQueue = queue
 		go StartCron(cronicleFileAbs, queue)
 		go ConsumeSchedule(queue, croniclePath, &wg)
-	} else {
+	case "self":
+		// Producer-served queue. cron tick + listener trigger write
+		// through to the SQLite jobs table; the in-process self-worker
+		// claims them. External workers (cronicle worker --producer URL)
+		// can claim from the same store via long-poll over HTTP.
+		if stateStore == nil {
+			Fatal("--queue self requires the state store; check that .cronicle/ is writable")
+		}
+		enqueueChan := make(chan []byte, 64)
+		triggerQueue = enqueueChan
+		go enqueueAdapter(enqueueChan, stateStore)
+		go StartCron(cronicleFileAbs, enqueueChan)
+		if runOptions.RunWorker {
+			go selfWorker(stateStore, croniclePath, &wg)
+		}
+		go reaperLoop(stateStore)
+	default:
 		transport := MakeViceTransport(runOptions.QueueType, runOptions.Addr)
 		triggerQueue = transport.Send(runOptions.QueueName)
 		go StartCron(cronicleFileAbs, triggerQueue)

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -79,12 +79,21 @@ func startListener(addr, token string, queue chan<- []byte) {
 	mux.HandleFunc("/v1/runs", s.handleListRuns)
 	mux.HandleFunc("/v1/runs/", s.handleGetRun)
 	mux.HandleFunc("/v1/events", s.handleIngestEvents)
+	mux.HandleFunc("/v1/jobs", s.handleClaimJob)
+	mux.HandleFunc("/v1/jobs/", s.handleJobControl)
 
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      10 * time.Second,
+		// WriteTimeout has to outlast the longest long-poll block. We
+		// cap GET /v1/jobs at 60s, so 90s here gives the handler room
+		// to finish writing the response after the wait returns.
+		WriteTimeout: 90 * time.Second,
+		// IdleTimeout closes connections that have been idle in the
+		// keep-alive pool — independent of WriteTimeout, but a sensible
+		// match for the long-poll cadence.
+		IdleTimeout: 120 * time.Second,
 	}
 	go func() {
 		slog.Info("Trigger listener up", "addr", addr)
@@ -515,5 +524,170 @@ func (s *listenServer) handleIngestEvents(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, ingestResponse{Accepted: accepted, Dropped: dropped})
+}
+
+// ---- /v1/jobs (queue dispatch) ---------------------------------------------
+
+// maxLongPollBlock caps the duration we hold a /v1/jobs request open
+// waiting for a job. Has to be < the http.Server WriteTimeout (90s) by
+// a safety margin. Also: keeping it short bounds the worst-case latency
+// for graceful shutdown.
+const maxLongPollBlock = 60 * time.Second
+
+// defaultClaimVisibility is how long a worker has to ack a claimed job
+// before the reaper takes it back. 5 minutes covers slow agent runs;
+// long-running tasks must heartbeat.
+const defaultClaimVisibility = 5 * time.Minute
+
+// handleClaimJob is GET /v1/jobs?worker=W1&block=30s
+//
+// Atomically claims one pending job and returns it. If none are
+// available, blocks up to `block` seconds (default 30s, max 60s) and
+// retries; returns 204 No Content if still empty after the wait.
+//
+// Query params:
+//
+//	worker=<id>      required, identifies the claimant for ack/heartbeat
+//	block=<duration> Go duration syntax: "30s", "1m". Default 30s, max 60s.
+func (s *listenServer) handleClaimJob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authed(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	store := s.currentStore()
+	if store == nil {
+		http.Error(w, "state store not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	q := r.URL.Query()
+	workerID := q.Get("worker")
+	if workerID == "" {
+		http.Error(w, "worker query param required", http.StatusBadRequest)
+		return
+	}
+	block := 30 * time.Second
+	if v := q.Get("block"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil || d < 0 {
+			http.Error(w, "invalid block duration", http.StatusBadRequest)
+			return
+		}
+		if d > maxLongPollBlock {
+			d = maxLongPollBlock
+		}
+		block = d
+	}
+
+	deadline := time.Now().Add(block)
+	for {
+		job, err := store.Claim(workerID, defaultClaimVisibility)
+		if err == nil {
+			writeJSON(w, http.StatusOK, job)
+			return
+		}
+		if !errors.Is(err, state.ErrNoJobs) {
+			slog.Error("claim failed", "worker", workerID, "error", err.Error())
+			http.Error(w, "claim failed", http.StatusInternalServerError)
+			return
+		}
+		// No jobs right now. Wait for a wakeup or until the deadline.
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		store.WaitForJob(r.Context(), remaining)
+		// Loop and try Claim again. If the wait was a spurious wakeup
+		// or the request context died, the next Claim returns ErrNoJobs
+		// and the deadline-elapsed branch above closes the response.
+		select {
+		case <-r.Context().Done():
+			// Client disconnected — don't try to write to a dead conn.
+			return
+		default:
+		}
+	}
+}
+
+// handleJobControl dispatches POSTs under /v1/jobs/. Two shapes:
+//
+//	POST /v1/jobs/{run_id}/ack
+//	POST /v1/jobs/{run_id}/heartbeat
+//
+// JSON body for ack: {"worker": "W1", "success": true|false, "error": "..."}.
+// JSON body for heartbeat: {"worker": "W1"}.
+func (s *listenServer) handleJobControl(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authed(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	store := s.currentStore()
+	if store == nil {
+		http.Error(w, "state store not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/jobs/")
+	parts := strings.Split(rest, "/")
+	if len(parts) != 2 {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	runID := parts[0]
+	verb := parts[1]
+	if runID == "" {
+		http.Error(w, "missing run_id", http.StatusBadRequest)
+		return
+	}
+	switch verb {
+	case "ack":
+		var body struct {
+			Worker  string `json:"worker"`
+			Success bool   `json:"success"`
+			Error   string `json:"error,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body); err != nil {
+			http.Error(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		if body.Worker == "" {
+			http.Error(w, "worker required in body", http.StatusBadRequest)
+			return
+		}
+		if err := store.Ack(runID, body.Worker, body.Success, body.Error); err != nil {
+			slog.Error("ack failed", "run_id", runID, "error", err.Error())
+			http.Error(w, "ack failed", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"acked": runID})
+	case "heartbeat":
+		var body struct {
+			Worker string `json:"worker"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body); err != nil {
+			http.Error(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		if body.Worker == "" {
+			http.Error(w, "worker required in body", http.StatusBadRequest)
+			return
+		}
+		if err := store.Heartbeat(runID, body.Worker, defaultClaimVisibility); err != nil {
+			// Lost-ownership is a 409, not 500 — the worker can stop
+			// heartbeating and exit cleanly without escalating to oncall.
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"heartbeat": runID})
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
 }
 

--- a/internal/cronicle/listen_jobs_test.go
+++ b/internal/cronicle/listen_jobs_test.go
@@ -1,0 +1,225 @@
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+func jobsHarness(t *testing.T) (*listenServer, *state.Store) {
+	t.Helper()
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return &listenServer{
+		token:    "secret",
+		stateSrc: func() *state.Store { return store },
+	}, store
+}
+
+// TestJobs_ClaimAuthRequired: bearer auth gates the queue.
+func TestJobs_ClaimAuthRequired(t *testing.T) {
+	srv, _ := jobsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs?worker=W1", nil)
+	srv.handleClaimJob(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", rr.Code)
+	}
+}
+
+// TestJobs_MissingWorker: worker query param is required.
+func TestJobs_MissingWorker(t *testing.T) {
+	srv, _ := jobsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleClaimJob(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing worker: got %d, want 400", rr.Code)
+	}
+}
+
+// TestJobs_ClaimReturnsJob: enqueue → claim returns 200 with the
+// payload bytes, claim metadata, attempt count.
+func TestJobs_ClaimReturnsJob(t *testing.T) {
+	srv, store := jobsHarness(t)
+	if err := store.Enqueue("R1", "daily", []byte(`{"name":"daily"}`)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs?worker=W1&block=100ms", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleClaimJob(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var j state.Job
+	if err := json.Unmarshal(rr.Body.Bytes(), &j); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if j.RunID != "R1" || j.Schedule != "daily" || j.ClaimedBy != "W1" || j.Attempt != 1 {
+		t.Fatalf("claim wrong: %+v", j)
+	}
+}
+
+// TestJobs_LongPollWaitTimeout: with no enqueued jobs, the long-poll
+// returns 204 after the block elapses.
+func TestJobs_LongPollWaitTimeout(t *testing.T) {
+	srv, _ := jobsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs?worker=W1&block=50ms", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	t0 := time.Now()
+	srv.handleClaimJob(rr, req)
+	dur := time.Since(t0)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("got %d, want 204", rr.Code)
+	}
+	if dur < 40*time.Millisecond {
+		t.Fatalf("returned too fast (%s) — long-poll didn't wait", dur)
+	}
+}
+
+// TestJobs_LongPollWakesOnEnqueue: a long-poll in flight wakes when
+// a job is enqueued during the wait.
+func TestJobs_LongPollWakesOnEnqueue(t *testing.T) {
+	srv, store := jobsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs?worker=W1&block=2s", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+
+	done := make(chan int, 1)
+	go func() {
+		srv.handleClaimJob(rr, req)
+		done <- rr.Code
+	}()
+	time.Sleep(30 * time.Millisecond) // let the handler park
+	_ = store.Enqueue("R1", "x", []byte(`{}`))
+
+	select {
+	case code := <-done:
+		if code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body=%s", code, rr.Body.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("long-poll did not wake on enqueue")
+	}
+}
+
+// TestJobs_AckSuccess: POST /v1/jobs/{id}/ack with success=true marks
+// the job done.
+func TestJobs_AckSuccess(t *testing.T) {
+	srv, store := jobsHarness(t)
+	_ = store.Enqueue("R1", "x", []byte(`{}`))
+	_, _ = store.Claim("W1", time.Minute)
+
+	body := `{"worker":"W1","success":true}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/R1/ack", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleJobControl(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if n, _ := store.CountJobsByStatus(state.JobDone); n != 1 {
+		t.Fatalf("expected 1 done, got %d", n)
+	}
+}
+
+// TestJobs_AckFailure: ack with success=false marks the job failed +
+// records the error.
+func TestJobs_AckFailure(t *testing.T) {
+	srv, store := jobsHarness(t)
+	_ = store.Enqueue("R1", "x", []byte(`{}`))
+	_, _ = store.Claim("W1", time.Minute)
+
+	body := `{"worker":"W1","success":false,"error":"boom"}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/R1/ack", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleJobControl(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d", rr.Code)
+	}
+	if n, _ := store.CountJobsByStatus(state.JobFailedQ); n != 1 {
+		t.Fatalf("expected 1 failed, got %d", n)
+	}
+}
+
+// TestJobs_HeartbeatExtends: heartbeat keeps the claim alive and returns 200.
+func TestJobs_HeartbeatExtends(t *testing.T) {
+	srv, store := jobsHarness(t)
+	_ = store.Enqueue("R1", "x", []byte(`{}`))
+	_, _ = store.Claim("W1", time.Hour)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/R1/heartbeat",
+		strings.NewReader(`{"worker":"W1"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleJobControl(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestJobs_HeartbeatLost: a heartbeat against an expired claim returns 409.
+func TestJobs_HeartbeatLost(t *testing.T) {
+	srv, store := jobsHarness(t)
+	_ = store.Enqueue("R1", "x", []byte(`{}`))
+	_, _ = store.Claim("W1", 5*time.Millisecond)
+	time.Sleep(15 * time.Millisecond)
+	_, _ = store.ReapExpired()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/R1/heartbeat",
+		strings.NewReader(`{"worker":"W1"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleJobControl(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 lost-claim, got %d", rr.Code)
+	}
+}
+
+// TestJobs_AckBadJSON: malformed body is 400, not 500.
+func TestJobs_AckBadJSON(t *testing.T) {
+	srv, _ := jobsHarness(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/R1/ack",
+		strings.NewReader(`not json`))
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.handleJobControl(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", rr.Code)
+	}
+}
+
+// TestJobs_LongPollClientDisconnect: client closes the connection mid-wait.
+// The handler should return without panic and without deadlock.
+func TestJobs_LongPollClientDisconnect(t *testing.T) {
+	srv, _ := jobsHarness(t)
+	rr := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/jobs?worker=W1&block=1s", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	done := make(chan struct{})
+	go func() {
+		srv.handleClaimJob(rr, req)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after client disconnect")
+	}
+}

--- a/internal/cronicle/queue_self.go
+++ b/internal/cronicle/queue_self.go
@@ -1,0 +1,135 @@
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// enqueueAdapter drains the cron-tick / listener-trigger channel and
+// pushes each Schedule JSON into the SQLite jobs table for durable,
+// claim-based dispatch. Decode errors are logged-and-dropped — the
+// schedule never executes if it can't be parsed for queueing, which
+// is the same outcome as today (json.Unmarshal failure inside
+// ConsumeSchedule swallows the schedule).
+//
+// The channel buffer (caller-sized) lets the cron tick return quickly
+// even if SQLite is briefly busy. At our load (sub-100 events/min)
+// the buffer is essentially never used, but it bounds the worst-case
+// blocking on the cron goroutine.
+func enqueueAdapter(in <-chan []byte, store *state.Store) {
+	for payload := range in {
+		var sch Schedule
+		if err := json.Unmarshal(payload, &sch); err != nil {
+			slog.Error("self-queue: bad payload, dropping", "error", err.Error())
+			continue
+		}
+		if sch.RunID == "" {
+			// Should never happen: ProduceSchedule and the listener both
+			// stamp RunID before queueing. Defensive: synthesize one
+			// rather than dropping the run.
+			sch.RunID = newRunID()
+			payload, _ = json.Marshal(sch)
+		}
+		if err := store.Enqueue(sch.RunID, sch.Name, payload); err != nil {
+			slog.Error("self-queue: enqueue failed", "run_id", sch.RunID, "error", err.Error())
+		}
+	}
+}
+
+// selfWorker is the in-process consumer for --queue self mode. Claims
+// jobs from the SQLite store, hands the payload to the same DAG walker
+// the existing ConsumeSchedule path uses, then acks. Treats Apply
+// failures as "the run executed but recorded a schedule_complete with
+// success=false" — the job is acked DONE either way; the projection
+// has the failure detail.
+//
+// Visibility timeout is 5 minutes. Long-running agent runs aren't
+// covered by that without explicit Heartbeat — single-node mode
+// rarely needs it because the worker IS the producer (no network
+// partition can preempt), but if a panic kills the goroutine the
+// reaper will recover the job.
+func selfWorker(store *state.Store, croniclePath string, wg *sync.WaitGroup) {
+	workerID := SelfWorkerID()
+	slog.Info("self-worker started", "worker_id", workerID)
+
+	for {
+		job, err := store.Claim(workerID, 5*time.Minute)
+		if errors.Is(err, state.ErrNoJobs) {
+			// Park until a wakeup or 30s elapses, then re-Claim.
+			store.WaitForJob(context.Background(), 30*time.Second)
+			continue
+		}
+		if err != nil {
+			slog.Error("self-worker: claim failed", "error", err.Error())
+			time.Sleep(time.Second)
+			continue
+		}
+		wg.Add(1)
+		go func(j state.Job) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("self-worker: panic during execute",
+						"run_id", j.RunID, "panic", r)
+					_ = store.Ack(j.RunID, workerID, false, "panic during execute")
+				}
+			}()
+
+			var sch Schedule
+			if err := json.Unmarshal(j.Payload, &sch); err != nil {
+				slog.Error("self-worker: payload decode failed",
+					"run_id", j.RunID, "error", err.Error())
+				_ = store.Ack(j.RunID, workerID, false, err.Error())
+				return
+			}
+			sch.PropigateTaskProperties(croniclePath)
+			sch.ExecuteTasks()
+			// Per-task success rolls into the projection via the slog
+			// Sink; the queue Ack just records "this worker handled
+			// this job to completion." Run-level success is recorded
+			// separately on the projection's runs row.
+			_ = store.Ack(j.RunID, workerID, true, "")
+		}(job)
+	}
+}
+
+// reaperLoop periodically walks the jobs table for claims past their
+// visibility deadline and moves them back to pending. Cadence is 10s —
+// shorter than the smallest reasonable visibility (we use 5 minutes)
+// by 30×, so a worker death is recovered within 5m+10s at worst.
+//
+// Logs only when something is actually reaped — quiet when the queue
+// is healthy.
+func reaperLoop(store *state.Store) {
+	t := time.NewTicker(10 * time.Second)
+	defer t.Stop()
+	for range t.C {
+		moved, err := store.ReapExpired()
+		if err != nil {
+			slog.Error("reaper: ReapExpired failed", "error", err.Error())
+			continue
+		}
+		if moved > 0 {
+			slog.Warn("reaper: moved expired claims back to pending", "count", moved)
+		}
+	}
+}
+
+// SelfWorkerID generates a stable id for the in-process consumer:
+// "self-<hostname>-<pid>". External workers use a separate id derived
+// from --worker-id (or the same hostname-pid fallback).
+func SelfWorkerID() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return "self-" + host + "-" + strconv.Itoa(os.Getpid())
+}

--- a/internal/cronicle/state/queue.go
+++ b/internal/cronicle/state/queue.go
@@ -1,0 +1,317 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// JobStatus values mirror the jobs.status column.
+const (
+	JobPending  = "pending"
+	JobClaimed  = "claimed"
+	JobDone     = "done"
+	JobFailedQ  = "failed" // suffixed to avoid collision with task StatusFailed
+	JobCanceled = "canceled"
+)
+
+// Job is the wire shape returned to a worker on long-poll. The Payload
+// is the serialized Schedule JSON the producer pushed; the worker
+// json.Unmarshals it into a Schedule and runs ExecuteTasks identically
+// to how the in-process ConsumeSchedule path always has.
+type Job struct {
+	RunID         string    `json:"run_id"`
+	Schedule      string    `json:"schedule"`
+	Payload       []byte    `json:"payload"` // base64-encoded JSON
+	EnqueuedAt    time.Time `json:"enqueued_at"`
+	Attempt       int       `json:"attempt"`
+	ClaimedBy     string    `json:"claimed_by,omitempty"`
+	ClaimExpires  time.Time `json:"claim_expires_at,omitzero"`
+}
+
+// ErrNoJobs is returned by Claim when no job is available to claim.
+// Callers (long-poll handler) should sleep on the wakeup chan and try
+// again rather than treating it as an error condition.
+var ErrNoJobs = errors.New("state: no jobs available")
+
+// jobWaiters synchronizes long-poll waiters with enqueue/visibility
+// reapers. Producers Broadcast on enqueue; reapers Broadcast when they
+// move expired claims back to pending. Cheaper than a per-worker
+// wakeup channel and correct at our scale (≤100 workers).
+type jobWaiters struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+}
+
+func (s *Store) waiters() *jobWaiters {
+	s.waitOnce.Do(func() {
+		s.wait = &jobWaiters{}
+		s.wait.cond = sync.NewCond(&s.wait.mu)
+	})
+	return s.wait
+}
+
+// Enqueue persists a job for a future Claim. Idempotent on duplicate
+// run_id — a re-enqueue with the same id is a no-op (workers are the
+// authoritative source on whether a job needs to run again).
+//
+// schedule is duplicated outside the payload so the index can answer
+// "any pending jobs?" without parsing JSON. It's also useful for
+// future per-schedule queue stats.
+func (s *Store) Enqueue(runID, schedule string, payload []byte) error {
+	if runID == "" {
+		return errors.New("Enqueue: empty run_id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.Exec(`
+		INSERT OR IGNORE INTO jobs(run_id, schedule, payload, status, enqueued_at)
+		VALUES (?, ?, ?, ?, ?)`,
+		runID, schedule, string(payload), JobPending, now,
+	)
+	if err != nil {
+		return fmt.Errorf("Enqueue: %w", err)
+	}
+	// Wake one waiter; if multiple long-polls are blocked, they'll race
+	// for the SQL claim and at most one wins.
+	w := s.waiters()
+	w.mu.Lock()
+	w.cond.Broadcast()
+	w.mu.Unlock()
+	return nil
+}
+
+// Claim attempts to atomically move one pending row to claimed=workerID
+// and return it. Returns ErrNoJobs if none are pending. The transaction
+// uses BEGIN IMMEDIATE so the write lock is acquired up front, avoiding
+// SQLITE_BUSY upgrades mid-statement.
+//
+// visibility is the duration after which the claim expires if the worker
+// neither acks nor heartbeats. The reaper periodically moves expired
+// claims back to pending.
+func (s *Store) Claim(workerID string, visibility time.Duration) (Job, error) {
+	if workerID == "" {
+		return Job{}, errors.New("Claim: empty worker_id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	expires := now.Add(visibility)
+
+	tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return Job{}, fmt.Errorf("Claim: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Pick the oldest pending row. If two workers race here, BEGIN
+	// IMMEDIATE has already serialized them — only one is in this txn
+	// at a time. The UPDATE below is conditional on status='pending'
+	// so even if the schema-level lock failed (it doesn't, but),
+	// double-claim is impossible.
+	row := tx.QueryRow(`
+		SELECT run_id, schedule, payload, enqueued_at, attempt
+		FROM jobs
+		WHERE status = ?
+		ORDER BY enqueued_at ASC
+		LIMIT 1`, JobPending)
+	var (
+		j          Job
+		enqueuedAt string
+	)
+	if err := row.Scan(&j.RunID, &j.Schedule, &j.Payload, &enqueuedAt, &j.Attempt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Job{}, ErrNoJobs
+		}
+		return Job{}, fmt.Errorf("Claim: select: %w", err)
+	}
+	j.EnqueuedAt, _ = time.Parse(time.RFC3339Nano, enqueuedAt)
+
+	res, err := tx.Exec(`
+		UPDATE jobs SET
+		    status = ?,
+		    claimed_by = ?,
+		    claimed_at = ?,
+		    claim_expires_at = ?,
+		    attempt = attempt + 1
+		WHERE run_id = ? AND status = ?`,
+		JobClaimed, workerID, now.Format(time.RFC3339Nano), expires.Format(time.RFC3339Nano),
+		j.RunID, JobPending,
+	)
+	if err != nil {
+		return Job{}, fmt.Errorf("Claim: update: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n != 1 {
+		// Someone else claimed it between our SELECT and UPDATE — extremely
+		// rare with BEGIN IMMEDIATE but theoretically possible. Treat as
+		// "no job for us" and let the caller retry.
+		return Job{}, ErrNoJobs
+	}
+	if err := tx.Commit(); err != nil {
+		return Job{}, fmt.Errorf("Claim: commit: %w", err)
+	}
+	j.ClaimedBy = workerID
+	j.ClaimExpires = expires
+	j.Attempt++ // reflect the post-UPDATE value to the caller
+	return j, nil
+}
+
+// Ack marks a job done (success=true) or failed (success=false, errMsg
+// recorded). Called by workers after the run completes (or by the
+// in-process consumer in --queue self mode). Idempotent.
+func (s *Store) Ack(runID, workerID string, success bool, errMsg string) error {
+	if runID == "" {
+		return errors.New("Ack: empty run_id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	status := JobDone
+	if !success {
+		status = JobFailedQ
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	// Only ack rows we own. If claim expired and was reassigned, the
+	// reaper has already cleared claimed_by; this UPDATE then matches
+	// nothing and we return without error — the new owner's ack will
+	// land instead.
+	_, err := s.db.Exec(`
+		UPDATE jobs SET
+		    status = ?,
+		    completed_at = ?,
+		    last_error = ?,
+		    claim_expires_at = NULL
+		WHERE run_id = ? AND claimed_by = ? AND status = ?`,
+		status, now, errMsg, runID, workerID, JobClaimed,
+	)
+	if err != nil {
+		return fmt.Errorf("Ack: %w", err)
+	}
+	return nil
+}
+
+// Heartbeat extends the visibility timeout on a claimed job. Workers
+// running long agent tasks should call this periodically (every
+// visibility/3 is a safe cadence) so the reaper doesn't preempt them.
+func (s *Store) Heartbeat(runID, workerID string, visibility time.Duration) error {
+	if runID == "" || workerID == "" {
+		return errors.New("Heartbeat: empty run_id or worker_id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	expires := time.Now().UTC().Add(visibility).Format(time.RFC3339Nano)
+	res, err := s.db.Exec(`
+		UPDATE jobs SET claim_expires_at = ?
+		WHERE run_id = ? AND claimed_by = ? AND status = ?`,
+		expires, runID, workerID, JobClaimed,
+	)
+	if err != nil {
+		return fmt.Errorf("Heartbeat: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Either the job already completed, or the claim expired and
+		// was reaped. Caller should stop heartbeating and check the
+		// run's status via /v1/runs/{id} if it still cares.
+		return errors.New("Heartbeat: no matching claimed job (lost ownership?)")
+	}
+	return nil
+}
+
+// ReapExpired moves rows whose claims have lapsed back to pending so
+// another worker can claim them. Called by a janitor goroutine on a
+// fixed cadence (every 10s is plenty given typical job durations).
+//
+// Returns the number of rows moved, useful for /healthz to surface
+// "workers are dying mid-job" via slow-burning-fire metrics.
+func (s *Store) ReapExpired() (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	res, err := s.db.Exec(`
+		UPDATE jobs SET
+		    status = ?,
+		    claimed_by = '',
+		    claimed_at = NULL,
+		    claim_expires_at = NULL
+		WHERE status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?`,
+		JobPending, JobClaimed, now,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("ReapExpired: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		// Wake any blocked long-polls so the freed jobs get claimed
+		// promptly rather than waiting for the next worker reconnect.
+		w := s.waiters()
+		w.mu.Lock()
+		w.cond.Broadcast()
+		w.mu.Unlock()
+	}
+	return int(n), nil
+}
+
+// WaitForJob blocks until either a job is available (signaled by
+// Enqueue or ReapExpired), the deadline elapses, or ctx is canceled.
+// Returns true if a job is plausibly available (caller should retry
+// Claim), false if the wait timed out. False positives are fine — the
+// caller's next Claim will return ErrNoJobs and the long-poll will
+// return 204.
+//
+// We use sync.Cond rather than a per-waiter chan because the broadcast
+// pattern (any pending → all waiters race for the SQL lock, only one
+// wins) maps cleanly to Cond. With ≤100 workers the wasted wakeups are
+// negligible; if we ever scale past, switch to a FIFO of waiter IDs.
+func (s *Store) WaitForJob(ctx context.Context, timeout time.Duration) bool {
+	w := s.waiters()
+	done := make(chan struct{})
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	go func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.cond.Wait()
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		// Wake the goroutine so Wait() returns and we don't leak it.
+		// A spurious broadcast is cheaper than tracking per-waiter state.
+		w.mu.Lock()
+		w.cond.Broadcast()
+		w.mu.Unlock()
+		return false
+	case <-ctx.Done():
+		w.mu.Lock()
+		w.cond.Broadcast()
+		w.mu.Unlock()
+		return false
+	}
+}
+
+// CountJobsByStatus is a small helper for tests, /healthz, and
+// dashboards. Not exposed via API yet — projection runs already give a
+// rich enough view; if dashboards ever ask, we'll add /v1/queue.
+func (s *Store) CountJobsByStatus(status string) (int, error) {
+	row := s.db.QueryRow(`SELECT COUNT(*) FROM jobs WHERE status = ?`, status)
+	var n int
+	err := row.Scan(&n)
+	return n, err
+}

--- a/internal/cronicle/state/queue_test.go
+++ b/internal/cronicle/state/queue_test.go
@@ -1,0 +1,277 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newQueueTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestQueue_EnqueueClaim: happy path. One enqueued job is claimed by
+// a worker; the wire shape carries the schedule + payload.
+func TestQueue_EnqueueClaim(t *testing.T) {
+	s := newQueueTestStore(t)
+	if err := s.Enqueue("R1", "daily", []byte(`{"schedule":"daily"}`)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if n, _ := s.CountJobsByStatus(JobPending); n != 1 {
+		t.Fatalf("pending count: got %d, want 1", n)
+	}
+	j, err := s.Claim("W_A", time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if j.RunID != "R1" || j.Schedule != "daily" || string(j.Payload) != `{"schedule":"daily"}` {
+		t.Fatalf("claimed wrong: %+v", j)
+	}
+	if j.ClaimedBy != "W_A" {
+		t.Fatalf("claimed_by: got %q, want W_A", j.ClaimedBy)
+	}
+	if j.Attempt != 1 {
+		t.Fatalf("attempt: got %d, want 1", j.Attempt)
+	}
+	if n, _ := s.CountJobsByStatus(JobClaimed); n != 1 {
+		t.Fatalf("claimed count: got %d, want 1", n)
+	}
+}
+
+// TestQueue_NoJobs: Claim returns ErrNoJobs when the queue is empty.
+func TestQueue_NoJobs(t *testing.T) {
+	s := newQueueTestStore(t)
+	_, err := s.Claim("W_A", time.Minute)
+	if !errors.Is(err, ErrNoJobs) {
+		t.Fatalf("expected ErrNoJobs, got %v", err)
+	}
+}
+
+// TestQueue_ConcurrentClaim: two workers race on a single job. SQLite
+// WAL serializes them; only one wins. The other gets ErrNoJobs.
+func TestQueue_ConcurrentClaim(t *testing.T) {
+	s := newQueueTestStore(t)
+	if err := s.Enqueue("R1", "x", []byte("{}")); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	var wg sync.WaitGroup
+	var wins atomic.Int32
+	var noJobs atomic.Int32
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if _, err := s.Claim("W"+string(rune('A'+i)), time.Minute); err == nil {
+				wins.Add(1)
+			} else if errors.Is(err, ErrNoJobs) {
+				noJobs.Add(1)
+			} else {
+				t.Errorf("unexpected: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if wins.Load() != 1 || noJobs.Load() != 1 {
+		t.Fatalf("expected 1 win + 1 no-jobs, got wins=%d noJobs=%d", wins.Load(), noJobs.Load())
+	}
+}
+
+// TestQueue_AckDone: after Ack(success=true), the row is status=done
+// and re-Claim returns nothing.
+func TestQueue_AckDone(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+	j, _ := s.Claim("W_A", time.Minute)
+
+	if err := s.Ack(j.RunID, "W_A", true, ""); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+	if n, _ := s.CountJobsByStatus(JobDone); n != 1 {
+		t.Fatalf("done count: %d", n)
+	}
+	if _, err := s.Claim("W_B", time.Minute); !errors.Is(err, ErrNoJobs) {
+		t.Fatalf("after ack: expected ErrNoJobs, got %v", err)
+	}
+}
+
+// TestQueue_AckFailed: Ack(success=false, errMsg) records the failure
+// reason on the row and marks it failed (not pending — failure is
+// terminal; retries are an explicit re-enqueue, not implicit).
+func TestQueue_AckFailed(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+	j, _ := s.Claim("W_A", time.Minute)
+
+	if err := s.Ack(j.RunID, "W_A", false, "boom"); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+	if n, _ := s.CountJobsByStatus(JobFailedQ); n != 1 {
+		t.Fatalf("failed count: %d", n)
+	}
+}
+
+// TestQueue_AckWrongWorker: a worker can't ack a job it didn't claim.
+// No error returned (idempotent path), but the row stays claimed.
+func TestQueue_AckWrongWorker(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+	_, _ = s.Claim("W_A", time.Minute)
+
+	if err := s.Ack("R1", "W_B", true, ""); err != nil {
+		t.Fatalf("Ack mismatched worker: %v", err)
+	}
+	if n, _ := s.CountJobsByStatus(JobClaimed); n != 1 {
+		t.Fatalf("claimed should still be 1, got %d", n)
+	}
+}
+
+// TestQueue_VisibilityTimeout: a worker dies (never acks). Time passes,
+// the reaper moves the row back to pending. Another worker picks it up.
+func TestQueue_VisibilityTimeout(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+
+	// Claim with a tiny visibility so we don't have to wait minutes.
+	j1, err := s.Claim("W_A", 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if j1.Attempt != 1 {
+		t.Fatalf("attempt 1: got %d", j1.Attempt)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Reaper sweep.
+	moved, err := s.ReapExpired()
+	if err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	if moved != 1 {
+		t.Fatalf("expected 1 reaped, got %d", moved)
+	}
+
+	// Worker B picks it up. Attempt counter advances.
+	j2, err := s.Claim("W_B", time.Minute)
+	if err != nil {
+		t.Fatalf("re-Claim: %v", err)
+	}
+	if j2.RunID != "R1" || j2.ClaimedBy != "W_B" {
+		t.Fatalf("re-claim wrong: %+v", j2)
+	}
+	if j2.Attempt != 2 {
+		t.Fatalf("attempt 2: got %d", j2.Attempt)
+	}
+}
+
+// TestQueue_HeartbeatExtends: a long-running task heartbeats, the
+// reaper does NOT take its job back.
+func TestQueue_HeartbeatExtends(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+	_, _ = s.Claim("W_A", 50*time.Millisecond)
+
+	// Halfway through visibility, heartbeat to extend by 1 minute.
+	time.Sleep(25 * time.Millisecond)
+	if err := s.Heartbeat("R1", "W_A", time.Minute); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	// Wait past the original visibility deadline.
+	time.Sleep(40 * time.Millisecond)
+	moved, _ := s.ReapExpired()
+	if moved != 0 {
+		t.Fatalf("heartbeat didn't protect: reaped %d", moved)
+	}
+	// Original claim still owns it.
+	if _, err := s.Claim("W_B", time.Minute); !errors.Is(err, ErrNoJobs) {
+		t.Fatalf("W_B should not claim a heartbeated job, got %v", err)
+	}
+}
+
+// TestQueue_HeartbeatLost: when the claim has lapsed, heartbeat fails
+// so the worker knows it's been preempted.
+func TestQueue_HeartbeatLost(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+	_, _ = s.Claim("W_A", 5*time.Millisecond)
+	time.Sleep(15 * time.Millisecond)
+	_, _ = s.ReapExpired()
+
+	err := s.Heartbeat("R1", "W_A", time.Minute)
+	if err == nil {
+		t.Fatalf("expected heartbeat to fail after preemption")
+	}
+}
+
+// TestQueue_EnqueueIdempotent: re-enqueuing the same run_id is a no-op.
+// The same job stays at attempt=1 with original status.
+func TestQueue_EnqueueIdempotent(t *testing.T) {
+	s := newQueueTestStore(t)
+	_ = s.Enqueue("R1", "x", []byte(`{"v":1}`))
+	_ = s.Enqueue("R1", "x", []byte(`{"v":2}`))
+	if n, _ := s.CountJobsByStatus(JobPending); n != 1 {
+		t.Fatalf("pending after re-enqueue: %d", n)
+	}
+	j, _ := s.Claim("W_A", time.Minute)
+	if string(j.Payload) != `{"v":1}` {
+		t.Fatalf("payload changed under re-enqueue: %s", j.Payload)
+	}
+}
+
+// TestQueue_WaitForJob_Wakes: a long-poll waiter unblocks when
+// Enqueue broadcasts.
+func TestQueue_WaitForJob_Wakes(t *testing.T) {
+	s := newQueueTestStore(t)
+	woke := make(chan bool, 1)
+	go func() {
+		woke <- s.WaitForJob(context.Background(), 2*time.Second)
+	}()
+	time.Sleep(20 * time.Millisecond) // let the waiter park
+	_ = s.Enqueue("R1", "x", []byte("{}"))
+	select {
+	case got := <-woke:
+		if !got {
+			t.Fatalf("WaitForJob: got false (timed out), wanted true")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitForJob did not wake on Enqueue")
+	}
+}
+
+// TestQueue_WaitForJob_Timeout: with no enqueue, the wait returns
+// false after the deadline.
+func TestQueue_WaitForJob_Timeout(t *testing.T) {
+	s := newQueueTestStore(t)
+	got := s.WaitForJob(context.Background(), 30*time.Millisecond)
+	if got {
+		t.Fatalf("expected timeout to return false")
+	}
+}
+
+// TestQueue_WaitForJob_CtxCancel: cancellation also unblocks the wait.
+func TestQueue_WaitForJob_CtxCancel(t *testing.T) {
+	s := newQueueTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	woke := make(chan bool, 1)
+	go func() {
+		woke <- s.WaitForJob(ctx, time.Hour)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case got := <-woke:
+		if got {
+			t.Fatalf("expected ctx cancel false return")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitForJob did not unblock on ctx cancel")
+	}
+}

--- a/internal/cronicle/state/schema.go
+++ b/internal/cronicle/state/schema.go
@@ -73,4 +73,37 @@ CREATE INDEX IF NOT EXISTS idx_events_run        ON events(run_id, id);
 CREATE INDEX IF NOT EXISTS idx_events_ts         ON events(ts);
 `
 
-const targetSchemaVersion = 1
+// schemaSQL_v2 adds the producer-served queue. Jobs persist as rows
+// transitioning pending → claimed → done|failed. The single-writer SQLite
+// txn that flips status='pending' → 'claimed' on a worker's long-poll IS
+// the claim primitive — no race window between "delivered" and "ack",
+// because the row's claimed_by column is the authoritative single owner.
+//
+// Visibility timeout: claim_expires_at is set on claim; a janitor sweeps
+// rows with status='claimed' AND claim_expires_at < now back to
+// status='pending' so a dead worker's job is re-dispatched.
+//
+// payload column carries the serialized Schedule JSON the producer
+// pushed at enqueue time. Workers decode it identically to how the
+// in-process consumer does today.
+const schemaSQL_v2 = `
+CREATE TABLE IF NOT EXISTS jobs (
+    run_id            TEXT PRIMARY KEY,
+    schedule          TEXT NOT NULL,
+    payload           TEXT NOT NULL,
+    status            TEXT NOT NULL,        -- pending | claimed | done | failed
+    enqueued_at       TEXT NOT NULL,
+    claimed_at        TEXT,
+    claimed_by        TEXT NOT NULL DEFAULT '',
+    claim_expires_at  TEXT,
+    attempt           INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT NOT NULL DEFAULT '',
+    completed_at      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status_enqueued ON jobs(status, enqueued_at);
+CREATE INDEX IF NOT EXISTS idx_jobs_claim_expires   ON jobs(claim_expires_at)
+  WHERE status = 'claimed';
+`
+
+const targetSchemaVersion = 2

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -39,9 +39,16 @@ const (
 // Store is the projection store. Concurrent-safe — internal mutex
 // serializes Apply() so out-of-order events (e.g. a shell_run racing
 // schedule_complete on a fast task) don't interleave their UPDATEs.
+//
+// Phase 2b adds queue methods (Enqueue/Claim/Ack/Heartbeat/Reap) that
+// share the same mutex. wait/waitOnce gate the lazy initialization of
+// the long-poll wakeup primitive so single-node mode (no queue methods
+// ever called) doesn't pay for it.
 type Store struct {
-	db *sql.DB
-	mu sync.Mutex // serializes write transactions
+	db       *sql.DB
+	mu       sync.Mutex // serializes write transactions
+	waitOnce sync.Once
+	wait     *jobWaiters
 }
 
 // Open returns a Store backed by the given DSN. Use ":memory:" for an
@@ -98,21 +105,33 @@ func (s *Store) Close() error {
 }
 
 // migrate runs the schema SQL idempotently and records the version.
-// Subsequent versions append additional execs guarded by a `version <` check.
+// Each numbered version's DDL is applied if the recorded version is < target.
+// Idempotent on re-runs because every CREATE uses IF NOT EXISTS.
 func (s *Store) migrate() error {
+	// v1: runs/tasks/events/schema_versions
 	if _, err := s.db.Exec(schemaSQL); err != nil {
-		return fmt.Errorf("state.migrate: %w", err)
+		return fmt.Errorf("state.migrate v1: %w", err)
 	}
 	var current int
 	row := s.db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM schema_versions`)
 	if err := row.Scan(&current); err != nil {
 		return fmt.Errorf("state.migrate: read version: %w", err)
 	}
+	// v2: jobs (queue table)
+	if current < 2 {
+		if _, err := s.db.Exec(schemaSQL_v2); err != nil {
+			return fmt.Errorf("state.migrate v2: %w", err)
+		}
+	}
 	if current >= targetSchemaVersion {
 		return nil
 	}
-	_, err := s.db.Exec(`INSERT INTO schema_versions(version) VALUES (?)`, targetSchemaVersion)
-	return err
+	for v := current + 1; v <= targetSchemaVersion; v++ {
+		if _, err := s.db.Exec(`INSERT INTO schema_versions(version) VALUES (?)`, v); err != nil {
+			return fmt.Errorf("state.migrate: record version %d: %w", v, err)
+		}
+	}
+	return nil
 }
 
 // Apply folds an event into the projection. Idempotent on event re-delivery

--- a/internal/cronicle/worker_event_ship.go
+++ b/internal/cronicle/worker_event_ship.go
@@ -1,0 +1,198 @@
+package cronicle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// eventShipper batches slog records that carry an entry_type and POSTs
+// them to the producer's /v1/events endpoint as JSONL. Implements
+// slog.Handler so it slots into the same multi-handler chain as the
+// file/stdout writers.
+//
+// Buffering is bounded — a misbehaving producer (slow, partitioned,
+// returning 503) cannot push back-pressure into the slog hot path that
+// runs inside ExecuteTasks. When the buffer fills, oldest events are
+// dropped and a stat counter increments. Local logs (stdout +
+// cronicle.jsonl) are NOT affected — they're written by sibling
+// handlers in the multi-handler chain that don't share the buffer.
+type eventShipper struct {
+	url        string // POST endpoint, e.g. http://producer:8765/v1/events
+	token      string
+	client     *http.Client
+	in         chan []byte
+	dropped    int64
+	dropCounMu sync.Mutex
+	closeOnce  sync.Once
+	done       chan struct{}
+}
+
+// newEventShipper constructs a running shipper. Caller is responsible
+// for calling stop() at process exit; otherwise the flusher goroutine
+// blocks forever holding the http.Client.
+func newEventShipper(producerURL, token string) *eventShipper {
+	s := &eventShipper{
+		url:    strings.TrimRight(producerURL, "/") + "/v1/events",
+		token:  token,
+		client: &http.Client{Timeout: 10 * time.Second},
+		in:     make(chan []byte, 4096),
+		done:   make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+// run drains the buffered channel into batched POSTs. We batch by
+// time + size: ship every 500ms or when the batch hits 64 events,
+// whichever comes first. At our load this means roughly one HTTP
+// roundtrip per few seconds, never more than one in flight at a time
+// (we wait for the previous to finish before issuing another).
+func (s *eventShipper) run() {
+	defer close(s.done)
+
+	const (
+		flushInterval = 500 * time.Millisecond
+		flushSize     = 64
+	)
+	t := time.NewTicker(flushInterval)
+	defer t.Stop()
+
+	var batch [][]byte
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		s.post(batch)
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case line, ok := <-s.in:
+			if !ok {
+				flush()
+				return
+			}
+			batch = append(batch, line)
+			if len(batch) >= flushSize {
+				flush()
+			}
+		case <-t.C:
+			flush()
+		}
+	}
+}
+
+// post sends one batch as a JSONL body. Errors are logged-and-dropped
+// (we already lost the source events at this point; the JSONL log on
+// disk has the audit trail). At-least-once semantics from the
+// producer's side are NOT guaranteed by this shipper — re-POSTing on
+// error would risk duplicate Apply calls, and the projection's row
+// updates are monotonic-ish but not perfectly idempotent. Better to
+// drop one batch than to corrupt counts.
+func (s *eventShipper) post(batch [][]byte) {
+	body := bytes.Join(batch, []byte("\n"))
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		// Log via stdlib log so we don't recurse into slog and
+		// re-feed the shipper.
+		s.bumpDropped(int64(len(batch)))
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		s.bumpDropped(int64(len(batch)))
+	}
+}
+
+func (s *eventShipper) bumpDropped(n int64) {
+	s.dropCounMu.Lock()
+	s.dropped += n
+	s.dropCounMu.Unlock()
+}
+
+// stop drains any remaining batch and tears down the goroutine. Safe
+// to call multiple times.
+func (s *eventShipper) stop() {
+	s.closeOnce.Do(func() {
+		close(s.in)
+		<-s.done
+	})
+}
+
+// ---- slog.Handler ----------------------------------------------------------
+
+func (s *eventShipper) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (s *eventShipper) Handle(_ context.Context, r slog.Record) error {
+	// Skip records without entry_type. Lifecycle prints (heartbeat,
+	// "Loading config…") aren't projection-relevant.
+	hasEntryType := false
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "entry_type" {
+			hasEntryType = true
+			return false
+		}
+		return true
+	})
+	if !hasEntryType {
+		return nil
+	}
+
+	// Same JSON shape the file logger writes. We don't reuse
+	// slog.NewJSONHandler because it writes to an io.Writer; we want
+	// the bytes back.
+	m := map[string]any{
+		"time":  r.Time,
+		"level": r.Level.String(),
+		"msg":   r.Message,
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		m[a.Key] = a.Value.Any()
+		return true
+	})
+	line, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	// Non-blocking send; on overflow, drop newest. Workers should
+	// never block their execution path on a slow producer.
+	select {
+	case s.in <- line:
+	default:
+		s.bumpDropped(1)
+	}
+	return nil
+}
+
+func (s *eventShipper) WithAttrs(_ []slog.Attr) slog.Handler { return s }
+func (s *eventShipper) WithGroup(_ string) slog.Handler      { return s }
+
+// enableEventShipping wires a shipper into the default slog handler
+// chain. Returns the shipper so the caller can stop() it at shutdown.
+// Composes with the file/stdout writers — they're independent
+// handlers in the multi-handler.
+func enableEventShipping(producerURL, token string) *eventShipper {
+	if producerURL == "" {
+		return nil
+	}
+	s := newEventShipper(producerURL, token)
+	current := slog.Default().Handler()
+	slog.SetDefault(slog.New(&multiHandler{handlers: []slog.Handler{current, s}}))
+	return s
+}

--- a/internal/cronicle/worker_http.go
+++ b/internal/cronicle/worker_http.go
@@ -1,0 +1,312 @@
+package cronicle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// HTTPWorkerOptions configures a worker that consumes via HTTP long-poll
+// against a producer's /v1/jobs endpoint instead of via a vice broker.
+//
+// This is the Phase 2 distributed mode. It replaces the Redis/NSQ
+// transport with the producer-served queue, so the only deployment
+// dependency is the producer URL.
+type HTTPWorkerOptions struct {
+	// ProducerURL is the base URL of cronicle run (e.g. http://producer:8765).
+	// Required.
+	ProducerURL string
+	// Token is the bearer credential. Required (the producer refuses to
+	// bind /v1/jobs without one).
+	Token string
+	// WorkerID identifies this consumer in claim/ack. Empty → default
+	// "<hostname>-<pid>".
+	WorkerID string
+	// Path is the local schedule repo root. Used by tasks that have
+	// repo blocks; same semantics as the existing StartWorker path
+	// argument.
+	Path string
+	// LogToFile mirrors the producer behavior: when true, structured
+	// JSON also writes to .cronicle/log/cronicle.jsonl on the worker
+	// host (per-worker audit trail).
+	LogToFile bool
+	// PollBlock is the long-poll wait passed to /v1/jobs?block=. Default 30s.
+	PollBlock time.Duration
+	// HeartbeatEvery is the cadence at which a worker pings /heartbeat
+	// for its currently-claimed job. Default visibility/3 = ~100s
+	// when the producer's visibility is 5 minutes.
+	HeartbeatEvery time.Duration
+}
+
+// StartHTTPWorker runs the long-poll consumer loop. Blocks until ctx
+// is canceled or an unrecoverable transport failure occurs (none are
+// unrecoverable today — connection errors trigger backoff and retry).
+//
+// File logging is set up identically to StartWorker — workers running
+// distributed get the same on-disk audit trail as single-node.
+func StartHTTPWorker(ctx context.Context, opts HTTPWorkerOptions) error {
+	if opts.ProducerURL == "" {
+		return errors.New("StartHTTPWorker: ProducerURL is required")
+	}
+	if opts.Token == "" {
+		return errors.New("StartHTTPWorker: Token is required (producer refuses unauthenticated workers)")
+	}
+	if opts.WorkerID == "" {
+		opts.WorkerID = defaultWorkerID()
+	}
+	if opts.PollBlock <= 0 {
+		opts.PollBlock = 30 * time.Second
+	}
+	if opts.HeartbeatEvery <= 0 {
+		opts.HeartbeatEvery = 100 * time.Second
+	}
+	pathAbs, err := filepath.Abs(opts.Path)
+	if err != nil {
+		return fmt.Errorf("StartHTTPWorker: abs path: %w", err)
+	}
+	if opts.LogToFile {
+		if err := EnableFileLog(pathAbs); err != nil {
+			return fmt.Errorf("StartHTTPWorker: file log: %w", err)
+		}
+	}
+	// In-memory projection on the worker side. Events are projected
+	// locally too so the worker can answer GET /v1/runs locally if
+	// debug-listening, AND so the slog Sink keeps working consistently
+	// with single-node mode. We don't ship a worker-side listener in
+	// Phase 2b; this is just for symmetry with the producer's slog
+	// chain.
+	if err := EnableStateStore(":memory:"); err != nil {
+		return fmt.Errorf("StartHTTPWorker: state store: %w", err)
+	}
+	// Ship event records back to the producer so its projection sees
+	// what really happened (schedule_start, shell_run, agent_run,
+	// schedule_complete). Non-blocking — workers never stall on a
+	// slow producer; oldest events drop on overflow.
+	shipper := enableEventShipping(opts.ProducerURL, opts.Token)
+	if shipper != nil {
+		defer shipper.stop()
+	}
+
+	client := &http.Client{
+		// One full long-poll cycle plus margin. Don't set this too
+		// tight or transient retransmits look like timeouts.
+		Timeout: opts.PollBlock + 30*time.Second,
+	}
+	w := &httpWorker{
+		opts:   opts,
+		client: client,
+		ctx:    ctx,
+	}
+
+	slog.Info("HTTP worker started",
+		"worker_id", opts.WorkerID,
+		"producer", opts.ProducerURL,
+		"poll_block", opts.PollBlock.String(),
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		job, gotJob, err := w.pollOnce()
+		if err != nil {
+			slog.Error("worker poll failed", "error", err.Error())
+			// Backoff. With the producer down workers should not
+			// hot-loop on connection errors.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(2 * time.Second):
+			}
+			continue
+		}
+		if !gotJob {
+			// 204 No Content — the long-poll waited and got nothing.
+			// Just reconnect immediately.
+			continue
+		}
+		w.execute(pathAbs, job)
+	}
+}
+
+type httpWorker struct {
+	opts   HTTPWorkerOptions
+	client *http.Client
+	ctx    context.Context
+}
+
+func (w *httpWorker) authHeader() string { return "Bearer " + w.opts.Token }
+
+// pollOnce issues one GET /v1/jobs roundtrip. Returns (job, true, nil)
+// on a 200 with a job, (zero, false, nil) on a 204, and (zero, false, err)
+// on transport / decode errors.
+func (w *httpWorker) pollOnce() (state.Job, bool, error) {
+	url := strings.TrimRight(w.opts.ProducerURL, "/") +
+		"/v1/jobs?worker=" + w.opts.WorkerID +
+		"&block=" + w.opts.PollBlock.String()
+	req, err := http.NewRequestWithContext(w.ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return state.Job{}, false, err
+	}
+	req.Header.Set("Authorization", w.authHeader())
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return state.Job{}, false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return state.Job{}, false, nil
+	case http.StatusOK:
+		var j state.Job
+		if err := json.NewDecoder(resp.Body).Decode(&j); err != nil {
+			return state.Job{}, false, fmt.Errorf("decode job: %w", err)
+		}
+		return j, true, nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return state.Job{}, false, fmt.Errorf("claim http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+// execute runs the job and acks it. Heartbeats while running. The
+// schedule's events stay local to the worker via slog (file + stdout
+// + memory projection); a future enhancement is to POST them back to
+// the producer via /v1/events.
+func (w *httpWorker) execute(croniclePath string, job state.Job) {
+	slog.Info("worker claimed job",
+		"run_id", job.RunID,
+		"schedule", job.Schedule,
+		"attempt", job.Attempt,
+	)
+
+	hbCtx, hbCancel := context.WithCancel(w.ctx)
+	defer hbCancel()
+	go w.heartbeatLoop(hbCtx, job.RunID)
+
+	var sch Schedule
+	success := true
+	errMsg := ""
+	if err := json.Unmarshal(job.Payload, &sch); err != nil {
+		slog.Error("worker: bad payload", "run_id", job.RunID, "error", err.Error())
+		success = false
+		errMsg = err.Error()
+	} else {
+		// Stamp source so the projection's runs row records "executed
+		// on a remote worker" rather than reusing whatever value the
+		// producer set. Most workers will run cron-fired or HTTP-fired
+		// schedules; we keep the producer's source if already set.
+		if sch.Source == "" {
+			sch.Source = "worker"
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					success = false
+					errMsg = fmt.Sprintf("panic: %v", r)
+				}
+			}()
+			sch.PropigateTaskProperties(croniclePath)
+			sch.ExecuteTasks()
+		}()
+	}
+
+	hbCancel()
+	if err := w.ack(job.RunID, success, errMsg); err != nil {
+		slog.Error("worker: ack failed", "run_id", job.RunID, "error", err.Error())
+	}
+}
+
+// heartbeatLoop pings /heartbeat on opts.HeartbeatEvery cadence until
+// ctx is canceled. A 409 (lost ownership) terminates the loop early —
+// the worker has been preempted by the reaper.
+func (w *httpWorker) heartbeatLoop(ctx context.Context, runID string) {
+	t := time.NewTicker(w.opts.HeartbeatEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := w.heartbeat(runID); err != nil {
+				slog.Warn("heartbeat failed; stopping heartbeat loop",
+					"run_id", runID, "error", err.Error())
+				return
+			}
+		}
+	}
+}
+
+func (w *httpWorker) heartbeat(runID string) error {
+	url := strings.TrimRight(w.opts.ProducerURL, "/") + "/v1/jobs/" + runID + "/heartbeat"
+	body, _ := json.Marshal(map[string]string{"worker": w.opts.WorkerID})
+	return w.post(url, body, http.StatusOK)
+}
+
+func (w *httpWorker) ack(runID string, success bool, errMsg string) error {
+	url := strings.TrimRight(w.opts.ProducerURL, "/") + "/v1/jobs/" + runID + "/ack"
+	body, _ := json.Marshal(map[string]any{
+		"worker":  w.opts.WorkerID,
+		"success": success,
+		"error":   errMsg,
+	})
+	return w.post(url, body, http.StatusOK)
+}
+
+func (w *httpWorker) post(url string, body []byte, expectCode int) error {
+	req, err := http.NewRequestWithContext(w.ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", w.authHeader())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != expectCode {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// defaultWorkerID returns "<hostname>-<pid>" for stable-but-unique
+// identification. Operators wanting prettier IDs pass --worker-id.
+func defaultWorkerID() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return host + "-" + strconv.Itoa(os.Getpid())
+}
+
+// hashOnly stays around as a placeholder for a future: if we ever
+// want to anonymize hostnames in worker IDs (compliance scenarios),
+// hashing host with a process-stable salt is the move.
+//
+//nolint:unused
+func hashOnly(s string) string {
+	return strings.ToLower(s)
+}
+
+// silence the unused import for sync — the worker uses sync.Once /
+// sync.Mutex paths only on the producer side. Keep the import here
+// reserved for follow-up work without re-shuffling each PR.
+var _ sync.Mutex


### PR DESCRIPTION
The big one. Replaces the Redis/NSQ vice broker with an in-process SQLite job queue that workers consume via HTTP long-poll. From the design doc (#84), this is what makes the deployment story collapse to "one binary, one optional disk file."

## What's in
- **Schema v2 + queue methods**: `jobs` table, `Enqueue`/`Claim`/`Ack`/`Heartbeat`/`ReapExpired`/`WaitForJob`. Atomic claim via `BEGIN IMMEDIATE` + `UPDATE ... WHERE status='pending'` — SQLite WAL serializes the race; `claimed_by` is the authoritative single owner.
- **HTTP queue API**:
  - `GET /v1/jobs?worker=&block=` — long-poll, max 60s, returns one job or 204
  - `POST /v1/jobs/{run_id}/ack` — worker reports completion (success or failure+error)
  - `POST /v1/jobs/{run_id}/heartbeat` — extends visibility for long agent runs; 409 if claim lost
- **`cronicle run --queue self`**: cron + listener trigger → SQLite enqueue → in-process self-worker. Janitor reaps expired claims every 10s.
- **`cronicle worker --producer URL --producer-token TOKEN`**: HTTP long-poll worker. Heartbeats while running, ships slog events back via `POST /v1/events` (batched 500ms/64ev). Acks on completion.
- **Event shipping**: workers tee their slog stream to the producer so its projection reflects what really happened. JSONL on the wire matches `cronicle.jsonl` on disk — single source of truth for event shape.

## End-to-end verification
```
producer  : cronicle run --queue self --listen :8801 --listen-token tok --worker=false
worker    : cronicle worker --producer http://localhost:8801 --producer-token tok --worker-id ext-1
trigger   : POST /v1/schedules/ondemand/trigger
result    : producer's GET /v1/runs/{id} returns the worker's full execution
            (schedule_start → task_start → shell_run → schedule_complete) including
            kind=shell, exit_code=0, duration_ms, etc.
```

## Tests
- 13 queue-layer tests: enqueue/claim happy path, ErrNoJobs, concurrent-claim race, ack done/failed, ack-wrong-worker, visibility timeout, heartbeat extends, heartbeat lost, idempotent enqueue, WaitForJob wake/timeout/ctx-cancel.
- 11 HTTP API tests: auth, missing worker, claim returns job, long-poll wait timeout, long-poll wakes on enqueue, ack success/failure, heartbeat extends/lost, bad JSON, client disconnect mid-wait.
- Full suite green (4 packages).

## What's NOT in (Phase 2c, next)
- Removing Redis/NSQ/vice and the deploy/redis|nsq directories. They still work; they're now slated for removal.
- SSE control channel for cancel/retry. That's Phase 3.
- A `/v1/workers` endpoint listing connected workers. Useful for dashboards; deferring until there's a UI consumer.

## Why this is the right shape
- **One binary, one disk file** for distributed mode. No Sentinel, no AOF tuning, no broker watchdog.
- **Stronger durability than vice**: every queue write is an SQLite WAL fsync.
- **Same mental model as the design doc**: long-poll IS the heartbeat, claim atomicity comes from SQL `UPDATE` with `WHERE`, no per-worker liveness tracking on the producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)