### PR TITLE
deploy/distributed: multi-worker fan-out + cancel/retry/resume walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ When `--log-to-file` is on, each task execution also writes a per-run JSONL tran
 
 ## Example Deployments
 
+* [Distributed mode walkthrough — multi-worker fan-out + cancel/retry/resume](deploy/distributed/README.md)
 * [Centralize cronicle logs on a local loki/graphana log aggregator](deploy/local/README.md)
 * [Daily-report agent fan-out + composer demo](deploy/daily-report/README.md)
-* Distributed mode without a broker — see "Distributed mode" below.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ When `--log-to-file` is on, each task execution also writes a per-run JSONL tran
 ## Example Deployments
 
 * [Distributed mode walkthrough — multi-worker fan-out + cancel/retry/resume](deploy/distributed/README.md)
-* [Centralize cronicle logs on a local loki/graphana log aggregator](deploy/local/README.md)
+* [MCP + skills + scratch in one task — minimal live demo](deploy/mcp-demo/README.md)
 * [Daily-report agent fan-out + composer demo](deploy/daily-report/README.md)
+* [Centralize cronicle logs on a local loki/graphana log aggregator](deploy/local/README.md)
 
 
 ---

--- a/deploy/daily-report/README.md
+++ b/deploy/daily-report/README.md
@@ -2,6 +2,14 @@
 
 A canonical multi-agent workflow: 4 crawlers fan out to read team state from different sources, a composer fans in to merge them into a unified daily report.
 
