### PR TITLE
Release prep: v0.5.0 version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ One-liner (Linux, macOS):
 curl -fsSL https://raw.githubusercontent.com/jshiv/cronicle/master/install.sh | sh
 ```
 
-Detects OS/arch, downloads the matching release artifact, installs to `/usr/local/bin` (or `$HOME/.local/bin` if `/usr/local/bin` isn't writable). Pin a version with `CRONICLE_VERSION=v0.4.0` or override the path with `CRONICLE_INSTALL_DIR=$HOME/.local/bin`.
+Detects OS/arch, downloads the matching release artifact, installs to `/usr/local/bin` (or `$HOME/.local/bin` if `/usr/local/bin` isn't writable). Pin a version with `CRONICLE_VERSION=v0.5.0` or override the path with `CRONICLE_INSTALL_DIR=$HOME/.local/bin`.
 
 Manual install: download the matching tarball from the [releases page](https://github.com/jshiv/cronicle/releases/latest) and place the `cronicle` binary on your `PATH`.
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/jshiv/cronicle/master/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/jshiv/cronicle/master/install.sh | CRONICLE_VERSION=v0.4.0 sh
+#   curl -fsSL https://raw.githubusercontent.com/jshiv/cronicle/master/install.sh | CRONICLE_VERSION=v0.5.0 sh
 #   curl -fsSL https://raw.githubusercontent.com/jshiv/cronicle/master/install.sh | CRONICLE_INSTALL_DIR=$HOME/.local/bin sh
 #
 # Environment:

--- a/internal/cronicle/mcp.go
+++ b/internal/cronicle/mcp.go
@@ -42,7 +42,7 @@ const MCPNameSep = "__"
 // name and a semver-ish version.
 const (
 	mcpClientName    = "cronicle"
-	mcpClientVersion = "0.4.0"
+	mcpClientVersion = "0.5.0"
 )
 
 // MCPHandle is the live state of a launched MCP server: the SDK session


### PR DESCRIPTION
Bumps the hardcoded v0.4.0 references to v0.5.0 ahead of the release tag.

- README install snippet pin example
- install.sh inline doc example
- internal/cronicle/mcp.go mcpClientVersion (sent in the MCP handshake)

Historical mentions in docs/design-state-plane.md are left alone — they describe the prior release as historical context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)