### PR TITLE
Fix: LoadCron panics on malformed HCL during heartbeat reload

### DIFF
--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -173,7 +173,22 @@ func LoadCron(cronicleFile string, c *cron.Cron, queue chan<- []byte, force bool
 	slog.Info("Loading config...", "cronicle", "heartbeat", "path", cronicleFile)
 	conf, err := GetConfig(cronicleFile)
 	if err != nil {
-		slog.Error("config load failed", "error", err.Error())
+		// HCL parse / decode failed. ParseFile returns (nil, diags) on
+		// hard parse errors, so falling through to conf.Hcl() below
+		// would deref a nil pointer and crash the producer. Keep the
+		// previous good config in place; operator can fix the file and
+		// the next heartbeat picks up the change.
+		slog.Error("config reload failed; keeping previous schedules in place",
+			"path", cronicleFile, "error", err.Error())
+		return
+	}
+	if conf == nil {
+		// Defensive: GetConfig contract is (nil, err) on failure, but
+		// some future change might return (nil, nil). Treat that the
+		// same way as an explicit error.
+		slog.Error("config reload returned nil config; keeping previous schedules in place",
+			"path", cronicleFile)
+		return
 	}
 
 	if string(confPriorGlobal.Hcl().Bytes) != string(conf.Hcl().Bytes) || force {

--- a/internal/cronicle/loadcron_test.go
+++ b/internal/cronicle/loadcron_test.go
@@ -1,0 +1,82 @@
+package cronicle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cron "github.com/robfig/cron/v3"
+)
+
+// TestLoadCron_MalformedHCLDoesNotPanic exercises the heartbeat
+// reload path with a file that's been corrupted on disk. Before this
+// fix, GetConfig returned (nil, err); LoadCron logged the error but
+// fell through to conf.Hcl(), dereffing nil and panicking. The
+// scheduler is supposed to keep the previous good config in place
+// until the operator fixes the file.
+func TestLoadCron_MalformedHCLDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	hclPath := filepath.Join(dir, "cronicle.hcl")
+	good := []byte(`
+heartbeat = "@every 60s"
+schedule "ok" {
+  cron = "@every 1h"
+  task "say" {
+    command = ["/bin/echo", "hi"]
+    depends = null
+    env     = null
+  }
+}
+`)
+	if err := os.WriteFile(hclPath, good, 0o644); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+
+	// Seed confPriorGlobal as the producer's Run() does, so LoadCron has
+	// a previous-config snapshot to compare against.
+	conf, err := GetConfig(hclPath)
+	if err != nil {
+		t.Fatalf("GetConfig good: %v", err)
+	}
+	confPriorGlobal = conf
+	defer func() { confPriorGlobal = nil }()
+
+	c := cron.New()
+	queue := make(chan []byte, 1)
+	defer close(queue)
+
+	// Force the initial load (analogous to startup).
+	LoadCron(hclPath, c, queue, true)
+	if got := len(c.Entries()); got == 0 {
+		t.Fatalf("expected entries after good load, got 0")
+	}
+	priorEntryCount := len(c.Entries())
+
+	// Now corrupt the file. A truncated block with an unclosed `{` makes
+	// hcl's parser error out hard.
+	if err := os.WriteFile(hclPath, []byte(`schedule "broken" { cron = "@every 1s"`), 0o644); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+
+	// LoadCron used to panic here. Now it should log and return,
+	// leaving confPriorGlobal and the cron entries intact.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("LoadCron panicked on malformed HCL: %v", r)
+		}
+	}()
+	LoadCron(hclPath, c, queue, false)
+
+	// Previous good config is still authoritative.
+	if confPriorGlobal == nil {
+		t.Fatalf("confPriorGlobal cleared on bad reload — should be preserved")
+	}
+	if !strings.Contains(string(confPriorGlobal.Hcl().Bytes), `"ok"`) {
+		t.Fatalf("confPriorGlobal mutated to broken state: %s",
+			confPriorGlobal.Hcl().Bytes)
+	}
+	if got := len(c.Entries()); got != priorEntryCount {
+		t.Fatalf("cron entries mutated: got %d, want %d", got, priorEntryCount)
+	}
+}


### PR DESCRIPTION
## Bug
When `cronicle.hcl` is edited into an unparseable state while `cronicle run` is alive, the heartbeat reload logged the parse error correctly and then crashed with a nil pointer deref. Operators lost the producer + had to restart, even though the previous good config was still in memory and could have kept running.

## Root cause
`internal/cronicle/cron.go` `LoadCron`:
```go
conf, err := GetConfig(cronicleFile)
if err != nil {
    slog.Error("config load failed", "error", err.Error())   // logged, no return
}
if string(confPriorGlobal.Hcl().Bytes) != string(conf.Hcl().Bytes) || force {
//                                              ^^^^^^^^^^^
//                                              conf is nil → panic
```
`ParseFile` returns `(nil, diags)` on hard parse errors; `GetConfig` propagates that. `LoadCron` logged and fell through, dereffing nil.

## Fix
Early-return on parse error. Keep `confPriorGlobal` and the running cron entries in place; next heartbeat tries the file again. Operator fixes the HCL → producer recovers without a restart.

## Verification
- Unit regression: `loadcron_test.go` seeds a good config, corrupts the file, calls `LoadCron`, asserts no panic + previous config preserved + cron entries unchanged.
- End-to-end smoke: producer running `@every 1s` schedule, corrupt the HCL mid-flight, watch ~4s pass with `heartbeat=@every 2s`. Process stayed alive, parse error logged twice (one per heartbeat), original task kept executing 7 times across the corruption window.

```
=== runtime BEFORE corruption ===
3 shell task runs

=== corrupt the HCL ===

=== runtime AFTER corruption ===
PROCESS STILL ALIVE ✓
7 shell task runs

=== error log ===
ERROR config reload failed; keeping previous schedules in place ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)