+**On MCP in this example**: the `slack`/`discord`/`email` blocks
+are shown commented out because those MCP servers need credentials
+(`SLACK_BOT_TOKEN`, etc.) and we can't ship working examples without
+real accounts. For a **live MCP demo that runs without credentials**,
+see [`deploy/mcp-demo/`](../mcp-demo/README.md) — it uses
+`@modelcontextprotocol/server-filesystem` (no auth, scoped to a
+directory passed as an arg).
+
 ## Shape
 
 ```

--- a/deploy/distributed/README.md
+++ b/deploy/distributed/README.md
@@ -13,6 +13,16 @@ No Redis. No NSQ. No docker-compose for the queue. The producer
 serves its own queue out of an embedded SQLite file at
 `.cronicle/state.db`; workers consume via HTTP long-poll.
 
+**Scope of this demo**: pure shell tasks, focused on the runtime
+control surface (queue, workers, cancel/retry/resume). For the agent
+side of cronicle:
+
+- [`deploy/mcp-demo/`](../mcp-demo/README.md) — smallest live demo
+  combining `mcp` + `skills` + `${scratch}` in one task.
+- [`deploy/daily-report/`](../daily-report/README.md) — multi-agent
+  fan-out + composer using `${scratch}` and `skills`; MCP server
+  blocks shown as commented templates (slack/gmail need credentials).
+
 ## Layout
 
 - `cronicle.hcl` — three `etl_*` schedules on `@every 30s` cadence and

--- a/deploy/distributed/README.md
+++ b/deploy/distributed/README.md
@@ -1,0 +1,256 @@
+# Distributed mode demo
+
+A working example of cronicle's broker-less distributed mode (introduced
+in v0.5.0). Demonstrates:
+
+- Multi-worker job fan-out — three ETL-style schedules firing on the
+  same cadence, claimed in parallel by the worker pool
+- The state-plane API: `/v1/runs`, `/v1/workers`, `/v1/schedules`
+- Cancel / retry / resume on a long-running pipeline
+- SSE control channel for low-latency cancel signals
+
+No Redis. No NSQ. No docker-compose for the queue. The producer
+serves its own queue out of an embedded SQLite file at
+`.cronicle/state.db`; workers consume via HTTP long-poll.
+
+## Layout
+
+- `cronicle.hcl` — three `etl_*` schedules on `@every 30s` cadence and
+  one `report_pipeline` schedule (cron=`""` — manual trigger only)
+  with three sequential tasks for the cancel/resume demo
+
+## Prerequisites
+
+- `cronicle` v0.5.0+ on your `PATH` (or invoke it by absolute path)
+- Three terminals (or `tmux`/`screen`)
+- A local copy of this directory: `git clone … && cd cronicle/deploy/distributed`
+
+## Walkthrough
+
+### 1. Start the producer
+
+The producer hosts the cron tick + the listener + the SQLite queue.
+`--worker=false` keeps it from running an in-process consumer, so all
+work goes to remote workers (cleaner for the demo).
+
+```bash
+# terminal 1
+export CRONICLE_LISTEN_TOKEN=demo-token
+cronicle run \
+  --path ./cronicle.hcl \
+  --listen :8765 \
+  --listen-token "$CRONICLE_LISTEN_TOKEN" \
+  --worker=false
+```
+
+You'll see the cron loop start and the trigger listener bind:
+
+```
+INFO config loaded path=./cronicle.hcl schedules=4 tasks=5
+INFO Starting Scheduler... cronicle=start
+INFO Starting cron... schedule=etl_users  cron="@every 30s"
+INFO Starting cron... schedule=etl_orders cron="@every 30s"
+INFO Starting cron... schedule=etl_events cron="@every 30s"
+INFO Trigger listener up addr=:8765
+```
+
+### 2. Start two workers
+
+Each worker registers itself on the producer, opens an SSE control
+channel (for cancel signals), and long-polls `/v1/jobs` for work to
+claim. Run them in separate terminals so you can watch them fight for
+jobs.
+
+```bash
+# terminal 2
+export CRONICLE_LISTEN_TOKEN=demo-token
+cronicle worker \
+  --path ./ \
+  --producer http://localhost:8765 \
+  --producer-token "$CRONICLE_LISTEN_TOKEN" \
+  --worker-id worker-A
+```
+
+```bash
+# terminal 3
+cronicle worker \
+  --path ./ \
+  --producer http://localhost:8765 \
+  --producer-token "$CRONICLE_LISTEN_TOKEN" \
+  --worker-id worker-B
+```
+
+Each worker logs its subscription to the control channel:
+
+```
+INFO HTTP worker started worker_id=worker-A producer=http://localhost:8765
+INFO control channel: subscribed worker_id=worker-A
+```
+
+### 3. Watch the registry
+
+```bash
+TOKEN=demo-token
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8765/v1/workers | jq .
+```
+
+```json
+[
+  { "worker_id": "worker-A", "host": "...", "status": "idle", "last_seen": "...", "runs_total": 0 },
+  { "worker_id": "worker-B", "host": "...", "status": "idle", "last_seen": "...", "runs_total": 0 }
+]
+```
+
+### 4. Watch the ETLs fan out
+
+The three `etl_*` schedules fire every 30s. With two workers up, two
+of them claim in parallel; the third waits in the queue and gets
+picked up by whichever worker frees up first.
+
+```bash
+# tail recent runs every few seconds
+watch -n 2 'curl -s -H "Authorization: Bearer '"$TOKEN"'" \
+  "http://localhost:8765/v1/runs?limit=10" \
+  | jq -r ".[] | \"\(.run_id)  \(.schedule)  \(.status)\""'
+```
+
+You'll see new runs appear with `status: succeeded` shortly after each
+30-second tick. Run the workers query again — `runs_total` should be
+roughly evenly split between A and B, with `status: idle|active`
+oscillating as they claim and release.
+
+### 5. Trigger the long pipeline + cancel mid-run
+
+`report_pipeline` is `extract → transform → load`. `transform` sleeps
+30 seconds, which is plenty of room to cancel.
+
+```bash
+# fire it
+RID=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8765/v1/schedules/report_pipeline/trigger \
+  | jq -r .queued)
+
+# wait a bit so 'extract' completes, then peek at the per-task state
+sleep 3
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs?schedule=report_pipeline&limit=1" \
+  | jq '.[0] | {run_id, status, tasks: .tasks | map({name, status})}'
+```
+
+You'll see something like:
+
+```json
+{
+  "run_id": "20260510T...-...",
+  "status": "running",
+  "tasks": [
+    { "name": "extract",   "status": "succeeded" },
+    { "name": "transform", "status": "running" },
+    { "name": "load",      "status": "queued" }
+  ]
+}
+```
+
+Now cancel:
+
+```bash
+RUN_ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs?schedule=report_pipeline&limit=1" \
+  | jq -r '.[0].run_id')
+
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs/$RUN_ID/cancel" | jq .
+```
+
+```json
+{
+  "run_id": "20260510T...",
+  "worker_id": "worker-A",
+  "was_claimed": true,
+  "status": "canceled"
+}
+```
+
+The worker holding `transform` receives the cancel SSE message within
+milliseconds, kills the sleep via SIGTERM, and logs:
+
+```
+INFO control: canceling run run_id=20260510T...
+ERROR shell task failed task=transform error="signal: terminated"
+```
+
+The projection's per-task state stays sticky — `transform` reports
+`canceled`, not `failed`, even though the SIGTERM'd shell emitted
+a failure event after.
+
+### 6. Resume
+
+The operator's "I fixed the underlying issue, pick up where we
+stopped" path. Re-enqueues a new run with the already-succeeded tasks
+filtered out:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs/$RUN_ID/resume" | jq .
+```
+
+```json
+{
+  "original_run_id": "20260510T...A",
+  "new_run_id":      "20260510T...B",
+  "schedule":        "report_pipeline",
+  "skipped_tasks":   ["extract"]
+}
+```
+
+The new run has only `transform` and `load`. `transform`'s
+`Depends` was rewired (the only entry, `extract`, was filtered) so
+it becomes a fresh DAG entry point. `load`'s `Depends=["transform"]`
+is preserved.
+
+(`/resume` replays the *stored payload*, not the current HCL. If your
+"fix" was a config change, hit `POST /v1/schedules/{name}/trigger`
+instead — that fires a fresh run from current HCL.)
+
+### 7. Compare with /retry
+
+`/retry` re-enqueues the **whole** DAG from scratch — including
+`extract`, which would re-run. Useful when the original output is
+suspect; wasteful when only the failing leaf needs rework.
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs/$RUN_ID/retry" | jq .
+```
+
+## Operational notes
+
+- **Worker liveness**: a worker that disappears (process killed,
+  network gone) shows up in `/v1/workers` as `status: stale` after
+  ~2 minutes. Its in-flight jobs are reaped by the visibility-timeout
+  janitor every 10s and become claimable again.
+- **Three persistent connections per worker**: long-poll `/v1/jobs`
+  for dispatch, SSE `/v1/workers/{id}/control` for cancel signals,
+  short-lived `POST /v1/events` for shipping log events back. No
+  hidden queues, no broker watchdog.
+- **State on disk**: `<--path-dir>/.cronicle/state.db` (SQLite, WAL
+  mode). One file holds the queue, the projection, and the worker
+  registry. `sqlite3 .cronicle/state.db '.tables'` to inspect.
+
+## Migrating from v0.4.x Redis/NSQ
+
+If you were running `cronicle run --queue redis --addr ...`, the
+migration is:
+
+```bash
+# old
+cronicle run --queue redis --addr 127.0.0.1:6379
+cronicle worker --queue redis --addr 127.0.0.1:6379
+
+# new
+cronicle run --listen :8765 --listen-token "$TOKEN"
+cronicle worker --producer http://localhost:8765 --producer-token "$TOKEN"
+```
+
+No external broker; the producer is the queue.

--- a/deploy/distributed/README.md
+++ b/deploy/distributed/README.md
@@ -224,6 +224,85 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   "http://localhost:8765/v1/runs/$RUN_ID/retry" | jq .
 ```
 
+### 8. Cancel scope (or: "does cancel stop everything?")
+
+No — cancel is scoped to one `run_id`. Each fire of each schedule gets
+its own run_id, its own queue row, its own per-run context on the
+worker, its own SSE message routed by run_id. Other schedules in the
+same HCL file keep running.
+
+To see this concretely: while the ETLs are firing every 30s, fire
+`report_pipeline` and cancel it mid-`transform`. The next ETL tick
+arrives normally; workers claim and execute it untouched.
+
+```bash
+# fire report_pipeline
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8765/v1/schedules/report_pipeline/trigger > /dev/null
+sleep 2
+RID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs?schedule=report_pipeline&limit=1" \
+  | jq -r '.[0].run_id')
+
+# cancel just that run_id
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs/$RID/cancel" > /dev/null
+
+# wait one tick, check that ETLs are still firing
+sleep 35
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/v1/runs?status=succeeded&limit=5" \
+  | jq -r '.[] | "\(.schedule)  \(.status)  \(.run_id)"'
+```
+
+You'll see the canceled `report_pipeline` next to fresh `etl_*`
+successes — the ETLs were never touched.
+
+The same scoping applies in reverse: a worker can hold multiple
+in-flight runs simultaneously (one per claimed job, each with its own
+`context.CancelFunc` keyed by `run_id`), and canceling one cancels
+exactly one.
+
+### 9. Inspecting state directly
+
+The producer's state lives in a single SQLite file. `sqlite3` works
+on it without locking the producer (WAL mode, concurrent readers
+are fine):
+
+```bash
+DB=.cronicle/state.db
+
+# tables
+sqlite3 "$DB" '.tables'
+#   events  jobs  runs  schema_versions  tasks  workers
+
+# recent runs by status
+sqlite3 -header -column "$DB" "
+  SELECT schedule, status, COUNT(*) AS n
+  FROM runs
+  WHERE started_at > datetime('now', '-1 hour')
+  GROUP BY schedule, status
+  ORDER BY schedule, status;
+"
+
+# what's pending in the queue right now
+sqlite3 -header "$DB" "
+  SELECT run_id, schedule, status, claimed_by, attempt
+  FROM jobs WHERE status IN ('pending', 'claimed')
+  ORDER BY enqueued_at;
+"
+
+# worker registry
+sqlite3 -header "$DB" "
+  SELECT worker_id, current_run, runs_total, runs_failed, last_seen
+  FROM workers ORDER BY last_seen DESC;
+"
+```
+
+Useful when you want a quick local query without going through the
+HTTP API, or when the listener is intentionally off and you still
+want a postmortem.
+
 ## Operational notes
 
 - **Worker liveness**: a worker that disappears (process killed,

--- a/deploy/distributed/cronicle.hcl
+++ b/deploy/distributed/cronicle.hcl
@@ -1,0 +1,61 @@
+// Distributed-mode demo. Three short ETL-style schedules that fire on
+// the same minute boundary, plus one manually-triggered long-running
+// schedule for the cancel/retry/resume walkthrough.
+//
+// With 2+ workers running, the three ETLs fan out — each worker
+// claims a different one. With a single worker, they execute serially
+// in claim order. Either way the projection at /v1/runs reflects who
+// ran what.
+heartbeat = "@every 30s"
+
+schedule "etl_users" {
+  cron = "@every 30s"
+  task "run" {
+    command = ["/bin/sh", "-c", "echo 'etl: users'; sleep 3; echo done"]
+    depends = null
+    env     = null
+  }
+}
+
+schedule "etl_orders" {
+  cron = "@every 30s"
+  task "run" {
+    command = ["/bin/sh", "-c", "echo 'etl: orders'; sleep 3; echo done"]
+    depends = null
+    env     = null
+  }
+}
+
+schedule "etl_events" {
+  cron = "@every 30s"
+  task "run" {
+    command = ["/bin/sh", "-c", "echo 'etl: events'; sleep 3; echo done"]
+    depends = null
+    env     = null
+  }
+}
+
+// Multi-step pipeline for cancel + resume demos. `extract` succeeds
+// quickly, `transform` is the slow step (cancel here), `load` is the
+// downstream that resume picks up.
+schedule "report_pipeline" {
+  cron = ""
+
+  task "extract" {
+    command = ["/bin/sh", "-c", "echo extracting; sleep 1; echo done"]
+    depends = null
+    env     = null
+  }
+
+  task "transform" {
+    command = ["/bin/sh", "-c", "echo transforming; sleep 30; echo done"]
+    depends = ["extract"]
+    env     = null
+  }
+
+  task "load" {
+    command = ["/bin/sh", "-c", "echo loading; sleep 1; echo done"]
+    depends = ["transform"]
+    env     = null
+  }
+}

--- a/deploy/mcp-demo/README.md
+++ b/deploy/mcp-demo/README.md
@@ -1,0 +1,145 @@
+# MCP + skills + scratch (one task, all three features)
+
+A minimal working example of cronicle's three agent-side composables
+in one task:
+
+| Feature | What it does here |
+|---------|-------------------|
+| `mcp`   | Launches `@modelcontextprotocol/server-filesystem` as a subprocess; agent gets `fs__list_directory`, `fs__read_text_file`, etc. scoped to `data/` |
+| `skills` | `file-summarizer/SKILL.md` defines the one-paragraph digest style; loaded on demand via `load_skill` (progressive disclosure) |
+| `${scratch}` | Schedule-scoped output dir the agent writes `SUMMARY.md` to |
+
+No credentials. The filesystem MCP server runs without auth and is
+restricted to the path passed as its argument — here `${path}/data`,
+the `data/` directory next to `cronicle.hcl`.
+
+## Layout
+
+```
+deploy/mcp-demo/
+├── cronicle.hcl
+├── data/                          # what the MCP server can see
+│   ├── architecture-note.md
+│   ├── operator-checklist.md
+│   └── release-notes.md
+└── skills/
+    └── file-summarizer/
+        └── SKILL.md
+```
+
+## Prereqs
+
+- **`ANTHROPIC_API_KEY`** in env (agent tasks need it).
+- **Node 18+** with `npx` on PATH. `npx -y @modelcontextprotocol/server-filesystem`
+  installs the server lazily on the first run; subsequent runs use the
+  cached version. If you want to pre-warm: `npx -y @modelcontextprotocol/server-filesystem --version`.
+- **cronicle v0.5.0+**.
+
+## Run it
+
+Foreground (single-process, in-memory queue, run completes when the
+agent task completes):
+
+```bash
+cd deploy/mcp-demo
+export ANTHROPIC_API_KEY=...
+
+cronicle exec \
+  --path ./cronicle.hcl \
+  --schedule mcp_demo \
+  --task summarize
+```
+
+You'll see the agent boot the MCP server, list and read files via
+`fs__*` tools, and finally write to scratch via `text_editor`. The
+final block looks like this:
+
+```
+agent run · schedule=mcp_demo · task=summarize · model=claude-haiku-4-5 · skills=[file-summarizer]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+→ fs.list_directory: /Users/.../deploy/mcp-demo/data
+← exit=0 12ms
+→ fs.read_text_file: release-notes.md
+← exit=0 8ms
+→ fs.read_text_file: architecture-note.md
+← exit=0 7ms
+→ fs.read_text_file: operator-checklist.md
+← exit=0 6ms
+→ editor: create .cronicle/scratch/mcp_demo/.../SUMMARY.md
+← exit=0 4ms
+
+SUMMARY WRITTEN.
+
+[1234 in / 280 out tokens · $0.001823 · 4521ms · stop=end_turn]
+```
+
+The `SUMMARY.md` lands under `.cronicle/scratch/mcp_demo/<run-id>/`.
+
+## What's actually being demonstrated
+
+- **MCP wiring is real.** The agent's tool universe is cronicle's
+  built-in `text_editor` + `load_skill` PLUS the MCP server's tools
+  (`fs__list_directory`, `fs__read_text_file`, `fs__read_multiple_files`,
+  `fs__search_files`, `fs__write_file`, `fs__create_directory`,
+  `fs__directory_tree`, etc.). The server is launched at run time, the
+  schemas are translated from MCP's JSON-Schema into Anthropic's
+  schema format, and the agent calls them like any built-in tool.
+- **Skills load on demand.** The frontmatter (name + description)
+  is appended to the system prompt up front. The body (the
+  `# When to use`, `## How to summarize`, `## Output format` sections
+  of `file-summarizer/SKILL.md`) only loads when the agent calls
+  `load_skill`. That's the progressive-disclosure pattern from
+  Anthropic's Skills standard.
+- **`${scratch}` resolves at execution time.** The HCL `prompt`
+  contains the literal `${scratch}`; cronicle substitutes it with
+  the per-run directory before sending the request. The
+  schedule-scoped scratch dir is created automatically; if you add
+  multiple tasks to this schedule, they all share the same dir.
+
+## Comparing with the other examples
+
+- [**`deploy/distributed/`**](../distributed/README.md) — same control
+  surface (cancel, retry, resume, workers), but pure shell tasks.
+  No agents, no MCP. Use this for "how does the broker-less queue
+  work?"
+- [**`deploy/daily-report/`**](../daily-report/README.md) — fully
+  agentic workflow (4 crawler agents + a composer), uses `${scratch}`
+  and `skills` extensively, references MCP servers in commented
+  blocks (slack, gmail, discord — they need credentials so they're
+  documentation-only). Use this for "how do I compose a multi-agent
+  pipeline?"
+- **This example** — the smallest possible working demonstration of
+  a *live* MCP server. Start here, then layer it into one of the
+  others.
+
+## Running this in distributed mode
+
+The HCL is the same. Add `--listen + --listen-token` to make the
+producer expose the API, run a worker, and trigger the schedule via
+the listener:
+
+```bash
+# terminal 1: producer
+export ANTHROPIC_API_KEY=...
+export CRONICLE_LISTEN_TOKEN=demo-token
+cronicle run \
+  --path ./cronicle.hcl \
+  --listen :8765 --listen-token "$CRONICLE_LISTEN_TOKEN" \
+  --worker=false
+
+# terminal 2: worker (also needs ANTHROPIC_API_KEY for the agent)
+export ANTHROPIC_API_KEY=...
+cronicle worker \
+  --path ./ \
+  --producer http://localhost:8765 \
+  --producer-token "$CRONICLE_LISTEN_TOKEN" \
+  --worker-id w1
+
+# terminal 3: fire the trigger
+curl -X POST -H "Authorization: Bearer $CRONICLE_LISTEN_TOKEN" \
+  http://localhost:8765/v1/schedules/mcp_demo/trigger
+```
+
+The worker boots the MCP server in its own process; the producer
+just dispatches the job.

--- a/deploy/mcp-demo/cronicle.hcl
+++ b/deploy/mcp-demo/cronicle.hcl
@@ -1,0 +1,75 @@
+// Live MCP demo. One agent task using cronicle's three composable
+// features together:
+//   - mcp     — a real Model Context Protocol server launched at run time
+//   - skills  — Anthropic Agent Skill that tells the model how to work
+//   - scratch — shared output dir written by the agent
+//
+// The MCP server is `@modelcontextprotocol/server-filesystem`, the
+// official no-auth filesystem server. It's installed lazily by `npx -y`
+// on the first run, so no manual setup. The agent gets list/read/search
+// capabilities scoped to `data/` (passed as an arg to the server) and
+// summarizes the files it finds.
+//
+// Prereqs:
+//   - ANTHROPIC_API_KEY in env (`cronicle exec` and `cronicle run` both
+//     need it for agent tasks)
+//   - npx on PATH (Node 18+; comes with node, available in most
+//     Linux/macOS environments)
+//
+// Run it foreground for the simplest demo:
+//
+//   export ANTHROPIC_API_KEY=...
+//   cronicle exec --path ./cronicle.hcl --task summarize --schedule mcp_demo
+
+schedule "mcp_demo" {
+  cron = ""   // manual trigger only
+
+  task "summarize" {
+    agent {
+      // The skill defines the *style* of the summary the agent
+      // produces. Skills are discovered via their YAML frontmatter
+      // (name + description) which is appended to the system prompt;
+      // bodies load on demand via the load_skill tool.
+      skills = ["skills/file-summarizer/SKILL.md"]
+
+      prompt = <<-EOT
+        You have read-only access to a `data/` directory via the
+        `fs` MCP server. Use fs__list_directory and
+        fs__read_text_file (or read_multiple_files) to inspect the
+        files there.
+
+        Follow the file-summarizer skill to produce a one-paragraph
+        digest. Write the result to ${scratch}/SUMMARY.md using the
+        text_editor tool. Reply: SUMMARY WRITTEN.
+      EOT
+
+      model = "claude-haiku-4-5"
+
+      // Tools allowlist (Anthropic-defined tools only).
+      //   - text_editor: writes the SUMMARY.md output to scratch
+      //
+      // load_skill is auto-registered when `skills` is non-empty;
+      // it doesn't appear here. MCP tools auto-register too — they
+      // arrive namespaced as <server-name>__<tool>, e.g.
+      // fs__list_directory, fs__read_text_file.
+      tools = ["text_editor"]
+
+      // Live MCP server. cronicle launches it as a subprocess at run
+      // time, speaks JSON-RPC over stdin/stdout, lists tools, and
+      // exposes them to the agent as `fs__*`. The server shuts down
+      // cleanly when the run ends.
+      //
+      // Note the second arg: the directory the server is allowed to
+      // touch. Use `${path}` so it resolves to this schedule's working
+      // directory (where data/ lives next to cronicle.hcl).
+      mcp "fs" {
+        command = ["npx", "-y", "@modelcontextprotocol/server-filesystem", "${path}/data"]
+      }
+
+      max_turns  = 8
+      wallclock  = "2m"
+      budget_usd = 0.05
+      max_tokens = 2000
+    }
+  }
+}

--- a/deploy/mcp-demo/data/architecture-note.md
+++ b/deploy/mcp-demo/data/architecture-note.md
@@ -1,0 +1,19 @@
+# State plane architecture (excerpt)
+
+The producer process owns three responsibilities:
+1. **Scheduling** — `robfig/cron` ticks fire `ProduceSchedule` to push
+   schedule JSON onto a queue (in-memory chan or SQLite jobs table).
+2. **State** — slog handler chain tees every event into the projection,
+   so the runs/tasks/events tables always reflect what slog wrote.
+3. **Control** — the HTTP listener exposes triggers, run queries,
+   cancel/retry/resume, the worker registry, and the SSE channel.
+
+Workers are HTTP clients only. They long-poll `/v1/jobs`, run the
+DAG, ship events back via `POST /v1/events`, ack via `POST
+/v1/jobs/{id}/ack`. The SSE channel `/v1/workers/{id}/control`
+gives them low-latency cancel preemption.
+
+The atomic claim primitive is `BEGIN IMMEDIATE; UPDATE jobs SET
+status='claimed' WHERE id=? AND status='pending'`. SQLite WAL
+serializes concurrent writers, so two workers racing on one row
+can't both win — the `WHERE` clause filters the loser.

--- a/deploy/mcp-demo/data/operator-checklist.md
+++ b/deploy/mcp-demo/data/operator-checklist.md
@@ -1,0 +1,19 @@
+# Operator checklist — first 10 minutes with cronicle
+
+Before you ship a production schedule:
+
+- [ ] `cronicle init --path ./cron` and version-control the result.
+- [ ] Pin a known-good binary via `CRONICLE_VERSION=v0.5.0` (or whatever
+  release you've validated) when installing on production hosts.
+- [ ] Set `CRONICLE_LISTEN_TOKEN` and pass `--listen-token "$TOKEN"`.
+  An open trigger endpoint on an unattended cron service is a
+  foot-cannon; the listener refuses to bind without a token anyway.
+- [ ] For distributed mode: `--worker=false` on the producer if all
+  execution should go to remote workers.
+- [ ] `--log-to-file` if you want the on-disk audit trail
+  (`.cronicle/log/cronicle.jsonl`, rotated by lumberjack).
+- [ ] Plan how cancel propagates: shell tasks honor `ctx` via
+  `exec.CommandContext`; agent tasks honor `ctx.Done()` between
+  turns. Tool calls in flight finish before the next check.
+- [ ] Decide whether you need `${scratch}` cross-task context or
+  whether each task should be standalone.

--- a/deploy/mcp-demo/data/release-notes.md
+++ b/deploy/mcp-demo/data/release-notes.md
@@ -1,0 +1,13 @@
+# cronicle v0.5.0 — release highlights
+
+- Broker-less distributed mode: SQLite-backed jobs queue, workers
+  consume via HTTP long-poll. Redis/NSQ support removed.
+- State plane: every fire of a schedule gets a `run_id` and is
+  projected into `.cronicle/state.db` for `/v1/runs` queries.
+- Cancel / retry / resume verbs on the listener API. Resume skips
+  already-succeeded tasks and re-runs the rest.
+- Worker registry at `/v1/workers` with derived status
+  (active / idle / stale).
+- SSE control channel for low-latency cancel signal routing.
+- `pkg/exec` consolidated around `os/exec.CommandContext`; shell
+  tasks now honor per-run cancellation.

--- a/deploy/mcp-demo/skills/file-summarizer/SKILL.md
+++ b/deploy/mcp-demo/skills/file-summarizer/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: file-summarizer
+description: |
+  Read one or more text files and produce a single-paragraph digest in
+  a consistent voice. Use when the operator wants a quick survey of a
+  directory's contents rather than per-file summaries.
+---
+
+# file-summarizer
+
+## When to use
+
+Use this skill when you've been given a directory (typically via the
+`fs__list_directory` and `fs__read_text_file` tools from the MCP
+filesystem server) and the operator wants one summary covering all
+of it, not file-by-file digests.
+
+## How to summarize
+
+- **One paragraph, 80–120 words.** Resist the urge to bullet — this
+  is a digest, not a manifest.
+- **Lead with the through-line.** What do these files have in common?
+  Where do they diverge? Open the paragraph with that frame.
+- **Name files inline** when a specific file carries a key point.
+  Use the basename only (e.g. `release-notes.md`), not the full path.
+- **No meta commentary.** Don't write "this directory contains…".
+  Write the digest as if it were going into a status report.
+
+## Output format
+
+Write to `${scratch}/SUMMARY.md` with exactly this shape:
+
+```markdown
+# File summary — <YYYY-MM-DD>
+
+<one paragraph, 80–120 words>
+
+---
+_files_: <comma-separated basenames>
+```
+
+Replace `<YYYY-MM-DD>` with today's date and `<comma-separated basenames>`
+with the file names you actually read.
+
+## When NOT to use
+
+If the operator asks for "summaries" plural (one per file) or
+"what's in each file," do that instead — this skill is the
+single-paragraph variant.

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -232,7 +232,20 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	// them down. Failures here abort the run before any API call. We close
 	// handles in the deferred path below regardless of how the run exits,
 	// so a panic or budget abort still cleans up subprocesses.
-	mcpHandles, mcpTools, mcpErr := LaunchMCPServers(runCtx, task.Agent.MCPs, task.Env, toolWriter)
+	//
+	// Apply the same template-var substitution shell tasks get to each
+	// MCP server's command args. Lets HCL like
+	//   mcp "fs" { command = ["npx", "...", "${path}/data"] }
+	// resolve to the task's working directory at launch time.
+	mcps := make([]MCP, len(task.Agent.MCPs))
+	for i, m := range task.Agent.MCPs {
+		mcps[i] = m
+		mcps[i].Command = make([]string, len(m.Command))
+		for j, c := range m.Command {
+			mcps[i].Command[j] = r.Replace(c)
+		}
+	}
+	mcpHandles, mcpTools, mcpErr := LaunchMCPServers(runCtx, mcps, task.Env, toolWriter)
 	if mcpErr != nil {
 		return exec.Result{
 			Command:    []string{"agent", task.Agent.Model},

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -39,6 +39,11 @@ var (
 			// token, then exec.go substitutes the schedule-scoped
 			// scratch dir path at run time.
 			"scratch": cty.StringVal("${scratch}"),
+			// path is the task working directory (typically the
+			// schedule's repo clone or the cronicle config dir).
+			// Used in mcp { command = ["...", "${path}/data"] }
+			// patterns where the server needs a real filesystem path.
+			"path": cty.StringVal("${path}"),
 		},
 	}
 

--- a/internal/cronicle/parse_test.go
+++ b/internal/cronicle/parse_test.go
@@ -20,7 +20,7 @@ import (
 
 var _ = Describe("Parse", func() {
 
-	It("cronicle.CommandEvalContext should contain date, datetime, timestamp, and scratch as arguments", func() {
+	It("cronicle.CommandEvalContext should contain date, datetime, timestamp, scratch, and path as arguments", func() {
 
 		expected := hcl.EvalContext{
 			Variables: map[string]cty.Value{
@@ -28,6 +28,7 @@ var _ = Describe("Parse", func() {
 				"datetime":  cty.StringVal("${datetime}"),
 				"timestamp": cty.StringVal("${timestamp}"),
 				"scratch":   cty.StringVal("${scratch}"),
+				"path":      cty.StringVal("${path}"),
 			},
 		}
 		Expect(cronicle.CommandEvalContext).To(Equal(expected))


### PR DESCRIPTION
A copy-pasteable example for v0.5.0's broker-less distributed mode. Replaces what `deploy/redis` and `deploy/nsq` used to demonstrate; this time the producer IS the queue.

## What's in
- **`deploy/distributed/cronicle.hcl`** — 3 ETL schedules on `@every 30s` (for fan-out demo) + 1 manually-triggered `report_pipeline` (extract → transform → load) with a 30s sleep on transform (for cancel/resume demo).
- **`deploy/distributed/README.md`** — full walkthrough with curl examples for `/v1/workers`, `/v1/runs`, cancel, retry, resume. Covers the key honest detail: `/resume` replays the stored payload, not the live HCL.
- Top-level README's example list lifted to put this demo first.

## End-to-end verified
- 2 workers up → ETLs fanned out across them (A=1 run, B=2 runs from 3 fires)
- `report_pipeline` trigger → `extract` succeeded, `transform` running
- Cancel mid-`transform` → projection sticky-canceled
- Resume → new run with `skipped_tasks=["extract"]`, `transform` and `load` re-queued, `transform.Depends` rewired (was `["extract"]`, now empty)

## Why a third "deploy/" example
- `deploy/local` shows the log-pipeline side
- `deploy/daily-report` shows the agent-fanout side
- `deploy/distributed` shows the runtime / control-plane side

The three together cover the operator surface the v0.5.0 release notes promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)