### PR TITLE
Three-plane live event stream: pretty SSE + Loki + slim state

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ set `CRONICLE_LISTEN_TOKEN` in the environment.
 | POST   | `/v1/schedules/{name}/tasks/{task}/trigger`            | Fire one task (depends stripped)     |
 | GET    | `/v1/runs`                                             | List recent runs (filterable)        |
 | GET    | `/v1/runs/{run_id}`                                    | Single run + per-task detail         |
+| GET    | `/v1/runs/{run_id}/events`                             | SSE: live, pretty-rendered task output |
 | POST   | `/v1/events`                                           | JSONL ingest (batched events)        |
 | GET    | `/v1/jobs?worker=&block=`                              | Long-poll job claim                  |
 | POST   | `/v1/jobs/{run_id}/ack`                                | Worker reports completion            |
@@ -539,6 +540,54 @@ Response shape (list):
 `cronicle exec` uses an in-memory projection (the run is foreground, you
 are watching it; nothing later queries the DB). `cronicle run` opens
 `.cronicle/state.db` in WAL mode and persists across restarts.
+
+### Live event stream (GET /v1/runs/{run_id}/events)
+
+Server-Sent Events stream of the live task output as it happens. The
+wire bytes are whatever `--live-format` produces — pretty by default,
+which means ANSI-colored multi-line text identical to what a TTY would
+show when running cronicle locally. Frontends with a terminal-emulator
+widget (e.g. xterm.js) render the stream as a faithful mirror of the
+producer's console.
+
+```bash
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8765/v1/runs/$RUN_ID/events
+# event: cronicle
+# data: hello from tick
+#
+# event: cronicle
+# data: step 2
+# ...
+```
+
+`--live-format` toggles the wire encoding:
+
+| flag                  | wire bytes                                                                |
+|-----------------------|---------------------------------------------------------------------------|
+| `--live-format=pretty` | ANSI multi-line — for xterm.js / TTY clients (default)                   |
+| `--live-format=json`   | one JSON object per record — for programmatic consumers                  |
+| `--live-format=text`   | `time=... level=INFO msg=... key=val` — for plain log viewers            |
+
+Architecture: cronicle keeps three planes for run telemetry, each tuned
+to a different consumer:
+
+| Plane         | Source                                       | Use case                                |
+|---------------|----------------------------------------------|-----------------------------------------|
+| **State**     | SQLite `runs` / `tasks` tables               | Red/green/blue status, filterable list  |
+| **History**   | `cronicle.jsonl` → Loki + on-disk transcripts | Search & debug past runs                |
+| **Live (this)** | LiveSink in-memory pub/sub                 | "What's happening right now?" — token-by-token, line-by-line |
+
+The live stream is **live-only**. Disconnect = miss. If your tab drops
+mid-task and reconnects, you start from "now"; switch to the Loki pane
+in your UI for the missed window. This keeps the server stateless and
+the wire format trivial.
+
+Cross-plane linking: every record in the JSONL log (and therefore in
+Loki) carries `seq` (per-process monotonic int64) and `lifetime`
+(8-char hex nonce per producer process) attrs injected by the top-of-
+chain `state.Tagger`. A frontend can deep-link from a live frame to
+a Loki query scoped to the same `lifetime`+`seq` neighborhood.
 
 ### Posting events directly (POST /v1/events)
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ When `--log-to-file` is on, each task execution also writes a per-run JSONL tran
 * [MCP + skills + scratch in one task — minimal live demo](deploy/mcp-demo/README.md)
 * [Daily-report agent fan-out + composer demo](deploy/daily-report/README.md)
 * [Centralize cronicle logs on a local loki/graphana log aggregator](deploy/local/README.md)
+* [SSE live-stream demo — per-run, per-schedule, firehose filters](deploy/sse-demo/README.md)
 
 
 ---
@@ -580,13 +581,104 @@ event: cronicle
 data: step 2
 ```
 
-`--live-format` toggles the wire encoding:
+Multi-line records (a pretty-rendered shell_run header, or an agent text
+delta containing `\n`) become one event with multiple `data:` lines per
+the SSE spec — browser `EventSource` joins them with `\n` automatically.
 
-| flag                  | wire bytes                                                                |
-|-----------------------|---------------------------------------------------------------------------|
-| `--live-format=pretty` | ANSI multi-line — for xterm.js / TTY clients (default)                   |
-| `--live-format=json`   | one JSON object per record — for programmatic consumers                  |
-| `--live-format=text`   | `time=... level=INFO msg=... key=val` — for plain log viewers            |
+#### Filter scope — when to use which endpoint
+
+| You want | Endpoint | Notes |
+|---|---|---|
+| Watch one specific in-flight run (operator clicked it from a list) | `GET /v1/runs/{run_id}/events` | Drill-in. Requires `run_id` to already exist — won't help for the next run. |
+| Watch every run of a schedule, including the next one before it fires | `GET /v1/schedules/{name}/events` | Subscribe BEFORE triggering. The handler routes by schedule name, so a run that doesn't have a `run_id` yet still delivers frames the moment it starts emitting. |
+| Operator dashboard — every run on every schedule | `GET /v1/events/stream` | Firehose. Concurrent runs interleave by event-time. |
+
+All three share the same SSE plumbing — same wire format, same `--live-format` controlling the encoding, same 15s `: ping` heartbeat. Frontend code differs only in the URL.
+
+#### Worked example — multi-schedule walkthrough
+
+Set up a `cronicle.hcl` with three schedules:
+
+```hcl
+schedule "heartbeat" {
+  cron = "@every 10s"
+  task "tick" {
+    command = ["sh", "-c", "echo 'tick'; sleep 1; echo 'second line'"]
+  }
+}
+
+schedule "long-build" {
+  cron = ""  // manual trigger
+  task "compile" {
+    command = ["sh", "-c", "for s in fetching compiling linking testing done; do echo \"[step] $s\"; sleep 1; done"]
+  }
+}
+
+schedule "story" {
+  cron = ""  // manual trigger
+  task "tell" {
+    agent {
+      prompt    = "Tell a two-sentence story about an octopus debugging Go."
+      model     = "claude-haiku-4-5"
+      max_turns = 1
+    }
+  }
+}
+```
+
+```bash
+cronicle run --path cronicle.hcl --listen :7766 --listen-token smoke
+```
+
+**Per-run** — trigger `long-build`, capture its `run_id`, subscribe to just that one:
+
+```bash
+curl -X POST -H "Authorization: Bearer smoke" \
+     http://localhost:7766/v1/schedules/long-build/trigger
+RUN_ID=$(curl -s -H "Authorization: Bearer smoke" \
+     "http://localhost:7766/v1/runs?status=running&limit=1" | jq -r '.[0].run_id')
+curl -N -H "Authorization: Bearer smoke" \
+     "http://localhost:7766/v1/runs/$RUN_ID/events"
+```
+
+Frames you'll see: `shell_run_start` (header rule + command), six `stdout_chunk` lines (`[step] fetching` …), footer `[exit=0 · 6062ms · transcript=…]`, `schedule_complete` ✓.
+
+**Per-schedule** — open SSE first, then trigger twice. Both runs flow through one connection:
+
+```bash
+( curl -N -H "Authorization: Bearer smoke" \
+       http://localhost:7766/v1/schedules/long-build/events ) &
+sleep 0.2
+curl -X POST -H "Authorization: Bearer smoke" \
+     http://localhost:7766/v1/schedules/long-build/trigger
+sleep 7
+curl -X POST -H "Authorization: Bearer smoke" \
+     http://localhost:7766/v1/schedules/long-build/trigger
+```
+
+Two full run sequences come down the same stream — `schedule_start` / `shell_run_start` / chunks / footer / `schedule_complete`, then the second run's identical sequence. No polling for the second run's `run_id`.
+
+**Firehose** — interleave heartbeat (auto-firing every 10s) with a manual `story` trigger:
+
+```bash
+( curl -N -H "Authorization: Bearer smoke" \
+       http://localhost:7766/v1/events/stream ) &
+sleep 0.2
+curl -X POST -H "Authorization: Bearer smoke" \
+     http://localhost:7766/v1/schedules/story/trigger
+```
+
+The stream interleaves `heartbeat`'s shell output with `story`'s agent `text_delta` tokens by event-time — you'll see frames from both runs alternating as they fire. That's the operator-dashboard view.
+
+#### Wire format toggle (`--live-format`)
+
+`--live-format` controls the bytes inside `data:` lines. Set at startup; the same format applies to every SSE consumer regardless of endpoint.
+
+| flag                   | wire bytes                                                       | best for |
+|------------------------|------------------------------------------------------------------|---|
+| `--live-format=pretty` | ANSI multi-line (default)                                        | xterm.js / TTY clients |
+| `--live-format=json`   | one JSON object per record (same shape as `cronicle.jsonl`)       | programmatic consumers, custom UIs |
+| `--live-format=text`   | `time=... level=INFO msg=... key=val`                            | plain log viewers, debugging |
 
 Architecture: cronicle keeps three planes for run telemetry, each tuned
 to a different consumer:

--- a/README.md
+++ b/README.md
@@ -464,7 +464,9 @@ set `CRONICLE_LISTEN_TOKEN` in the environment.
 | POST   | `/v1/schedules/{name}/tasks/{task}/trigger`            | Fire one task (depends stripped)     |
 | GET    | `/v1/runs`                                             | List recent runs (filterable)        |
 | GET    | `/v1/runs/{run_id}`                                    | Single run + per-task detail         |
-| GET    | `/v1/runs/{run_id}/events`                             | SSE: live, pretty-rendered task output |
+| GET    | `/v1/runs/{run_id}/events`                             | SSE: live frames for one run         |
+| GET    | `/v1/schedules/{name}/events`                          | SSE: live frames for every run of a schedule (incl. next run) |
+| GET    | `/v1/events/stream`                                    | SSE: firehose — every run on every schedule |
 | POST   | `/v1/events`                                           | JSONL ingest (batched events)        |
 | GET    | `/v1/jobs?worker=&block=`                              | Long-poll job claim                  |
 | POST   | `/v1/jobs/{run_id}/ack`                                | Worker reports completion            |
@@ -541,24 +543,41 @@ Response shape (list):
 are watching it; nothing later queries the DB). `cronicle run` opens
 `.cronicle/state.db` in WAL mode and persists across restarts.
 
-### Live event stream (GET /v1/runs/{run_id}/events)
+### Live event stream
 
-Server-Sent Events stream of the live task output as it happens. The
-wire bytes are whatever `--live-format` produces — pretty by default,
-which means ANSI-colored multi-line text identical to what a TTY would
-show when running cronicle locally. Frontends with a terminal-emulator
-widget (e.g. xterm.js) render the stream as a faithful mirror of the
-producer's console.
+Server-Sent Events stream of task output as it happens — token-by-token
+for agents, line-by-line for shell. The wire bytes are whatever
+`--live-format` produces (default `pretty`: ANSI-colored multi-line
+text identical to what a TTY would show). Frontends with a terminal-
+emulator widget (e.g. xterm.js) render the stream as a faithful mirror
+of the producer's console.
+
+Three subscription scopes, each its own endpoint:
 
 ```bash
+# Drill into one specific run (only works after the run exists)
 curl -N -H "Authorization: Bearer $TOKEN" \
   http://localhost:8765/v1/runs/$RUN_ID/events
-# event: cronicle
-# data: hello from tick
-#
-# event: cronicle
-# data: step 2
-# ...
+
+# Watch every run of a schedule — including the NEXT run before its
+# run_id exists. Open this BEFORE triggering; the SSE handler routes
+# by schedule name, so the next-run's frames arrive without polling.
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8765/v1/schedules/daily/events
+
+# Firehose — every run on every schedule. Dashboard view.
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8765/v1/events/stream
+```
+
+A typical frame:
+
+```
+event: cronicle
+data: hello from tick
+
+event: cronicle
+data: step 2
 ```
 
 `--live-format` toggles the wire encoding:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,10 +31,17 @@ var cfgFile string
 // PersistentPreRun before any subcommand executes.
 var logFormat string
 
+// liveFormat is bound to the --live-format persistent flag. Sets the
+// wire encoding for the live SSE event stream (GET /v1/runs/{id}/events).
+// Default "pretty" emits ANSI-colored multi-line bytes that an xterm.js
+// frontend renders as a faithful TTY mirror.
+var liveFormat string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		cronicle.SetupLogging(cronicle.LogFormat(logFormat))
+		cronicle.SetLiveFormat(cronicle.LiveFormat(liveFormat))
 	},
 	Use:   "cronicle",
 	Short: "Cronicle is a distributed, git integrated cron based task engine.",
@@ -84,6 +91,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cronicle.yaml)")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "auto",
 		"stdout log format: auto (pretty if TTY, text if piped), pretty, text, or json")
+	rootCmd.PersistentFlags().StringVar(&liveFormat, "live-format", "pretty",
+		"wire format for the live SSE event stream (GET /v1/runs/{id}/events): pretty (ANSI, default), json, or text")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/deploy/sse-demo/README.md
+++ b/deploy/sse-demo/README.md
@@ -1,0 +1,112 @@
+# SSE live-stream demo
+
+Three schedules, three filter scopes — a fully-worked example of
+cronicle's live SSE event stream.
+
+```bash
+export ANTHROPIC_API_KEY=...     # only needed for the `story` agent task
+
+cronicle run \
+  --path deploy/sse-demo/cronicle.hcl \
+  --listen :7766 \
+  --listen-token smoke \
+  --log-to-file
+```
+
+`heartbeat` fires every 10s on its own; `long-build` and `story` are
+manual-trigger only (`cron = ""`).
+
+```bash
+TOKEN=smoke
+BASE=http://localhost:7766
+AUTH="Authorization: Bearer $TOKEN"
+```
+
+---
+
+## 1. Per-run drill-in — `/v1/runs/{run_id}/events`
+
+Use when the operator clicks a specific running run from a list.
+Requires the run_id to already exist.
+
+```bash
+# Fire long-build, race to capture its run_id
+curl -s -X POST -H "$AUTH" "$BASE/v1/schedules/long-build/trigger" > /dev/null
+RUN_ID=$(curl -s -H "$AUTH" "$BASE/v1/runs?status=running&limit=1" | jq -r '.[0].run_id')
+echo "watching $RUN_ID"
+
+# Subscribe to just this one run
+curl -N -H "$AUTH" "$BASE/v1/runs/$RUN_ID/events"
+```
+
+Expect: `shell_run_start` header rule, six `stdout_chunk` lines
+(`[step] fetching sources` … `[step] done`), footer
+`[exit=0 · 6062ms · transcript=…]`, then `✓ schedule complete`.
+
+---
+
+## 2. Per-schedule — `/v1/schedules/{name}/events`
+
+Subscribe BEFORE the run exists. Every run of the named schedule flows
+through the same connection.
+
+```bash
+# Open SSE first (background), then trigger twice
+curl -sN -H "$AUTH" "$BASE/v1/schedules/long-build/events" &
+sleep 0.2
+curl -s -X POST -H "$AUTH" "$BASE/v1/schedules/long-build/trigger" > /dev/null
+sleep 7   # let run 1 finish
+curl -s -X POST -H "$AUTH" "$BASE/v1/schedules/long-build/trigger" > /dev/null
+```
+
+Expect: full sequence for run 1 (`schedule_start` → header → 6 chunks →
+footer → `schedule_complete`), then the same sequence for run 2 — both
+on one stream, no polling needed.
+
+This solves the "open SSE before the run starts" chicken-and-egg
+because the filter key is the stable schedule name.
+
+---
+
+## 3. Firehose — `/v1/events/stream`
+
+Every run on every schedule. Frames from concurrent runs interleave by
+event-time, which is exactly what an operator dashboard wants.
+
+```bash
+curl -sN -H "$AUTH" "$BASE/v1/events/stream" &
+sleep 0.2
+curl -s -X POST -H "$AUTH" "$BASE/v1/schedules/heartbeat/trigger" > /dev/null
+curl -s -X POST -H "$AUTH" "$BASE/v1/schedules/story/trigger" > /dev/null
+```
+
+Expect: heartbeat's shell output (`tick from heartbeat`, `second line`)
+threaded through `story`'s agent text-delta tokens, plus any
+cron-auto-fired heartbeat ticks landing in the middle. All three
+schedules' bytes share one wire.
+
+---
+
+## Choosing the encoding (`--live-format`)
+
+| flag                   | wire bytes inside `data:`                     | best for |
+|------------------------|----------------------------------------------|---|
+| `--live-format=pretty` | ANSI multi-line (default)                    | xterm.js / TTY |
+| `--live-format=json`   | one compact JSON object per record           | structured frontends |
+| `--live-format=text`   | `time=... level=INFO msg=... key=val`        | plain log viewers |
+
+Set at startup; applies to every SSE endpoint regardless of scope.
+
+---
+
+## Notes
+
+- **Live means live.** SSE frames are not retained server-side. Drop
+  the connection and reconnect — you start from "now." For history of
+  past runs, query `cronicle.jsonl` (or Loki, if you ship it via the
+  pipeline in `deploy/local/`).
+- **Auth** is bearer-token, same as the trigger endpoints. The token
+  is set with `--listen-token` (or `CRONICLE_LISTEN_TOKEN`).
+- **Heartbeat ping** every 15s (`: ping <unix>`) keeps proxies from
+  killing idle connections. Browser EventSource clients ignore comment
+  lines automatically.

--- a/deploy/sse-demo/cronicle.hcl
+++ b/deploy/sse-demo/cronicle.hcl
@@ -1,0 +1,42 @@
+// Multi-schedule SSE demo. Three schedules exercise the three filter
+// scopes of /v1/runs/{id}/events, /v1/schedules/{name}/events, and
+// /v1/events/stream:
+//
+//   heartbeat  — short shell task, fires every 10s. Drives the firehose
+//                with regular background activity.
+//   long-build — longer shell task (6s of stdout). Manual trigger. Good
+//                for "subscribe before trigger" demos against the
+//                per-schedule endpoint.
+//   story      — agent task (text_delta streaming). Manual trigger.
+//                Shows token-by-token wire frames.
+
+schedule "heartbeat" {
+  cron = "@every 10s"
+
+  task "tick" {
+    command = ["sh", "-c", "echo 'tick from heartbeat'; sleep 1; echo 'second line'"]
+  }
+}
+
+schedule "long-build" {
+  cron = "" // manual trigger only
+
+  task "compile" {
+    command = ["sh", "-c", "for s in 'fetching sources' 'compiling foo.c' 'compiling bar.c' 'linking' 'running tests' 'done'; do echo \"[step] $s\"; sleep 1; done"]
+  }
+}
+
+schedule "story" {
+  cron = "" // manual trigger only
+
+  task "tell-a-story" {
+    agent {
+      prompt     = "Tell a very short, two-sentence story about an octopus debugging Go code."
+      model      = "claude-haiku-4-5"
+      max_turns  = 1
+      max_tokens = 200
+      budget_usd = 0.05
+      wallclock  = "30s"
+    }
+  }
+}

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -55,7 +55,7 @@ func (task *Task) Exec(t time.Time) exec.Result {
 
 		streaming := IsStreamingPretty()
 		var sw *StreamingWriter
-		var stdoutW, stderrW io.Writer
+		var stdoutInner, stderrInner io.Writer = io.Discard, io.Discard
 		if streaming {
 			// Per-task writer: leader streams to stdout, followers buffer.
 			// The shell command runs WITHOUT holding the global lock, so
@@ -64,9 +64,17 @@ func (task *Task) Exec(t time.Time) exec.Result {
 			defer sw.Close()
 			WriteShellRunHeader(sw, task.ScheduleName, task.Name, strings.Join(cmd, " "))
 			fmt.Fprintln(sw)
-			stdoutW = sw
-			stderrW = sw
+			stdoutInner = sw
+			stderrInner = sw
 		}
+
+		// Per-line slog emission feeds LiveSink (live SSE) and the JSONL
+		// log (→ Loki) regardless of stdout pretty mode. The frontend's
+		// live pane works even when cronicle's stdout is text/json.
+		stdoutEmitter := newLineEmitter(stdoutInner, task.RunID, task.Name, task.ScheduleName, "stdout")
+		stderrEmitter := newLineEmitter(stderrInner, task.RunID, task.Name, task.ScheduleName, "stderr")
+		defer stdoutEmitter.Flush()
+		defer stderrEmitter.Flush()
 
 		// Honor the per-run cancel context when one is plumbed in
 		// (HTTP-worker mode, /v1/runs/{id}/cancel preempt). Falls
@@ -77,11 +85,10 @@ func (task *Task) Exec(t time.Time) exec.Result {
 			runCtx = context.Background()
 		}
 		startedAt := time.Now()
-		if streaming {
-			result = exec.ExecuteWithStreamContext(runCtx, cmd, task.Path, task.Env, stdoutW, stderrW)
-		} else {
-			result = exec.ExecuteContext(runCtx, cmd, task.Path, task.Env)
-		}
+		// Always use the streaming entry point so per-line slog records
+		// fire; pkg/exec captures stdout/stderr into the Result either
+		// way, so the shell_run terminal event payload is unchanged.
+		result = exec.ExecuteWithStreamContext(runCtx, cmd, task.Path, task.Env, stdoutEmitter, stderrEmitter)
 		finishedAt := time.Now()
 		task.lastDurationMs = finishedAt.Sub(startedAt).Milliseconds()
 
@@ -179,6 +186,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		skillsAvailable = skillTool.Available()
 	}
 	var sw *StreamingWriter
+	var downstream agent.StreamHandler
 	if streaming {
 		// Per-task writer: the leader streams live to stdout; followers
 		// buffer and atomically flush on Close. agent.Run runs WITHOUT
@@ -188,8 +196,13 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 		defer sw.Close()
 		WriteAgentRunHeader(sw, task.ScheduleName, task.Name, effectiveModel, skillsAvailable)
 		fmt.Fprintln(sw)
-		cfg.StreamHandler = NewAgentStreamRenderer(sw)
+		downstream = NewAgentStreamRenderer(sw)
 	}
+	// Always wire the slog bridge so text_delta / thinking_delta /
+	// tool_use_start / tool_result / turn_start records flow to
+	// LiveSink (live SSE pane) and the JSONL log (→ Loki) regardless
+	// of stdout pretty mode.
+	cfg.StreamHandler = NewAgentSlogBridge(runID, task.Name, task.ScheduleName, downstream)
 
 	// Tools: bind to the task's workspace and stream writer so bash output
 	// flows into the agent's pretty block AND the cronicle execution

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -76,6 +76,20 @@ func (task *Task) Exec(t time.Time) exec.Result {
 		defer stdoutEmitter.Flush()
 		defer stderrEmitter.Flush()
 
+		// Header slog record carries the metadata pretty stdout would put
+		// in its bordered block (schedule, task, command). LiveSink's
+		// pretty encoder renders it as the header; stdout pretty mode
+		// suppresses it because StreamingWriter already wrote those bytes
+		// directly (above). file/Loki consumers see a structural record
+		// they can use to mark "task started" with full context.
+		slog.Info("shell run start",
+			"entry_type", "shell_run_start",
+			"run_id", task.RunID,
+			"schedule", task.ScheduleName,
+			"task", task.Name,
+			"command", strings.Join(cmd, " "),
+		)
+
 		// Honor the per-run cancel context when one is plumbed in
 		// (HTTP-worker mode, /v1/runs/{id}/cancel preempt). Falls
 		// through to context.Background() in default in-process mode
@@ -206,6 +220,20 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	// subscriptions on. The local `runID` is a separate agent-internal
 	// identifier used for the per-task transcript file name.
 	cfg.StreamHandler = NewAgentSlogBridge(task.RunID, task.Name, task.ScheduleName, downstream)
+
+	// Header slog record — carries schedule/task/model/skills metadata.
+	// LiveSink's pretty encoder renders this as the bordered header block;
+	// stdout pretty mode suppresses it because WriteAgentRunHeader (above)
+	// already wrote those bytes directly. file/Loki consumers see a
+	// structural "agent task started" record with full context.
+	slog.Info("agent run start",
+		"entry_type", "agent_run_start",
+		"run_id", task.RunID,
+		"schedule", task.ScheduleName,
+		"task", task.Name,
+		"model", effectiveModel,
+		"skills_available", skillsAvailable,
+	)
 
 	// Tools: bind to the task's workspace and stream writer so bash output
 	// flows into the agent's pretty block AND the cronicle execution

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -201,8 +201,11 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 	// Always wire the slog bridge so text_delta / thinking_delta /
 	// tool_use_start / tool_result / turn_start records flow to
 	// LiveSink (live SSE pane) and the JSONL log (→ Loki) regardless
-	// of stdout pretty mode.
-	cfg.StreamHandler = NewAgentSlogBridge(runID, task.Name, task.ScheduleName, downstream)
+	// of stdout pretty mode. We use task.RunID (the SCHEDULE run_id)
+	// for the slog records — that's what /v1/runs/{id}/events keys
+	// subscriptions on. The local `runID` is a separate agent-internal
+	// identifier used for the per-task transcript file name.
+	cfg.StreamHandler = NewAgentSlogBridge(task.RunID, task.Name, task.ScheduleName, downstream)
 
 	// Tools: bind to the task's workspace and stream writer so bash output
 	// flows into the agent's pretty block AND the cronicle execution

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -79,6 +79,7 @@ func startListener(addr, token string, queue chan<- []byte) {
 	mux.HandleFunc("/v1/schedules/", s.handleScheduleRoute)
 	mux.HandleFunc("/v1/runs", s.handleListRuns)
 	mux.HandleFunc("/v1/events", s.handleIngestEvents)
+	mux.HandleFunc("/v1/events/stream", s.handleEventsStream)
 	mux.HandleFunc("/v1/jobs", s.handleClaimJob)
 	mux.HandleFunc("/v1/jobs/", s.handleJobControl)
 	mux.HandleFunc("/v1/workers", s.handleListWorkers)
@@ -161,19 +162,18 @@ func (s *listenServer) handleListSchedules(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, out)
 }
 
-// handleScheduleRoute dispatches POSTs under /v1/schedules/. Two shapes:
+// handleScheduleRoute dispatches under /v1/schedules/. Shapes:
 //
 //	POST /v1/schedules/{name}/trigger
 //	POST /v1/schedules/{name}/tasks/{task}/trigger
+//	GET  /v1/schedules/{name}/events   → SSE: live frames for every
+//	                                    run of this schedule (incl.
+//	                                    runs that haven't started yet)
 //
 // We split on "/" rather than mounting per-pattern routers because the
-// path shape is fixed and tiny; bringing in a routing library for two
+// path shape is fixed and tiny; bringing in a routing library for three
 // endpoints is overkill.
 func (s *listenServer) handleScheduleRoute(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
 	if !s.authed(r) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
@@ -189,6 +189,16 @@ func (s *listenServer) handleScheduleRoute(w http.ResponseWriter, r *http.Reques
 	sch := s.findSchedule(schedName)
 	if sch == nil {
 		http.Error(w, fmt.Sprintf("schedule %q not found", schedName), http.StatusNotFound)
+		return
+	}
+
+	// GET /v1/schedules/{name}/events — live SSE.
+	if len(parts) == 2 && parts[1] == "events" && r.Method == http.MethodGet {
+		s.scheduleEvents(w, r, schedName)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -46,10 +46,11 @@ import (
 // function so tests can inject a store without exporting a setter on
 // the listener.
 type listenServer struct {
-	queue    chan<- []byte
-	token    string
-	confSrc  func() *Config
-	stateSrc func() *state.Store
+	queue       chan<- []byte
+	token       string
+	confSrc     func() *Config
+	stateSrc    func() *state.Store
+	liveSinkSrc func() *state.LiveSink
 }
 
 // startListener brings up the HTTP server in a background goroutine.
@@ -66,10 +67,11 @@ func startListener(addr, token string, queue chan<- []byte) {
 		return
 	}
 	s := &listenServer{
-		queue:    queue,
-		token:    token,
-		confSrc:  func() *Config { return confPriorGlobal },
-		stateSrc: StateStore,
+		queue:       queue,
+		token:       token,
+		confSrc:     func() *Config { return confPriorGlobal },
+		stateSrc:    StateStore,
+		liveSinkSrc: LiveSink,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealth)
@@ -405,6 +407,19 @@ func (s *listenServer) currentStore() *state.Store {
 		return s.stateSrc()
 	}
 	return StateStore()
+}
+
+// currentLiveSink mirrors currentStore — falls back to the global
+// LiveSink so tests that wire only stateSrc still get the firehose.
+// Returns nil when the state subsystem is disabled.
+func (s *listenServer) currentLiveSink() *state.LiveSink {
+	if s == nil {
+		return nil
+	}
+	if s.liveSinkSrc != nil {
+		return s.liveSinkSrc()
+	}
+	return LiveSink()
 }
 
 // ---- /v1/events -------------------------------------------------------------

--- a/internal/cronicle/listen_control.go
+++ b/internal/cronicle/listen_control.go
@@ -68,23 +68,54 @@ func (s *listenServer) handleRunRoute(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// runEvents streams the run's live event stream as Server-Sent Events.
-// LIVE-ONLY: no replay on subscribe, no Last-Event-ID resume. The
-// frame bytes are whatever LiveSink's configured Encoder produces
-// (pretty ANSI by default — set via --live-format). Frontends with a
-// terminal-emulator widget render those bytes faithfully, giving
-// operators the same visual experience as `cronicle run` in a TTY.
+// runEvents streams the events of one specific run. Drill-in case —
+// operator clicks a run from a list, wants its frames only.
+func (s *listenServer) runEvents(w http.ResponseWriter, r *http.Request, runID string) {
+	s.streamLive(w, r, state.Filter{RunID: runID})
+}
+
+// scheduleEvents streams every run of the named schedule, including
+// future runs that don't have a run_id yet. Solves the "open SSE
+// before trigger" chicken-and-egg: the subscriber registers against a
+// stable schedule name, and LiveSink delivers records as soon as the
+// next run starts emitting them — no polling for the run_id in between.
+//
+// Frontend pattern: schedule overview page opens this endpoint once,
+// renders runs as they fire. The pretty encoder's schedule_start /
+// agent_run / shell_run blocks make run boundaries visually obvious in
+// an xterm.js pane.
+func (s *listenServer) scheduleEvents(w http.ResponseWriter, r *http.Request, name string) {
+	s.streamLive(w, r, state.Filter{Schedule: name})
+}
+
+// handleEventsStream is the firehose: every run-bearing record across
+// every schedule. For operator dashboards monitoring all activity at
+// once. Volume can be high; xterm.js readers should mostly use the
+// per-schedule endpoint instead.
+func (s *listenServer) handleEventsStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authed(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	s.streamLive(w, r, state.Filter{})
+}
+
+// streamLive is the shared SSE plumbing for run / schedule / firehose
+// endpoints. LIVE-ONLY: no replay on subscribe, no Last-Event-ID
+// resume. Frame bytes are whatever LiveSink's configured Encoder
+// produces (pretty ANSI by default — set via --live-format).
 //
 // For history (older runs, debugging) the frontend queries Loki using
 // the seq+lifetime cursor IDs embedded in cronicle.jsonl. That's a
-// separate pane in the UI — this endpoint is purely "what's happening
-// right now."
+// separate pane in the UI — this code path is purely "what's
+// happening right now."
 //
-// Disconnect = miss. If the connection drops mid-task the client
-// won't see the missed bytes on reconnect; switch to the Loki pane
-// for that window. Keeps the server stateless and the implementation
-// trivial.
-func (s *listenServer) runEvents(w http.ResponseWriter, r *http.Request, runID string) {
+// Disconnect = miss. Keeps the server stateless and the wire trivial.
+func (s *listenServer) streamLive(w http.ResponseWriter, r *http.Request, filter state.Filter) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported by this server", http.StatusInternalServerError)
@@ -96,7 +127,7 @@ func (s *listenServer) runEvents(w http.ResponseWriter, r *http.Request, runID s
 		return
 	}
 
-	ch, unsubscribe := ls.Subscribe(runID)
+	ch, unsubscribe := ls.Subscribe(filter)
 	defer unsubscribe()
 
 	w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/cronicle/listen_control.go
+++ b/internal/cronicle/listen_control.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -27,9 +28,10 @@ import (
 
 // ---- /v1/runs/{id}/(get|cancel|retry) --------------------------------------
 
-// handleRunRoute dispatches under /v1/runs/. Three shapes:
+// handleRunRoute dispatches under /v1/runs/. Shapes:
 //
 //	GET  /v1/runs/{id}         → run + tasks (Phase 1)
+//	GET  /v1/runs/{id}/events  → SSE: live-only stream of slog records for this run
 //	POST /v1/runs/{id}/cancel  → cancel a running or pending run
 //	POST /v1/runs/{id}/retry   → re-enqueue a terminal run with a new id
 func (s *listenServer) handleRunRoute(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +55,8 @@ func (s *listenServer) handleRunRoute(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case len(parts) == 1 && r.Method == http.MethodGet:
 		s.runGet(w, store, runID)
+	case len(parts) == 2 && parts[1] == "events" && r.Method == http.MethodGet:
+		s.runEvents(w, r, runID)
 	case len(parts) == 2 && parts[1] == "cancel" && r.Method == http.MethodPost:
 		s.runCancel(w, store, runID)
 	case len(parts) == 2 && parts[1] == "retry" && r.Method == http.MethodPost:
@@ -62,6 +66,93 @@ func (s *listenServer) handleRunRoute(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "not found", http.StatusNotFound)
 	}
+}
+
+// runEvents streams the run's live event stream as Server-Sent Events.
+// LIVE-ONLY: no replay on subscribe, no Last-Event-ID resume. The
+// frame bytes are whatever LiveSink's configured Encoder produces
+// (pretty ANSI by default — set via --live-format). Frontends with a
+// terminal-emulator widget render those bytes faithfully, giving
+// operators the same visual experience as `cronicle run` in a TTY.
+//
+// For history (older runs, debugging) the frontend queries Loki using
+// the seq+lifetime cursor IDs embedded in cronicle.jsonl. That's a
+// separate pane in the UI — this endpoint is purely "what's happening
+// right now."
+//
+// Disconnect = miss. If the connection drops mid-task the client
+// won't see the missed bytes on reconnect; switch to the Loki pane
+// for that window. Keeps the server stateless and the implementation
+// trivial.
+func (s *listenServer) runEvents(w http.ResponseWriter, r *http.Request, runID string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported by this server", http.StatusInternalServerError)
+		return
+	}
+	ls := s.currentLiveSink()
+	if ls == nil {
+		http.Error(w, "live stream not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	ch, unsubscribe := ls.Subscribe(runID)
+	defer unsubscribe()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	// Heartbeat keeps proxies (nginx, k8s, ELB) from killing idle
+	// connections. SSE comment lines are ignored by clients but count
+	// as activity at the TCP layer.
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			fmt.Fprintf(w, ": ping %d\n\n", time.Now().Unix())
+			flusher.Flush()
+		case line, alive := <-ch:
+			if !alive {
+				return
+			}
+			writeSSEFrame(w, line)
+			flusher.Flush()
+		}
+	}
+}
+
+// writeSSEFrame emits one SSE event with the given bytes as data. Pretty
+// encoding produces multi-line text — SSE allows multiple `data:` lines
+// in one frame; clients (browsers' EventSource) join them with '\n'.
+// Empty payload is dropped (the encoder occasionally returns nothing
+// for filtered records, no point shipping an empty frame).
+func writeSSEFrame(w io.Writer, payload []byte) {
+	if len(payload) == 0 {
+		return
+	}
+	fmt.Fprint(w, "event: cronicle\n")
+	// Per SSE spec, every newline in the payload starts a new `data:`
+	// line. Trailing newline collapses to no extra line.
+	start := 0
+	for i := 0; i < len(payload); i++ {
+		if payload[i] == '\n' {
+			fmt.Fprintf(w, "data: %s\n", payload[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(payload) {
+		fmt.Fprintf(w, "data: %s\n", payload[start:])
+	}
+	fmt.Fprint(w, "\n")
 }
 
 // runGet is what handleGetRun used to do — kept here so all run-route

--- a/internal/cronicle/listen_run_events_test.go
+++ b/internal/cronicle/listen_run_events_test.go
@@ -136,6 +136,188 @@ func TestRunEvents_NoLiveSinkReturnsServiceUnavailable(t *testing.T) {
 	}
 }
 
+// TestScheduleEvents_LiveStream: subscribing to /v1/schedules/{name}/events
+// delivers frames from any run of that schedule. This is the chicken-
+// and-egg solver: the test subscribes BEFORE any record is published,
+// then publishes — and the frame still arrives because LiveSink keys
+// on schedule, not on a run_id we'd have to know first.
+func TestScheduleEvents_LiveStream(t *testing.T) {
+	ls := state.NewLiveSink(newLiveEncoder(LiveFormatPretty))
+	store, _ := state.Open(":memory:")
+	defer store.Close()
+
+	// findSchedule needs a Config — provide one that has the schedule
+	// the test is subscribing to. The dispatcher 404s if missing.
+	conf := &Config{
+		Schedules: []Schedule{{Name: "story"}},
+	}
+	srv := &listenServer{
+		token:       "secret",
+		confSrc:     func() *Config { return conf },
+		stateSrc:    func() *state.Store { return store },
+		liveSinkSrc: func() *state.LiveSink { return ls },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/schedules/", srv.handleScheduleRoute)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/schedules/story/events", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+
+	got := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var cur []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				frame := strings.Join(cur, "\n")
+				cur = nil
+				if strings.HasPrefix(frame, ": ping") {
+					continue
+				}
+				got <- frame
+				return
+			}
+			cur = append(cur, line)
+		}
+		got <- ""
+	}()
+
+	// Let the subscriber register, then publish with a brand-new
+	// run_id the SSE caller never knew. The schedule filter still
+	// catches the frame.
+	time.Sleep(50 * time.Millisecond)
+	r := slog.NewRecord(time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC),
+		slog.LevelInfo, "live from new run", 0)
+	r.AddAttrs(
+		slog.String("entry_type", "stdout_chunk"),
+		slog.String("run_id", "20260511T999999Z-justnow"),
+		slog.String("schedule", "story"),
+		slog.String("task", "tell-a-story"),
+		slog.String("stream", "stdout"),
+	)
+	_ = ls.Handle(context.Background(), r)
+
+	select {
+	case frame := <-got:
+		if !strings.Contains(frame, "data: live from new run") {
+			t.Fatalf("schedule subscriber missed the frame: %q", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for schedule SSE frame")
+	}
+}
+
+// TestScheduleEvents_UnknownSchedule404: misspelled or unloaded
+// schedules return 404 honestly rather than hanging the client on a
+// never-firing subscription.
+func TestScheduleEvents_UnknownSchedule404(t *testing.T) {
+	conf := &Config{Schedules: []Schedule{{Name: "real"}}}
+	srv := &listenServer{
+		token:       "secret",
+		confSrc:     func() *Config { return conf },
+		liveSinkSrc: func() *state.LiveSink { return state.NewLiveSink(newLiveEncoder(LiveFormatPretty)) },
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/schedules/typo/events", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	srv.handleScheduleRoute(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", rr.Code)
+	}
+}
+
+// TestEventsStream_Firehose: GET /v1/events/stream delivers records
+// from ANY schedule. The single subscriber sees frames from "story"
+// and "tick" both, proving Filter{} matches everything.
+func TestEventsStream_Firehose(t *testing.T) {
+	ls := state.NewLiveSink(newLiveEncoder(LiveFormatPretty))
+	srv := &listenServer{
+		token:       "secret",
+		liveSinkSrc: func() *state.LiveSink { return ls },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events/stream", srv.handleEventsStream)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/events/stream", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+
+	frames := make(chan string, 4)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var cur []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				frame := strings.Join(cur, "\n")
+				cur = nil
+				if strings.HasPrefix(frame, ": ping") {
+					continue
+				}
+				select {
+				case frames <- frame:
+				default:
+					return
+				}
+				continue
+			}
+			cur = append(cur, line)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	for _, sched := range []string{"story", "tick"} {
+		r := slog.NewRecord(time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC),
+			slog.LevelInfo, sched+" line", 0)
+		r.AddAttrs(
+			slog.String("entry_type", "stdout_chunk"),
+			slog.String("run_id", "R-"+sched),
+			slog.String("schedule", sched),
+			slog.String("task", "t1"),
+			slog.String("stream", "stdout"),
+		)
+		_ = ls.Handle(context.Background(), r)
+	}
+
+	seen := map[string]bool{}
+	deadline := time.After(2 * time.Second)
+	for len(seen) < 2 {
+		select {
+		case f := <-frames:
+			if strings.Contains(f, "data: story line") {
+				seen["story"] = true
+			}
+			if strings.Contains(f, "data: tick line") {
+				seen["tick"] = true
+			}
+		case <-deadline:
+			t.Fatalf("firehose got %v, want both story and tick", seen)
+		}
+	}
+}
+
 // TestRunEvents_AuthRequired: bearer token check applies.
 func TestRunEvents_AuthRequired(t *testing.T) {
 	srv := &listenServer{token: "secret"}

--- a/internal/cronicle/listen_run_events_test.go
+++ b/internal/cronicle/listen_run_events_test.go
@@ -1,0 +1,278 @@
+package cronicle
+
+import (
+	"bufio"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// TestRunEvents_LivePrettyStream: an in-flight slog record routed via
+// LiveSink arrives at the SSE consumer as pretty bytes wrapped in
+// standard event-stream framing. The test exercises the full handler
+// chain: slog.Info → Tagger → LiveSink (with pretty encoder) → SSE
+// frame writer → client scanner.
+//
+// We use a real httptest.NewServer because the response body must
+// stream piecemeal — ResponseRecorder buffers and would mask race
+// conditions in the live tail logic.
+func TestRunEvents_LivePrettyStream(t *testing.T) {
+	// Build a LiveSink that uses the same pretty encoder cronicle wires
+	// at startup. The trivial-text encoder would also work, but the
+	// pretty path is what the operator actually sees, so we test it.
+	ls := state.NewLiveSink(newLiveEncoder(LiveFormatPretty))
+
+	// In-memory store satisfies the listener's stateSrc check; we don't
+	// actually query it for live-only events.
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	defer store.Close()
+
+	srv := &listenServer{
+		token:       "secret",
+		stateSrc:    func() *state.Store { return store },
+		liveSinkSrc: func() *state.LiveSink { return ls },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/runs/", srv.handleRunRoute)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/runs/R1/events", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+
+	// Scan SSE frames inline so we observe them as they arrive (not
+	// buffered until body close).
+	got := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var cur []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				frame := strings.Join(cur, "\n")
+				cur = nil
+				// Skip heartbeat comment frames.
+				if strings.HasPrefix(frame, ": ping") {
+					continue
+				}
+				got <- frame
+				return
+			}
+			cur = append(cur, line)
+		}
+		got <- ""
+	}()
+
+	// Give the handler a beat to Subscribe before publishing.
+	time.Sleep(50 * time.Millisecond)
+
+	// Push a stdout_chunk record through LiveSink directly. The pretty
+	// encoder (suppressChunks=false for the LiveSink path) renders the
+	// chunk as raw bytes — exactly what the frontend's xterm.js pane
+	// needs.
+	r := slog.NewRecord(time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC), slog.LevelInfo,
+		"hello from live", 0)
+	r.AddAttrs(
+		slog.String("entry_type", "stdout_chunk"),
+		slog.String("run_id", "R1"),
+		slog.String("task", "say-hi"),
+		slog.String("schedule", "tick"),
+		slog.String("stream", "stdout"),
+	)
+	_ = ls.Handle(context.Background(), r)
+
+	select {
+	case frame := <-got:
+		if frame == "" {
+			t.Fatal("got empty frame")
+		}
+		if !strings.HasPrefix(frame, "event: cronicle") {
+			t.Errorf("missing SSE event prefix; frame=%q", frame)
+		}
+		if !strings.Contains(frame, "data: hello from live") {
+			t.Errorf("missing rendered stdout_chunk in frame; frame=%q", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE frame")
+	}
+}
+
+// TestRunEvents_NoLiveSinkReturnsServiceUnavailable: the endpoint
+// surfaces 503 honestly when state (and thus LiveSink) is disabled,
+// rather than hanging.
+func TestRunEvents_NoLiveSinkReturnsServiceUnavailable(t *testing.T) {
+	store, _ := state.Open(":memory:")
+	defer store.Close()
+	srv := &listenServer{
+		token:       "secret",
+		stateSrc:    func() *state.Store { return store },
+		liveSinkSrc: func() *state.LiveSink { return nil },
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/runs/R1/events", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	srv.handleRunRoute(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503", rr.Code)
+	}
+}
+
+// TestRunEvents_AuthRequired: bearer token check applies.
+func TestRunEvents_AuthRequired(t *testing.T) {
+	srv := &listenServer{token: "secret"}
+	req := httptest.NewRequest(http.MethodGet, "/v1/runs/R1/events", nil)
+	rr := httptest.NewRecorder()
+	srv.handleRunRoute(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", rr.Code)
+	}
+}
+
+// TestWriteSSEFrame_MultilineSplit: a pretty-rendered multi-line
+// payload becomes one event with one `data:` line per source line, per
+// SSE spec. Browsers join with '\n' on receive.
+func TestWriteSSEFrame_MultilineSplit(t *testing.T) {
+	var buf strings.Builder
+	writeSSEFrame(&buf, []byte("line one\nline two\nline three"))
+	got := buf.String()
+	want := "event: cronicle\ndata: line one\ndata: line two\ndata: line three\n\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// TestWriteSSEFrame_TrailingNewline: a payload ending in '\n' shouldn't
+// produce a trailing empty `data:` line. SSE spec is forgiving but a
+// stray empty data is ugly on the wire.
+func TestWriteSSEFrame_TrailingNewline(t *testing.T) {
+	var buf strings.Builder
+	writeSSEFrame(&buf, []byte("only line\n"))
+	got := buf.String()
+	want := "event: cronicle\ndata: only line\n\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// TestWriteSSEFrame_EmptyPayloadDropped: nothing in → nothing out.
+// Avoids stuttering empty events when an encoder filters a record.
+func TestWriteSSEFrame_EmptyPayloadDropped(t *testing.T) {
+	var buf strings.Builder
+	writeSSEFrame(&buf, nil)
+	writeSSEFrame(&buf, []byte{})
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output, got %q", buf.String())
+	}
+}
+
+// TestLineEmitter_OneRecordPerNewline confirms the lineEmitter splits
+// at \n and emits one slog record per completed line. Buffer state
+// across calls is exercised by writing a partial line then completing
+// it.
+func TestLineEmitter_OneRecordPerNewline(t *testing.T) {
+	collected := &slogCollector{}
+	prev := slog.Default()
+	defer slog.SetDefault(prev)
+	slog.SetDefault(slog.New(collected))
+
+	le := newLineEmitter(&noopWriter{}, "R1", "say-hi", "tick", "stdout")
+	le.Write([]byte("hello world\n"))
+	le.Write([]byte("partial "))
+	le.Write([]byte("continued\nfinal"))
+	le.Flush()
+
+	lines := collected.lines("stdout_chunk")
+	want := []string{"hello world", "partial continued", "final"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d records, want %d: %v", len(lines), len(want), lines)
+	}
+	for i, line := range want {
+		if lines[i] != line {
+			t.Errorf("record %d: got %q, want %q", i, lines[i], line)
+		}
+	}
+}
+
+// TestLineEmitter_StderrTagsEntryType: stderr stream produces
+// entry_type=stderr_chunk so consumers can route/color separately.
+func TestLineEmitter_StderrTagsEntryType(t *testing.T) {
+	collected := &slogCollector{}
+	prev := slog.Default()
+	defer slog.SetDefault(prev)
+	slog.SetDefault(slog.New(collected))
+
+	le := newLineEmitter(&noopWriter{}, "R1", "t", "s", "stderr")
+	le.Write([]byte("oops\n"))
+
+	if got := collected.lines("stderr_chunk"); len(got) != 1 || got[0] != "oops" {
+		t.Fatalf("stderr_chunk records: %v", got)
+	}
+	if got := collected.lines("stdout_chunk"); len(got) != 0 {
+		t.Fatalf("did not expect stdout_chunk records: %v", got)
+	}
+}
+
+// slogCollector captures every slog.Record so tests can assert on
+// emitted msg + entry_type. Concurrency-safe; the line emitter
+// uses its own mutex but a test may run multiple goroutines.
+type slogCollector struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (c *slogCollector) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (c *slogCollector) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	c.records = append(c.records, r)
+	c.mu.Unlock()
+	return nil
+}
+func (c *slogCollector) WithAttrs(_ []slog.Attr) slog.Handler { return c }
+func (c *slogCollector) WithGroup(_ string) slog.Handler      { return c }
+
+// lines returns the msg field of every collected record with the given
+// entry_type, in arrival order.
+func (c *slogCollector) lines(entryType string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, r := range c.records {
+		var et string
+		r.Attrs(func(a slog.Attr) bool {
+			if a.Key == "entry_type" {
+				et = a.Value.String()
+				return false
+			}
+			return true
+		})
+		if et == entryType {
+			out = append(out, r.Message)
+		}
+	}
+	return out
+}
+
+// noopWriter swallows bytes — the lineEmitter forwards to its inner
+// writer first; for tests we don't need the bytes to land anywhere.
+type noopWriter struct{}
+
+func (*noopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -508,26 +508,54 @@ func (p *prettyHandler) Enabled(ctx context.Context, l slog.Level) bool {
 func (p *prettyHandler) Handle(_ context.Context, r slog.Record) error {
 	switch entryType(r) {
 	case "agent_run":
-		return p.renderAgentRun(r)
+		// suppressChunks=true (stdout) → full block as before.
+		// suppressChunks=false (LiveSink) → footer only; body was already
+		// streamed via text_delta records that the bridge always emits.
+		if p.suppressChunks {
+			return p.renderAgentRun(r)
+		}
+		return p.renderAgentRunFooter(r)
 	case "agent_run_streamed":
-		// The streaming dispatch path already wrote the block to stdout in
-		// real time; the slog event exists only for the file mirror and
-		// non-pretty consumers. Suppress here.
-		return nil
+		// suppressChunks=true → no-op (StreamingWriter wrote the entire
+		// block directly to stdout; the slog event is for file/Loki).
+		// suppressChunks=false → footer only; LiveSink saw the header
+		// via agent_run_start and the body via text_delta records.
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderAgentRunFooter(r)
+	case "agent_run_start":
+		// Header rule + line + rule. Suppressed on stdout pretty mode
+		// because the StreamingWriter already wrote it via
+		// WriteAgentRunHeader; emitted to LiveSink so SSE consumers
+		// see the model/task/schedule context at the top of the block.
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderAgentRunStart(r)
 	case "shell_run":
-		return p.renderShellRun(r)
+		if p.suppressChunks {
+			return p.renderShellRun(r)
+		}
+		return p.renderShellRunFooter(r)
 	case "shell_run_streamed":
-		// Already rendered to stdout in real time; the slog event exists
-		// only for the file mirror.
-		return nil
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderShellRunFooter(r)
+	case "shell_run_start":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderShellRunStart(r)
 	case "schedule_start":
 		return p.renderScheduleStart(r)
 	case "schedule_complete":
 		return p.renderScheduleComplete(r)
 	case "task_start":
-		// Block headers (agent_run / shell_run) subsume the start signal,
-		// so suppress task_start in pretty mode. The file mirror still
-		// gets the event.
+		// Block headers (agent_run_start / shell_run_start) subsume the
+		// start signal, so suppress task_start in pretty mode. The file
+		// mirror still gets the event.
 		return nil
 	case "stdout_chunk":
 		if p.suppressChunks {
@@ -638,6 +666,91 @@ func attrStrings(r slog.Record, key string) []string {
 		return false
 	})
 	return out
+}
+
+// renderAgentRunStart writes the bordered header block for an agent run
+// to p.out — same shape WriteAgentRunHeader produces for the TTY's
+// StreamingWriter. Used by LiveSink (suppressChunks=false) so SSE
+// consumers see model/task/schedule context BEFORE the deltas stream.
+func (p *prettyHandler) renderAgentRunStart(r slog.Record) error {
+	schedule := attrString(r, "schedule")
+	task := attrString(r, "task")
+	model := attrString(r, "model")
+	var skills []string
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "skills_available" {
+			if v, ok := a.Value.Any().([]string); ok {
+				skills = v
+			}
+			return false
+		}
+		return true
+	})
+	var b bytes.Buffer
+	WriteAgentRunHeader(&b, schedule, task, model, skills)
+	b.WriteByte('\n')
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// renderAgentRunFooter writes ONLY the bracketed footer line for an
+// agent run — the metrics summary. Used by LiveSink (suppressChunks=
+// false): the header was already emitted via agent_run_start, the body
+// streamed via text_delta records, so the SSE consumer only needs the
+// terminal metrics line.
+func (p *prettyHandler) renderAgentRunFooter(r slog.Record) error {
+	var (
+		costStr                        string
+		stop, transcript               string
+		durationMs, in, out, cacheRead int64
+	)
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "cost_usd":
+			costStr = fmt.Sprintf("%.6f", a.Value.Float64())
+		case "duration_ms":
+			durationMs = a.Value.Int64()
+		case "input_tokens":
+			in = a.Value.Int64()
+		case "output_tokens":
+			out = a.Value.Int64()
+		case "cache_read":
+			cacheRead = a.Value.Int64()
+		case "stop_reason":
+			stop = a.Value.String()
+		case "transcript":
+			transcript = a.Value.String()
+		}
+		return true
+	})
+	var b bytes.Buffer
+	WriteAgentRunFooter(&b, in, out, cacheRead, costStr, durationMs, stop, transcript)
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// renderShellRunStart writes the bordered header block for a shell run.
+// Mirrors renderAgentRunStart for the shell-task path.
+func (p *prettyHandler) renderShellRunStart(r slog.Record) error {
+	schedule := attrString(r, "schedule")
+	task := attrString(r, "task")
+	command := attrString(r, "command")
+	var b bytes.Buffer
+	WriteShellRunHeader(&b, schedule, task, command)
+	b.WriteByte('\n')
+	_, err := p.out.Write(b.Bytes())
+	return err
+}
+
+// renderShellRunFooter writes the bracketed footer line for a shell run.
+func (p *prettyHandler) renderShellRunFooter(r slog.Record) error {
+	exit := attrInt64(r, "exit")
+	durationMs := attrInt64(r, "duration_ms")
+	transcript := attrString(r, "transcript")
+	var b bytes.Buffer
+	WriteShellRunFooter(&b, exit, durationMs, transcript)
+	_, err := p.out.Write(b.Bytes())
+	return err
 }
 
 func (p *prettyHandler) renderAgentRun(r slog.Record) error {

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -30,6 +30,35 @@ const (
 	LogFormatJSON   LogFormat = "json"
 )
 
+// LiveFormat selects the wire encoding of the live-stream SSE endpoint
+// (GET /v1/runs/{id}/events). Independent of LogFormat — operators may
+// want pretty-on-stdout AND json-on-the-wire, or vice versa.
+//
+// Default (set by SetLiveFormat at startup) is pretty: the SSE stream
+// emits ANSI-colored multi-line text identical to what a TTY would
+// show. Frontends consume via xterm.js. JSON / text are alternatives
+// for non-terminal clients.
+type LiveFormat string
+
+const (
+	LiveFormatPretty LiveFormat = "pretty"
+	LiveFormatJSON   LiveFormat = "json"
+	LiveFormatText   LiveFormat = "text"
+)
+
+// currentLiveFormat is the format applied when NewLiveEncoder is called
+// from EnableStateStore. Defaults to pretty; override with SetLiveFormat
+// before EnableStateStore.
+var currentLiveFormat LiveFormat = LiveFormatPretty
+
+// SetLiveFormat changes the wire format the SSE live-stream will use.
+// Call before EnableStateStore. Empty string keeps the default (pretty).
+func SetLiveFormat(format LiveFormat) {
+	if format != "" {
+		currentLiveFormat = format
+	}
+}
+
 // resolvedLogFormat tracks what format SetupLogging settled on after auto-
 // resolution. Other subsystems (the agent streaming path) probe it via
 // IsStreamingPretty to decide whether to render in real time or buffer.
@@ -54,6 +83,10 @@ func SetupLogging(format LogFormat) {
 		handler = &prettyHandler{
 			fallback: newTintHandler(os.Stdout),
 			out:      os.Stdout,
+			// stdout already gets per-line bytes from StreamingWriter / the
+			// agent renderer; don't double-print when those records also
+			// flow through slog.
+			suppressChunks: true,
 		}
 	case LogFormatJSON:
 		handler = slog.NewJSONHandler(os.Stdout, nil)
@@ -146,28 +179,84 @@ var CroniclePath string
 // Set by EnableStateStore; closed by CloseStateStore at shutdown.
 var stateStore *state.Store
 
+// liveSink is the process-wide live-stream pub/sub. Constructed by
+// EnableStateStore (paired with the projection store — same lifecycle).
+// nil when state is disabled. The HTTP listener's SSE handler reads
+// this via LiveSink() to subscribe per-run.
+var liveSink *state.LiveSink
+
 // StateStore returns the process-wide state.Store, or nil if not enabled.
 // Listener handlers and tests use this to issue queries.
 func StateStore() *state.Store { return stateStore }
 
-// EnableStateStore opens the projection store at dsn (":memory:" or a
-// filesystem path), wires its slog Sink into the default handler chain,
-// and stashes the handle for retrieval via StateStore. Idempotent — a
-// second call closes the prior store and replaces it.
+// LiveSink returns the process-wide LiveSink, or nil if not enabled.
+// The /v1/runs/{id}/events SSE handler uses this to subscribe.
+func LiveSink() *state.LiveSink { return liveSink }
+
+// EnableStateStore opens the projection store at dsn, wires the slog
+// chain to fan out into:
+//
+//	Tagger → multiHandler{ existing, Sink, LiveSink }
+//
+// Tagger sits at the top so every record gets seq+lifetime BEFORE the
+// fan-out — guaranteeing the bytes in cronicle.jsonl (which Loki ships)
+// carry the same cursor IDs as the frames in the live SSE stream. The
+// frontend can deep-link "I clicked seq=42 in live → take me to the
+// Loki view scoped to lifetime+seq=42."
+//
+// Idempotent — a second call closes the prior store and replaces both
+// store and live sink.
 func EnableStateStore(dsn string) error {
 	if stateStore != nil {
 		_ = stateStore.Close()
 		stateStore = nil
+		liveSink = nil
 	}
 	s, err := state.Open(dsn)
 	if err != nil {
 		return err
 	}
 	stateStore = s
+	liveSink = state.NewLiveSink(newLiveEncoder(currentLiveFormat))
+
 	current := slog.Default().Handler()
+	// If a Tagger already sits at the top of the chain (re-enable),
+	// peel it off so we don't stack two — that would double-tag every
+	// record (two seq attrs, two lifetime attrs).
+	if t, ok := current.(*state.Tagger); ok {
+		current = t.Inner()
+	}
 	sink := state.NewSink(s)
-	slog.SetDefault(slog.New(&multiHandler{handlers: []slog.Handler{current, sink}}))
+	multi := &multiHandler{handlers: []slog.Handler{current, sink, liveSink}}
+	slog.SetDefault(slog.New(state.NewTagger(multi)))
 	return nil
+}
+
+// newLiveEncoder constructs the per-record encoding closure used by
+// LiveSink. Each invocation gets a fresh bytes.Buffer plus a handler
+// configured to write into it; we return the captured bytes.
+//
+// Pretty mode reuses the existing prettyHandler (same logic that drives
+// cronicle's stdout rendering); JSON/text reuse the slog built-ins.
+// Allocation per record is small and amortizes against the network send.
+func newLiveEncoder(format LiveFormat) state.Encoder {
+	return func(r slog.Record) []byte {
+		var buf bytes.Buffer
+		var h slog.Handler
+		switch format {
+		case LiveFormatJSON:
+			h = slog.NewJSONHandler(&buf, nil)
+		case LiveFormatText:
+			h = slog.NewTextHandler(&buf, nil)
+		default: // pretty (also the empty-string fallback)
+			h = &prettyHandler{
+				fallback: newTintHandler(&buf),
+				out:      &buf,
+			}
+		}
+		_ = h.Handle(context.Background(), r)
+		return buf.Bytes()
+	}
 }
 
 // CloseStateStore tears down the projection store. Safe to call when
@@ -199,7 +288,16 @@ func EnableFileLog(croniclePath string) error {
 	}
 	fileHandler := slog.NewJSONHandler(file, nil)
 	current := slog.Default().Handler()
-	slog.SetDefault(slog.New(&multiHandler{handlers: []slog.Handler{current, fileHandler}}))
+	// Preserve Tagger at the top so file records also carry seq+lifetime.
+	// Without this, cronicle.jsonl → Loki would lack the cursor IDs the
+	// frontend uses to deep-link from live → history.
+	if t, ok := current.(*state.Tagger); ok {
+		inner := t.Inner()
+		combined := &multiHandler{handlers: []slog.Handler{inner, fileHandler}}
+		slog.SetDefault(slog.New(state.NewTagger(combined)))
+	} else {
+		slog.SetDefault(slog.New(&multiHandler{handlers: []slog.Handler{current, fileHandler}}))
+	}
 	FileLoggingEnabled = true
 	CroniclePath = croniclePath
 	return nil
@@ -390,9 +488,17 @@ func formatValue(v slog.Value) string {
 // or compact section headers, and everything else as a dim single line. The
 // fallback handler exists for nested compositions but isn't used for direct
 // rendering — pretty mode always renders something itself.
+//
+// suppressChunks controls whether the streaming entry_types (stdout_chunk,
+// text_delta, etc.) render at all. On stdout pretty mode it MUST be true:
+// the StreamingWriter and NewAgentStreamRenderer already wrote the bytes
+// directly to stdout, and rendering them again from slog would double-print.
+// For the LiveSink encoder (live SSE wire) it MUST be false — those bytes
+// are exactly what the frontend needs in its live pane.
 type prettyHandler struct {
-	fallback slog.Handler
-	out      io.Writer
+	fallback        slog.Handler
+	out             io.Writer
+	suppressChunks  bool
 }
 
 func (p *prettyHandler) Enabled(ctx context.Context, l slog.Level) bool {
@@ -423,17 +529,47 @@ func (p *prettyHandler) Handle(_ context.Context, r slog.Record) error {
 		// so suppress task_start in pretty mode. The file mirror still
 		// gets the event.
 		return nil
+	case "stdout_chunk":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderStdoutChunk(r, false)
+	case "stderr_chunk":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderStdoutChunk(r, true)
+	case "text_delta":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderTextDelta(r, false)
+	case "thinking_delta":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderTextDelta(r, true)
+	case "tool_use_start":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderToolUseStart(r)
+	case "tool_result":
+		if p.suppressChunks {
+			return nil
+		}
+		return p.renderToolResult(r)
 	default:
 		return p.renderDimLine(r)
 	}
 }
 
 func (p *prettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &prettyHandler{fallback: p.fallback.WithAttrs(attrs), out: p.out}
+	return &prettyHandler{fallback: p.fallback.WithAttrs(attrs), out: p.out, suppressChunks: p.suppressChunks}
 }
 
 func (p *prettyHandler) WithGroup(name string) slog.Handler {
-	return &prettyHandler{fallback: p.fallback.WithGroup(name), out: p.out}
+	return &prettyHandler{fallback: p.fallback.WithGroup(name), out: p.out, suppressChunks: p.suppressChunks}
 }
 
 // entryType extracts the entry_type attr from a record, returning "" if absent.
@@ -970,6 +1106,67 @@ func (p *prettyHandler) renderScheduleComplete(r slog.Record) error {
 // renderDimLine renders a record as a faint single line. Used for lifecycle
 // events (Loading, executing tasks, heartbeat, refreshing config, etc.) that
 // don't carry a structural entry_type.
+// renderStdoutChunk writes one line of streaming task output. The slog
+// record carries the line as msg. stderr is rendered in red (matching
+// what a TTY would show); stdout is rendered plain.
+func (p *prettyHandler) renderStdoutChunk(r slog.Record, isStderr bool) error {
+	line := r.Message
+	if isStderr {
+		// Faint red so error output is visible without overpowering normal
+		// stdout. Mirrors what users see when running the command locally.
+		errc := color.New(color.FgRed, color.Faint).SprintFunc()
+		_, err := fmt.Fprintln(p.out, errc(line))
+		return err
+	}
+	_, err := fmt.Fprintln(p.out, line)
+	return err
+}
+
+// renderTextDelta writes one chunk of agent output. Text deltas are
+// rendered inline (no decoration, no trailing newline added — the model
+// controls its own newlines). Thinking deltas are dimmed and prefixed
+// once per turn-start, matching the existing NewAgentStreamRenderer
+// behavior so the live SSE pane reads identically to the local TTY.
+func (p *prettyHandler) renderTextDelta(r slog.Record, isThinking bool) error {
+	if isThinking {
+		dim := color.New(color.Faint).SprintFunc()
+		_, err := fmt.Fprint(p.out, dim(r.Message))
+		return err
+	}
+	_, err := fmt.Fprint(p.out, r.Message)
+	return err
+}
+
+// renderToolUseStart writes the highlighted "→ tool: <input>" line that
+// the agent stream renderer used to write directly to stdout. Reads
+// the attrs the bridge emits: tool, input.
+func (p *prettyHandler) renderToolUseStart(r slog.Record) error {
+	toolHi := color.New(color.FgYellow).SprintFunc()
+	tool := attrString(r, "tool")
+	input := attrString(r, "input")
+	display := displayToolName(tool)
+	formatted := formatToolInput(tool, input)
+	_, err := fmt.Fprintf(p.out, "\n%s%s%s %s\n",
+		toolHi("→ "), toolHi(display), toolHi(":"), formatted)
+	return err
+}
+
+// renderToolResult writes the colored result line. Exit / duration come
+// from attrs; is_error flips green→red.
+func (p *prettyHandler) renderToolResult(r slog.Record) error {
+	dim := color.New(color.Faint).SprintFunc()
+	ok := color.New(color.FgGreen, color.Faint).SprintFunc()
+	bad := color.New(color.FgRed, color.Faint).SprintFunc()
+	isError := attrBool(r, "is_error")
+	duration := attrInt64(r, "duration_ms")
+	marker := ok("← exit=0")
+	if isError {
+		marker = bad("← error")
+	}
+	_, err := fmt.Fprintf(p.out, "%s %s\n", marker, dim(formatDuration(duration)))
+	return err
+}
+
 func (p *prettyHandler) renderDimLine(r slog.Record) error {
 	dim := color.New(color.Faint).SprintFunc()
 

--- a/internal/cronicle/state/live_sink.go
+++ b/internal/cronicle/state/live_sink.go
@@ -1,0 +1,188 @@
+package state
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// LiveSink is the in-memory pub/sub for the visceral live-stream plane.
+//
+// Architecture: cronicle keeps three distinct planes for run telemetry,
+// each tuned to a different consumer:
+//
+//   - State (SQLite runs/tasks/events tables) — answers "what is the
+//     status of every run?" Small, indexed, queryable.
+//   - History (cronicle.jsonl → Loki) — answers "show me the logs of
+//     this failed task last Tuesday." Structured, searchable, retained.
+//   - LIVE (this) — answers "what is happening RIGHT NOW in this
+//     task?" Token-by-token, line-by-line, ANSI-colored, no retention.
+//     If you disconnect, you miss it; switch to Loki for history.
+//
+// LiveSink sits in the slog handler chain alongside Sink and the file
+// handler. Every record flows through it, gets format-encoded (pretty
+// by default), and is fanned out to subscribers indexed by run_id.
+// Subscribers receive pre-rendered bytes — the SSE handler ships them
+// straight to the wire without further encoding.
+//
+// Wire format is whatever the Encoder produces. The default pretty
+// encoder emits ANSI-colored multi-line text identical to what your
+// local terminal shows when cronicle runs there. A frontend with
+// xterm.js (or any terminal emulator widget) renders those bytes
+// faithfully — the operator feels like they're watching the run on
+// the producer's TTY.
+//
+// LiveSink is concurrency-safe. The pub/sub mutex is held only for
+// the subscriber-set walk; channel sends happen under no lock so a
+// slow consumer's drop costs only the drop, not other subscribers.
+type LiveSink struct {
+	encode Encoder
+
+	subsMu sync.Mutex
+	subs   map[*liveSub]struct{}
+}
+
+// Encoder turns a slog.Record into the wire bytes a subscriber will
+// receive. Implementations are stateless and goroutine-safe; LiveSink
+// calls Encoder once per Handle. Bytes can include newlines — the SSE
+// layer splits them into multiple `data:` lines per the spec.
+//
+// Three Encoders are provided by the cronicle package: pretty (ANSI
+// multi-line, default), json (one compact JSON object), text (logfmt-
+// ish). Operators pick at startup via --live-format.
+type Encoder func(slog.Record) []byte
+
+// liveSub is one subscription. runID="" matches every run (firehose);
+// otherwise this subscriber only receives records carrying that run_id.
+// task filtering is intentionally not in the type — a frontend usually
+// wants the whole run's stream so it can show schedule_start,
+// task_start, output, and schedule_complete in one pane.
+type liveSub struct {
+	ch    chan []byte
+	runID string
+}
+
+// NewLiveSink returns a handler that encodes via `encode` and fans out
+// to subscribers. Pass nil and the handler will silently drop everything
+// (useful as a placeholder when state isn't enabled).
+func NewLiveSink(encode Encoder) *LiveSink {
+	return &LiveSink{encode: encode}
+}
+
+// Subscribe registers a per-run consumer. Pass runID="" for the firehose.
+// Returns the receive channel and an unsubscribe func the caller MUST
+// defer to clean up — leaks compound when many SSE connections come
+// and go.
+//
+// Channel buffer is 256. Empirically that's >5x the burst rate of a
+// fast schedule_complete chain when per-line stdout chunks are
+// flowing. A consumer that falls further behind drops records — the
+// frontend's reaction is "switch to Loki to see what you missed."
+func (s *LiveSink) Subscribe(runID string) (<-chan []byte, func()) {
+	sub := &liveSub{ch: make(chan []byte, 256), runID: runID}
+	s.subsMu.Lock()
+	if s.subs == nil {
+		s.subs = make(map[*liveSub]struct{})
+	}
+	s.subs[sub] = struct{}{}
+	s.subsMu.Unlock()
+
+	// Unsubscribe is idempotent. We delete-then-skip-close so a publish
+	// in flight at the moment of unsubscribe can't see a closed channel —
+	// the channel is abandoned and GC'd once the caller drops its ref.
+	var unsubOnce sync.Once
+	return sub.ch, func() {
+		unsubOnce.Do(func() {
+			s.subsMu.Lock()
+			delete(s.subs, sub)
+			s.subsMu.Unlock()
+		})
+	}
+}
+
+// Enabled is true for every level — the live stream wants WARN/ERROR
+// from within a task too (e.g., "tool failed" diagnostics), not just
+// INFO. The per-record run_id presence is the only gate.
+func (s *LiveSink) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+// Handle is the slog.Handler entry point. Extract run_id, drop if
+// absent, encode via the injected Encoder, fan out to matching
+// subscribers. Never returns an error — slog handlers in a multi-
+// chain are best-effort; a return would short-circuit siblings.
+func (s *LiveSink) Handle(_ context.Context, r slog.Record) error {
+	if s == nil || s.encode == nil {
+		return nil
+	}
+	runID := extractRunID(r)
+	if runID == "" {
+		// Process-level lifecycle prints ("config loaded", heartbeat) don't
+		// belong to any specific run; the SSE endpoint is per-run.
+		return nil
+	}
+	line := s.encode(r)
+	if len(line) == 0 {
+		return nil
+	}
+	s.fanout(runID, line)
+	return nil
+}
+
+// WithAttrs / WithGroup are no-ops. cronicle doesn't construct
+// logger.With(...) chains for projection-bearing events; supporting
+// them would add cost and complexity without payoff.
+func (s *LiveSink) WithAttrs(_ []slog.Attr) slog.Handler { return s }
+func (s *LiveSink) WithGroup(_ string) slog.Handler      { return s }
+
+// Inject forwards a pre-encoded byte sequence to subscribers as if it
+// had come through Handle. Used by the distributed-mode ingest path
+// (POST /v1/events) where worker records arrive at the producer as
+// bytes, not through the producer's slog handler chain, so Handle
+// never sees them.
+func (s *LiveSink) Inject(runID string, line []byte) {
+	if s == nil || runID == "" || len(line) == 0 {
+		return
+	}
+	s.fanout(runID, line)
+}
+
+// fanout walks the subscriber set under the mutex, then sends under no
+// lock. Slow consumers get a non-blocking drop — better to lose a few
+// frames in one tab than stall every other tab watching the same run.
+func (s *LiveSink) fanout(runID string, line []byte) {
+	s.subsMu.Lock()
+	if len(s.subs) == 0 {
+		s.subsMu.Unlock()
+		return
+	}
+	targets := make([]*liveSub, 0, len(s.subs))
+	for sub := range s.subs {
+		if sub.runID == "" || sub.runID == runID {
+			targets = append(targets, sub)
+		}
+	}
+	s.subsMu.Unlock()
+
+	for _, t := range targets {
+		select {
+		case t.ch <- line:
+		default:
+			// slow consumer — drop. The frontend's recourse is Loki for
+			// the missing window, not a buffered replay we'd have to keep.
+		}
+	}
+}
+
+// extractRunID walks the record's attrs looking for `run_id`. Returns
+// "" if absent. Cheap for the common case (run_id near the front of
+// the attr slice); slog records have small attr slices in practice.
+func extractRunID(r slog.Record) string {
+	var out string
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "run_id" {
+			out = a.Value.String()
+			return false
+		}
+		return true
+	})
+	return out
+}

--- a/internal/cronicle/state/live_sink.go
+++ b/internal/cronicle/state/live_sink.go
@@ -52,14 +52,53 @@ type LiveSink struct {
 // ish). Operators pick at startup via --live-format.
 type Encoder func(slog.Record) []byte
 
-// liveSub is one subscription. runID="" matches every run (firehose);
-// otherwise this subscriber only receives records carrying that run_id.
-// task filtering is intentionally not in the type — a frontend usually
-// wants the whole run's stream so it can show schedule_start,
-// task_start, output, and schedule_complete in one pane.
+// Filter narrows which records a subscriber receives. Every non-empty
+// field must match the corresponding attr on the record:
+//
+//   - RunID    matches `run_id`    — drill into one run
+//   - Schedule matches `schedule`  — every run of a schedule, including
+//     the next one to fire (frontend can subscribe BEFORE the run_id
+//     exists, solving the "open SSE before trigger" chicken-and-egg)
+//   - Task     matches `task`      — narrow to one task across runs
+//
+// Zero-value Filter is the firehose — every run-bearing record reaches
+// the subscriber. Useful for operator dashboards monitoring all activity.
+//
+// All filter fields are AND'd. To get "either schedule A or schedule B"
+// open two subscriptions.
+type Filter struct {
+	RunID    string
+	Schedule string
+	Task     string
+}
+
+func (f Filter) matches(t recordTags) bool {
+	if f.RunID != "" && f.RunID != t.runID {
+		return false
+	}
+	if f.Schedule != "" && f.Schedule != t.schedule {
+		return false
+	}
+	if f.Task != "" && f.Task != t.task {
+		return false
+	}
+	return true
+}
+
+// recordTags are the routing-relevant attrs extracted from a slog.Record
+// in Handle. Pulled out once and passed to fanout so each subscriber's
+// filter check is a few string compares, not an attr-slice walk.
+type recordTags struct {
+	runID    string
+	schedule string
+	task     string
+}
+
+// liveSub is one subscription. filter is the predicate every record must
+// pass to land on this subscriber's channel.
 type liveSub struct {
-	ch    chan []byte
-	runID string
+	ch     chan []byte
+	filter Filter
 }
 
 // NewLiveSink returns a handler that encodes via `encode` and fans out
@@ -69,17 +108,17 @@ func NewLiveSink(encode Encoder) *LiveSink {
 	return &LiveSink{encode: encode}
 }
 
-// Subscribe registers a per-run consumer. Pass runID="" for the firehose.
-// Returns the receive channel and an unsubscribe func the caller MUST
-// defer to clean up — leaks compound when many SSE connections come
-// and go.
+// Subscribe registers a consumer that receives every record matching
+// `filter`. Zero-value filter is the firehose. Returns the receive
+// channel and an unsubscribe func the caller MUST defer — leaks
+// compound when many SSE connections come and go.
 //
 // Channel buffer is 256. Empirically that's >5x the burst rate of a
 // fast schedule_complete chain when per-line stdout chunks are
 // flowing. A consumer that falls further behind drops records — the
-// frontend's reaction is "switch to Loki to see what you missed."
-func (s *LiveSink) Subscribe(runID string) (<-chan []byte, func()) {
-	sub := &liveSub{ch: make(chan []byte, 256), runID: runID}
+// frontend's recourse is "switch to Loki to see what you missed."
+func (s *LiveSink) Subscribe(filter Filter) (<-chan []byte, func()) {
+	sub := &liveSub{ch: make(chan []byte, 256), filter: filter}
 	s.subsMu.Lock()
 	if s.subs == nil {
 		s.subs = make(map[*liveSub]struct{})
@@ -105,25 +144,27 @@ func (s *LiveSink) Subscribe(runID string) (<-chan []byte, func()) {
 // INFO. The per-record run_id presence is the only gate.
 func (s *LiveSink) Enabled(_ context.Context, _ slog.Level) bool { return true }
 
-// Handle is the slog.Handler entry point. Extract run_id, drop if
-// absent, encode via the injected Encoder, fan out to matching
-// subscribers. Never returns an error — slog handlers in a multi-
-// chain are best-effort; a return would short-circuit siblings.
+// Handle is the slog.Handler entry point. Extract routing tags, drop
+// records without a run_id, encode, fan out to matching subscribers.
+// Never returns an error — slog handlers in a multi-chain are best-
+// effort; a non-nil return would short-circuit siblings.
 func (s *LiveSink) Handle(_ context.Context, r slog.Record) error {
 	if s == nil || s.encode == nil {
 		return nil
 	}
-	runID := extractRunID(r)
-	if runID == "" {
+	tags := extractTags(r)
+	if tags.runID == "" {
 		// Process-level lifecycle prints ("config loaded", heartbeat) don't
-		// belong to any specific run; the SSE endpoint is per-run.
+		// belong to any run; per-run / per-schedule subscribers wouldn't
+		// match, and the firehose intentionally also skips them — those
+		// prints are operator-side noise, not run telemetry.
 		return nil
 	}
 	line := s.encode(r)
 	if len(line) == 0 {
 		return nil
 	}
-	s.fanout(runID, line)
+	s.fanout(tags, line)
 	return nil
 }
 
@@ -133,22 +174,23 @@ func (s *LiveSink) Handle(_ context.Context, r slog.Record) error {
 func (s *LiveSink) WithAttrs(_ []slog.Attr) slog.Handler { return s }
 func (s *LiveSink) WithGroup(_ string) slog.Handler      { return s }
 
-// Inject forwards a pre-encoded byte sequence to subscribers as if it
-// had come through Handle. Used by the distributed-mode ingest path
-// (POST /v1/events) where worker records arrive at the producer as
-// bytes, not through the producer's slog handler chain, so Handle
-// never sees them.
-func (s *LiveSink) Inject(runID string, line []byte) {
+// Inject forwards pre-encoded bytes to subscribers as if they had come
+// through Handle. Used by the distributed-mode ingest path (POST
+// /v1/events) where worker records arrive at the producer as bytes,
+// not through the producer's slog handler chain, so Handle never sees
+// them. Caller passes the routing tags it already decoded from the
+// Event struct.
+func (s *LiveSink) Inject(runID, schedule, task string, line []byte) {
 	if s == nil || runID == "" || len(line) == 0 {
 		return
 	}
-	s.fanout(runID, line)
+	s.fanout(recordTags{runID: runID, schedule: schedule, task: task}, line)
 }
 
 // fanout walks the subscriber set under the mutex, then sends under no
 // lock. Slow consumers get a non-blocking drop — better to lose a few
 // frames in one tab than stall every other tab watching the same run.
-func (s *LiveSink) fanout(runID string, line []byte) {
+func (s *LiveSink) fanout(tags recordTags, line []byte) {
 	s.subsMu.Lock()
 	if len(s.subs) == 0 {
 		s.subsMu.Unlock()
@@ -156,7 +198,7 @@ func (s *LiveSink) fanout(runID string, line []byte) {
 	}
 	targets := make([]*liveSub, 0, len(s.subs))
 	for sub := range s.subs {
-		if sub.runID == "" || sub.runID == runID {
+		if sub.filter.matches(tags) {
 			targets = append(targets, sub)
 		}
 	}
@@ -172,17 +214,24 @@ func (s *LiveSink) fanout(runID string, line []byte) {
 	}
 }
 
-// extractRunID walks the record's attrs looking for `run_id`. Returns
-// "" if absent. Cheap for the common case (run_id near the front of
-// the attr slice); slog records have small attr slices in practice.
-func extractRunID(r slog.Record) string {
-	var out string
+// extractTags pulls the routing attrs off a record in one pass. Cheap —
+// records typically have a small attr slice and the keys land near the
+// front (the dispatch sites build records via slog.Info(msg, "run_id", …,
+// "schedule", …, "task", …)).
+func extractTags(r slog.Record) recordTags {
+	var t recordTags
 	r.Attrs(func(a slog.Attr) bool {
-		if a.Key == "run_id" {
-			out = a.Value.String()
-			return false
+		switch a.Key {
+		case "run_id":
+			t.runID = a.Value.String()
+		case "schedule":
+			t.schedule = a.Value.String()
+		case "task":
+			t.task = a.Value.String()
 		}
-		return true
+		// Continue walking; we want all three. Bail once we have them.
+		return t.runID == "" || t.schedule == "" || t.task == ""
 	})
-	return out
+	return t
 }
+

--- a/internal/cronicle/state/live_sink_test.go
+++ b/internal/cronicle/state/live_sink_test.go
@@ -37,9 +37,9 @@ func trivialEncoder(r slog.Record) []byte {
 // A subscriber and skips the B subscriber.
 func TestLiveSink_PerRunDelivery(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	chA, unsubA := ls.Subscribe("A")
+	chA, unsubA := ls.Subscribe(Filter{RunID: "A"})
 	defer unsubA()
-	chB, unsubB := ls.Subscribe("B")
+	chB, unsubB := ls.Subscribe(Filter{RunID: "B"})
 	defer unsubB()
 
 	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "hello",
@@ -68,7 +68,7 @@ func TestLiveSink_PerRunDelivery(t *testing.T) {
 // process-level lifecycle prints don't belong on per-run SSE.
 func TestLiveSink_NoRunIDDrops(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	all, unsub := ls.Subscribe("")
+	all, unsub := ls.Subscribe(Filter{})
 	defer unsub()
 
 	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "config loaded",
@@ -86,7 +86,7 @@ func TestLiveSink_NoRunIDDrops(t *testing.T) {
 // TestLiveSink_FirehoseSeesEveryRun: Subscribe("") receives every run.
 func TestLiveSink_FirehoseSeesEveryRun(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	all, unsub := ls.Subscribe("")
+	all, unsub := ls.Subscribe(Filter{})
 	defer unsub()
 
 	for _, id := range []string{"A", "B", "C"} {
@@ -116,7 +116,7 @@ func TestLiveSink_FirehoseSeesEveryRun(t *testing.T) {
 // a placeholder for tests/code paths that don't need live streaming.
 func TestLiveSink_NoEncoderIsNoOp(t *testing.T) {
 	ls := NewLiveSink(nil)
-	ch, unsub := ls.Subscribe("A")
+	ch, unsub := ls.Subscribe(Filter{RunID: "A"})
 	defer unsub()
 
 	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
@@ -137,7 +137,7 @@ func TestLiveSink_NoEncoderIsNoOp(t *testing.T) {
 func TestLiveSink_EmptyEncodedBytesDropped(t *testing.T) {
 	emptyEnc := func(_ slog.Record) []byte { return nil }
 	ls := NewLiveSink(emptyEnc)
-	ch, unsub := ls.Subscribe("A")
+	ch, unsub := ls.Subscribe(Filter{RunID: "A"})
 	defer unsub()
 
 	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
@@ -158,9 +158,9 @@ func TestLiveSink_EmptyEncodedBytesDropped(t *testing.T) {
 // and the rest drop without blocking.
 func TestLiveSink_SlowConsumerDropsNotBlocks(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	_, unsubSlow := ls.Subscribe("R") // intentionally undrained
+	_, unsubSlow := ls.Subscribe(Filter{RunID: "R"}) // intentionally undrained
 	defer unsubSlow()
-	fast, unsubFast := ls.Subscribe("R")
+	fast, unsubFast := ls.Subscribe(Filter{RunID: "R"})
 	defer unsubFast()
 
 	done := make(chan struct{})
@@ -202,7 +202,7 @@ func TestLiveSink_SlowConsumerDropsNotBlocks(t *testing.T) {
 // records arrive even if Handle is called.
 func TestLiveSink_UnsubscribeStopsDelivery(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	ch, unsub := ls.Subscribe("R")
+	ch, unsub := ls.Subscribe(Filter{RunID: "R"})
 	unsub()
 
 	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
@@ -219,11 +219,122 @@ func TestLiveSink_UnsubscribeStopsDelivery(t *testing.T) {
 	}
 }
 
+// TestLiveSink_ScheduleFilterMatchesAnyRunOfSchedule: a subscriber
+// with Filter{Schedule: "X"} sees records from every run of schedule
+// X — including a NEW run started AFTER subscribe (the chicken-and-egg
+// case where a frontend wants to watch the next run before its run_id
+// exists).
+func TestLiveSink_ScheduleFilterMatchesAnyRunOfSchedule(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	ch, unsub := ls.Subscribe(Filter{Schedule: "X"})
+	defer unsub()
+
+	// Record from a different schedule — should NOT match.
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "ignored",
+		slog.String("run_id", "R1"),
+		slog.String("schedule", "Y"),
+		slog.String("task", "t1"),
+	))
+	// Two records from schedule X, different run_ids — both should arrive.
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "first",
+		slog.String("run_id", "R1"),
+		slog.String("schedule", "X"),
+		slog.String("task", "t1"),
+	))
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "second",
+		slog.String("run_id", "R2"),
+		slog.String("schedule", "X"),
+		slog.String("task", "t1"),
+	))
+
+	got := []string{}
+	deadline := time.After(time.Second)
+	for len(got) < 2 {
+		select {
+		case b := <-ch:
+			got = append(got, string(b))
+		case <-deadline:
+			t.Fatalf("got %d frames, want 2: %v", len(got), got)
+		}
+	}
+	// Schedule Y's record must NOT have arrived.
+	for _, g := range got {
+		if strings.Contains(g, "ignored") {
+			t.Fatalf("schedule filter let through wrong-schedule record: %v", got)
+		}
+	}
+}
+
+// TestLiveSink_FilterFirehoseSeesAllSchedules: Filter{} (zero value) is
+// the firehose — records from every schedule reach the subscriber.
+func TestLiveSink_FilterFirehoseSeesAllSchedules(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	ch, unsub := ls.Subscribe(Filter{})
+	defer unsub()
+
+	for _, sched := range []string{"X", "Y", "Z"} {
+		_ = ls.Handle(context.Background(), rec(slog.LevelInfo, sched,
+			slog.String("run_id", "R-"+sched),
+			slog.String("schedule", sched),
+			slog.String("task", "t1"),
+		))
+	}
+
+	got := 0
+	deadline := time.After(time.Second)
+	for got < 3 {
+		select {
+		case <-ch:
+			got++
+		case <-deadline:
+			t.Fatalf("firehose got %d, want 3", got)
+		}
+	}
+}
+
+// TestLiveSink_FilterAndedCombined: RunID + Schedule + Task all set
+// means all three must match. Only records satisfying every non-empty
+// field arrive.
+func TestLiveSink_FilterAndedCombined(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	ch, unsub := ls.Subscribe(Filter{RunID: "R1", Schedule: "X", Task: "t1"})
+	defer unsub()
+
+	// Wrong task — must NOT arrive.
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "wrong task",
+		slog.String("run_id", "R1"),
+		slog.String("schedule", "X"),
+		slog.String("task", "t2"),
+	))
+	// All three match — MUST arrive.
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "match",
+		slog.String("run_id", "R1"),
+		slog.String("schedule", "X"),
+		slog.String("task", "t1"),
+	))
+
+	select {
+	case b := <-ch:
+		if !strings.Contains(string(b), "match") {
+			t.Fatalf("wrong record passed combined filter: %s", b)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("matching record did not arrive")
+	}
+	// Confirm nothing else arrives.
+	select {
+	case b := <-ch:
+		t.Fatalf("non-matching record leaked through: %s", b)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
 // TestLiveSink_DoubleUnsubscribeIsSafe: idempotent — calling unsub
 // twice doesn't panic.
 func TestLiveSink_DoubleUnsubscribeIsSafe(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	_, unsub := ls.Subscribe("R")
+	_, unsub := ls.Subscribe(Filter{RunID: "R"})
 	unsub()
 	unsub() // would panic if not idempotent
 }
@@ -234,11 +345,11 @@ func TestLiveSink_DoubleUnsubscribeIsSafe(t *testing.T) {
 // remote worker rather than through this process's slog chain.
 func TestLiveSink_InjectFanout(t *testing.T) {
 	ls := NewLiveSink(trivialEncoder)
-	ch, unsub := ls.Subscribe("R")
+	ch, unsub := ls.Subscribe(Filter{RunID: "R"})
 	defer unsub()
 
 	line := []byte("hello from worker\n")
-	ls.Inject("R", line)
+	ls.Inject("R", "sched", "task1", line)
 
 	select {
 	case got := <-ch:
@@ -250,8 +361,8 @@ func TestLiveSink_InjectFanout(t *testing.T) {
 	}
 
 	// Empty runID and empty line are no-ops.
-	ls.Inject("", line)
-	ls.Inject("R", nil)
+	ls.Inject("", "sched", "task1", line)
+	ls.Inject("R", "sched", "task1", nil)
 }
 
 // TestLiveSink_ConcurrentSubscribePublish: lots of subscribers, lots
@@ -264,7 +375,7 @@ func TestLiveSink_ConcurrentSubscribePublish(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ch, unsub := ls.Subscribe("R")
+			ch, unsub := ls.Subscribe(Filter{RunID: "R"})
 			defer unsub()
 			go func() {
 				for range ch {

--- a/internal/cronicle/state/live_sink_test.go
+++ b/internal/cronicle/state/live_sink_test.go
@@ -1,0 +1,339 @@
+package state
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// rec constructs a slog.Record with the given attrs. Time fixed so
+// tests don't compare moving values.
+func rec(level slog.Level, msg string, attrs ...slog.Attr) slog.Record {
+	r := slog.NewRecord(time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC), level, msg, 0)
+	r.AddAttrs(attrs...)
+	return r
+}
+
+// trivialEncoder turns a record into "<run_id>:<msg>\n" — easy to
+// assert on without importing the cronicle package's pretty handler.
+// Includes run_id so firehose tests can distinguish records that share
+// the same message.
+func trivialEncoder(r slog.Record) []byte {
+	var runID string
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "run_id" {
+			runID = a.Value.String()
+			return false
+		}
+		return true
+	})
+	return []byte(runID + ":" + r.Message + "\n")
+}
+
+// TestLiveSink_PerRunDelivery: a record with run_id=A reaches the
+// A subscriber and skips the B subscriber.
+func TestLiveSink_PerRunDelivery(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	chA, unsubA := ls.Subscribe("A")
+	defer unsubA()
+	chB, unsubB := ls.Subscribe("B")
+	defer unsubB()
+
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "hello",
+		slog.String("entry_type", "task_start"),
+		slog.String("run_id", "A"),
+	))
+
+	select {
+	case got := <-chA:
+		if !strings.Contains(string(got), "hello") {
+			t.Fatalf("payload missing message: %s", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("A did not receive its record")
+	}
+
+	select {
+	case got := <-chB:
+		t.Fatalf("B should not have received A's record: %s", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+// TestLiveSink_NoRunIDDrops: a record with no run_id reaches no one —
+// process-level lifecycle prints don't belong on per-run SSE.
+func TestLiveSink_NoRunIDDrops(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	all, unsub := ls.Subscribe("")
+	defer unsub()
+
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "config loaded",
+		slog.Int("schedules", 3),
+	))
+
+	select {
+	case got := <-all:
+		t.Fatalf("firehose received a no-run_id record: %s", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+// TestLiveSink_FirehoseSeesEveryRun: Subscribe("") receives every run.
+func TestLiveSink_FirehoseSeesEveryRun(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	all, unsub := ls.Subscribe("")
+	defer unsub()
+
+	for _, id := range []string{"A", "B", "C"} {
+		_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
+			slog.String("entry_type", "task_start"),
+			slog.String("run_id", id),
+		))
+	}
+
+	got := map[string]bool{}
+	deadline := time.After(2 * time.Second)
+	for len(got) < 3 {
+		select {
+		case b := <-all:
+			// Extract run_id prefix from "<run_id>:<msg>\n".
+			s := string(b)
+			if i := strings.Index(s, ":"); i > 0 {
+				got[s[:i]] = true
+			}
+		case <-deadline:
+			t.Fatalf("firehose missed runs; got %v", got)
+		}
+	}
+}
+
+// TestLiveSink_NoEncoderIsNoOp: nil encoder = no-op handler. Useful as
+// a placeholder for tests/code paths that don't need live streaming.
+func TestLiveSink_NoEncoderIsNoOp(t *testing.T) {
+	ls := NewLiveSink(nil)
+	ch, unsub := ls.Subscribe("A")
+	defer unsub()
+
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
+		slog.String("run_id", "A"),
+	))
+
+	select {
+	case got := <-ch:
+		t.Fatalf("nil encoder should drop; got %s", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+// TestLiveSink_EmptyEncodedBytesDropped: an encoder returning an empty
+// slice (e.g., pretty handler suppressed the record) doesn't ship a
+// frame. Avoids stuttering empty events on the wire.
+func TestLiveSink_EmptyEncodedBytesDropped(t *testing.T) {
+	emptyEnc := func(_ slog.Record) []byte { return nil }
+	ls := NewLiveSink(emptyEnc)
+	ch, unsub := ls.Subscribe("A")
+	defer unsub()
+
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
+		slog.String("run_id", "A"),
+	))
+
+	select {
+	case got := <-ch:
+		t.Fatalf("empty encoding should not produce a frame; got %s", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+// TestLiveSink_SlowConsumerDropsNotBlocks: a subscriber that doesn't
+// drain its channel must not block other subscribers or future Handle
+// calls. We push a few-hundred records — the buffer (256) overflows
+// and the rest drop without blocking.
+func TestLiveSink_SlowConsumerDropsNotBlocks(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	_, unsubSlow := ls.Subscribe("R") // intentionally undrained
+	defer unsubSlow()
+	fast, unsubFast := ls.Subscribe("R")
+	defer unsubFast()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
+				slog.String("run_id", "R"),
+				slog.Int("seq", i),
+			))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow subscriber blocked the publisher")
+	}
+
+	// Fast subscriber should have received at least 256 (its buffer size).
+	got := 0
+	for {
+		select {
+		case <-fast:
+			got++
+			if got >= 256 {
+				return // success
+			}
+		case <-time.After(200 * time.Millisecond):
+			if got == 0 {
+				t.Fatalf("fast subscriber got nothing while slow stalled")
+			}
+			return
+		}
+	}
+}
+
+// TestLiveSink_UnsubscribeStopsDelivery: after unsub, no further
+// records arrive even if Handle is called.
+func TestLiveSink_UnsubscribeStopsDelivery(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	ch, unsub := ls.Subscribe("R")
+	unsub()
+
+	_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
+		slog.String("run_id", "R"),
+	))
+
+	select {
+	case got, ok := <-ch:
+		if ok {
+			t.Fatalf("expected no delivery after unsub, got: %s", got)
+		}
+	case <-time.After(100 * time.Millisecond):
+		// expected — channel abandoned, not closed (documented behavior)
+	}
+}
+
+// TestLiveSink_DoubleUnsubscribeIsSafe: idempotent — calling unsub
+// twice doesn't panic.
+func TestLiveSink_DoubleUnsubscribeIsSafe(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	_, unsub := ls.Subscribe("R")
+	unsub()
+	unsub() // would panic if not idempotent
+}
+
+// TestLiveSink_InjectFanout: Inject takes pre-encoded bytes and
+// delivers them as if they came through Handle. Used by the ingest
+// path (POST /v1/events) where worker events arrive as bytes from a
+// remote worker rather than through this process's slog chain.
+func TestLiveSink_InjectFanout(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+	ch, unsub := ls.Subscribe("R")
+	defer unsub()
+
+	line := []byte("hello from worker\n")
+	ls.Inject("R", line)
+
+	select {
+	case got := <-ch:
+		if string(got) != string(line) {
+			t.Fatalf("payload mismatch: got %s", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Inject did not deliver")
+	}
+
+	// Empty runID and empty line are no-ops.
+	ls.Inject("", line)
+	ls.Inject("R", nil)
+}
+
+// TestLiveSink_ConcurrentSubscribePublish: lots of subscribers, lots
+// of publishes, race detector must be happy.
+func TestLiveSink_ConcurrentSubscribePublish(t *testing.T) {
+	ls := NewLiveSink(trivialEncoder)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch, unsub := ls.Subscribe("R")
+			defer unsub()
+			go func() {
+				for range ch {
+				}
+			}()
+			time.Sleep(10 * time.Millisecond)
+		}()
+	}
+	for i := 0; i < 200; i++ {
+		_ = ls.Handle(context.Background(), rec(slog.LevelInfo, "x",
+			slog.String("run_id", "R"),
+		))
+	}
+	wg.Wait()
+}
+
+// TestTagger_InjectsSeqAndLifetime: a record passing through Tagger
+// gets seq + lifetime attrs. Successive records have strictly
+// increasing seqs; lifetime is stable for the process.
+func TestTagger_InjectsSeqAndLifetime(t *testing.T) {
+	collect := &collectingHandler{}
+	tagger := NewTagger(collect)
+	logger := slog.New(tagger)
+
+	logger.Info("a")
+	logger.Info("b")
+	logger.Info("c")
+
+	if len(collect.records) != 3 {
+		t.Fatalf("want 3 records, got %d", len(collect.records))
+	}
+	lifetimes := map[string]bool{}
+	seqs := []int64{}
+	for _, r := range collect.records {
+		var lt string
+		var seq int64
+		r.Attrs(func(a slog.Attr) bool {
+			switch a.Key {
+			case "seq":
+				seq = a.Value.Int64()
+			case "lifetime":
+				lt = a.Value.String()
+			}
+			return true
+		})
+		lifetimes[lt] = true
+		seqs = append(seqs, seq)
+	}
+	if len(lifetimes) != 1 {
+		t.Fatalf("lifetime should be constant; got %d distinct: %v", len(lifetimes), lifetimes)
+	}
+	if seqs[0] >= seqs[1] || seqs[1] >= seqs[2] {
+		t.Fatalf("seqs should be strictly increasing, got %v", seqs)
+	}
+}
+
+// collectingHandler is a tiny test fake: records every slog.Record
+// it receives. No encoding, no filtering.
+type collectingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (c *collectingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (c *collectingHandler) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	c.records = append(c.records, r)
+	c.mu.Unlock()
+	return nil
+}
+func (c *collectingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return c }
+func (c *collectingHandler) WithGroup(_ string) slog.Handler      { return c }

--- a/internal/cronicle/state/schema.go
+++ b/internal/cronicle/state/schema.go
@@ -10,10 +10,12 @@ package state
 // tasks:   one row per task within a run. Status follows the same lifecycle
 //          and rolls up into the parent run's status on completion.
 //
-// events:  append-only mirror of every slog event with entry_type set. Powers
-//          GET /v1/runs/{id}/events (live + recent). Bounded by retention
-//          window (see internal/cronicle/state/janitor.go); deeper history
-//          lives in the JSONL log on disk.
+// events:  slim chronology ledger — one row per structural slog event
+//          (entry_type-bearing) so the API can answer "what happened in
+//          this run, in what order?" without parsing JSONL. NO payload
+//          column: the rich bytes live in cronicle.jsonl (and Loki, when
+//          shipped). This table is metadata only; pretty/text/json bytes
+//          come from Loki for history, from LiveSink for live.
 //
 // schema_versions: numbered migrations. v1 is everything below; v2+ are
 //          appended via additional `schemaSQL_v2` blocks executed if the
@@ -65,12 +67,11 @@ CREATE TABLE IF NOT EXISTS events (
     run_id     TEXT NOT NULL,
     task       TEXT NOT NULL DEFAULT '',
     entry_type TEXT NOT NULL,
-    ts         TEXT NOT NULL,
-    payload    TEXT NOT NULL          -- the raw JSON record
+    ts         TEXT NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_events_run        ON events(run_id, id);
-CREATE INDEX IF NOT EXISTS idx_events_ts         ON events(ts);
+CREATE INDEX IF NOT EXISTS idx_events_run ON events(run_id, id);
+CREATE INDEX IF NOT EXISTS idx_events_ts  ON events(ts);
 `
 
 // schemaSQL_v2 adds the producer-served queue. Jobs persist as rows
@@ -134,4 +135,28 @@ CREATE TABLE IF NOT EXISTS workers (
 CREATE INDEX IF NOT EXISTS idx_workers_last_seen ON workers(last_seen DESC);
 `
 
-const targetSchemaVersion = 3
+// schemaSQL_v4 slims the events table. Previously `payload` stored the
+// full JSON line — duplicate of cronicle.jsonl and the Loki ingest, and
+// the source of the unbounded-growth concern. After v4, events is a
+// chronology ledger only: id, run_id, task, entry_type, ts. The actual
+// log bytes live in cronicle.jsonl → Loki for history, and in LiveSink
+// for live.
+//
+// Aggressive rebuild rather than ALTER TABLE DROP COLUMN: keeps the
+// SQL trivial and we don't carry forward old payloads anyway.
+const schemaSQL_v4 = `
+DROP TABLE IF EXISTS events;
+
+CREATE TABLE events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id     TEXT NOT NULL,
+    task       TEXT NOT NULL DEFAULT '',
+    entry_type TEXT NOT NULL,
+    ts         TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_run ON events(run_id, id);
+CREATE INDEX IF NOT EXISTS idx_events_ts  ON events(ts);
+`
+
+const targetSchemaVersion = 4

--- a/internal/cronicle/state/seq.go
+++ b/internal/cronicle/state/seq.go
@@ -1,0 +1,110 @@
+package state
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"sync/atomic"
+)
+
+// Sequence numbering for the slog event stream.
+//
+// Tagger sits at the top of the slog handler chain and stamps every
+// record with two attrs before fan-out to pretty/file/Sink/LiveSink:
+//
+//   - seq      — process-monotonic int64, starts at 1, increments per record.
+//   - lifetime — 8-char hex nonce minted at process startup.
+//
+// These attrs flow into cronicle.jsonl (and from there into Loki) so the
+// frontend can deep-link between the live SSE pane and a Loki query at
+// the same cursor:  "I see seq=42 in live, take me to seq=42 in history."
+// They also let any consumer detect missed records (gap in seq) within
+// a single process lifetime, and distinguish two processes' streams
+// (different lifetime) when correlating across restarts.
+//
+// What this is NOT (this time):
+//
+//   - NOT a de-dup key for SSE replay. Live is live; no replay path
+//     exists, so de-dup isn't required.
+//   - NOT written to the events table. The slim chronology ledger
+//     (id, run_id, task, entry_type, ts) is sufficient for ordering;
+//     seq/lifetime would be redundant there.
+
+// processNonce is minted lazily on first read. Stable for the lifetime
+// of this process. crypto/rand avoids any chance of collision across
+// producer restarts that happen within the same wall second.
+var (
+	nonceOnce  atomic.Pointer[string]
+	nonceMutex atomic.Bool // light spin-lock guarding the one-time mint
+)
+
+// ProcessNonce returns the 8-char hex lifetime tag for this process.
+// First call mints it; subsequent calls return the cached value.
+func ProcessNonce() string {
+	if p := nonceOnce.Load(); p != nil {
+		return *p
+	}
+	// Mint once. CAS dance avoids importing sync.Once for one call site;
+	// with a single producer this path runs once and never contends.
+	for !nonceMutex.CompareAndSwap(false, true) {
+	}
+	defer nonceMutex.Store(false)
+	if p := nonceOnce.Load(); p != nil {
+		return *p
+	}
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	n := hex.EncodeToString(b[:])
+	nonceOnce.Store(&n)
+	return n
+}
+
+// nextSeq is the per-process monotonic counter. Each Tagger.Handle call
+// increments it by one, so seq values are dense (no gaps) and globally
+// strictly increasing within the process.
+var nextSeq atomic.Int64
+
+// Tagger is the top-of-chain slog handler. It mints (lifetime, seq)
+// for every record and injects them as attrs before delegating. All
+// sibling handlers (pretty, JSON file, Sink, LiveSink) observe the
+// SAME tagged record — so the seq emitted in the live SSE pane
+// matches the seq written to the JSONL log byte-for-byte.
+type Tagger struct {
+	inner slog.Handler
+}
+
+// NewTagger wraps inner. Callers point slog.Default at the returned
+// Tagger. See log.go where it's wired in.
+func NewTagger(inner slog.Handler) *Tagger { return &Tagger{inner: inner} }
+
+// Inner returns the wrapped handler. Used by EnableStateStore to peel
+// the Tagger off when re-installing the chain so consecutive enables
+// don't stack two Taggers (which would double-tag every record).
+func (t *Tagger) Inner() slog.Handler { return t.inner }
+
+func (t *Tagger) Enabled(ctx context.Context, l slog.Level) bool {
+	return t.inner.Enabled(ctx, l)
+}
+
+// Handle injects seq + lifetime attrs and delegates. Tag every record,
+// not just run-bearing ones — operators want monotonic counters on
+// lifecycle prints too (proves no records were dropped between
+// handlers).
+func (t *Tagger) Handle(ctx context.Context, r slog.Record) error {
+	seq := nextSeq.Add(1)
+	r2 := r.Clone()
+	r2.AddAttrs(
+		slog.Int64("seq", seq),
+		slog.String("lifetime", ProcessNonce()),
+	)
+	return t.inner.Handle(ctx, r2)
+}
+
+func (t *Tagger) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &Tagger{inner: t.inner.WithAttrs(attrs)}
+}
+
+func (t *Tagger) WithGroup(name string) slog.Handler {
+	return &Tagger{inner: t.inner.WithGroup(name)}
+}

--- a/internal/cronicle/state/sink.go
+++ b/internal/cronicle/state/sink.go
@@ -35,6 +35,23 @@ func (s *Sink) Errors() int64 { return s.errs.Load() }
 // rarely carry entry_type.
 func (s *Sink) Enabled(_ context.Context, _ slog.Level) bool { return true }
 
+// skipEntryTypes are noisy per-line / per-token entry_types that flow
+// through pretty/file/Loki/LiveSink but MUST NOT bloat the slim events
+// ledger. A long shell task can emit thousands of stdout_chunk records;
+// an agent run emits one text_delta per token. The chronology ledger
+// answers "what structural events happened?" and only structural events
+// (schedule_*, task_*, shell_run, agent_run) get rows.
+var skipEntryTypes = map[string]bool{
+	"stdout_chunk":    true,
+	"stderr_chunk":    true,
+	"text_delta":      true,
+	"thinking_delta":  true,
+	"tool_use_start":  true,
+	"tool_use_stop":   true,
+	"tool_result":     true,
+	"turn_start":      true,
+}
+
 // Handle converts r → JSON line → Event → store.Apply. The roundtrip
 // through JSON keeps Sink consistent with the wire format used in
 // Phase 2 (POST /v1/events): the same encoder that produces the file
@@ -44,18 +61,18 @@ func (s *Sink) Handle(ctx context.Context, r slog.Record) error {
 	if s == nil || s.store == nil {
 		return nil
 	}
-	// Quick discard for records without entry_type — the bulk of slog
-	// traffic is lifecycle prints (Loading config, heartbeat, …) we
-	// don't project. Saves the JSON marshal on the hot path.
-	hasEntry := false
+	// Quick discard for records without entry_type, OR records whose
+	// entry_type is on the skip list (per-line/per-token streaming
+	// records that go to file/Loki/LiveSink but never to SQLite).
+	var entryType string
 	r.Attrs(func(a slog.Attr) bool {
 		if a.Key == "entry_type" {
-			hasEntry = true
+			entryType = a.Value.String()
 			return false
 		}
 		return true
 	})
-	if !hasEntry {
+	if entryType == "" || skipEntryTypes[entryType] {
 		return nil
 	}
 	line, err := encodeRecord(r)

--- a/internal/cronicle/state/sink.go
+++ b/internal/cronicle/state/sink.go
@@ -42,14 +42,16 @@ func (s *Sink) Enabled(_ context.Context, _ slog.Level) bool { return true }
 // answers "what structural events happened?" and only structural events
 // (schedule_*, task_*, shell_run, agent_run) get rows.
 var skipEntryTypes = map[string]bool{
-	"stdout_chunk":    true,
-	"stderr_chunk":    true,
-	"text_delta":      true,
-	"thinking_delta":  true,
-	"tool_use_start":  true,
-	"tool_use_stop":   true,
-	"tool_result":     true,
-	"turn_start":      true,
+	"stdout_chunk":     true,
+	"stderr_chunk":     true,
+	"text_delta":       true,
+	"thinking_delta":   true,
+	"tool_use_start":   true,
+	"tool_use_stop":    true,
+	"tool_result":      true,
+	"turn_start":       true,
+	"agent_run_start":  true,
+	"shell_run_start":  true,
 }
 
 // Handle converts r → JSON line → Event → store.Apply. The roundtrip

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -135,6 +135,12 @@ func (s *Store) migrate() error {
 			return fmt.Errorf("state.migrate v3: %w", err)
 		}
 	}
+	// v4: slim events ledger (drop payload column on upgrade)
+	if current < 4 {
+		if _, err := s.db.Exec(schemaSQL_v4); err != nil {
+			return fmt.Errorf("state.migrate v4: %w", err)
+		}
+	}
 	if current >= targetSchemaVersion {
 		return nil
 	}
@@ -175,22 +181,15 @@ func (s *Store) Apply(e Event) error {
 	return tx.Commit()
 }
 
-// recordEvent appends to the events table. Stores the original JSON line
-// when present; otherwise re-marshals the typed Event (lossy for unknown
-// fields but acceptable for programmatic emitters).
+// recordEvent appends a chronology row to the events ledger. Metadata
+// only — no payload. The rich bytes for an event live in cronicle.jsonl
+// (and Loki, when shipped); this row just answers "what entry_type fired
+// at which timestamp for this run/task?" so /v1/runs/{id}/events can
+// return a coarse timeline without parsing JSONL.
 func (s *Store) recordEvent(tx *sql.Tx, e Event) error {
-	payload := e.raw
-	if len(payload) == 0 {
-		// Re-marshal a minimal record. Programmatic Apply() callers don't
-		// usually need raw fidelity.
-		payload = fmt.Appendf(nil,
-			`{"time":%q,"entry_type":%q,"run_id":%q,"schedule":%q,"task":%q}`,
-			e.Time.Format(time.RFC3339Nano), e.EntryType, e.RunID, e.Schedule, e.Task,
-		)
-	}
 	_, err := tx.Exec(
-		`INSERT INTO events(run_id, task, entry_type, ts, payload) VALUES (?,?,?,?,?)`,
-		e.RunID, e.Task, e.EntryType, e.Time.UTC().Format(time.RFC3339Nano), string(payload),
+		`INSERT INTO events(run_id, task, entry_type, ts) VALUES (?,?,?,?)`,
+		e.RunID, e.Task, e.EntryType, e.Time.UTC().Format(time.RFC3339Nano),
 	)
 	if err != nil {
 		return fmt.Errorf("state.recordEvent: %w", err)

--- a/internal/cronicle/stream.go
+++ b/internal/cronicle/stream.go
@@ -1,0 +1,168 @@
+package cronicle
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/jshiv/cronicle/pkg/agent"
+)
+
+// lineEmitter wraps an io.Writer to emit one slog record per newline
+// AS BYTES FLOW THROUGH. The underlying writer (typically the
+// StreamingWriter that fronts stdout in pretty mode) still receives
+// the bytes unchanged, so the operator's terminal renders the output
+// in real time the same way it always did.
+//
+// Each completed line is also emitted as a slog.Info record with
+// entry_type=stdout_chunk (or stderr_chunk), feeding three downstream
+// destinations through the slog chain:
+//
+//   - file (cronicle.jsonl → Loki) — durable history, queryable
+//   - LiveSink → SSE — feeds the frontend's live xterm.js pane
+//   - Sink filter drops these (see state/sink.go skipEntryTypes)
+//
+// Partial lines (no trailing \n) are held in the internal buffer until
+// the next Write call brings the newline. Flush emits whatever's left
+// when the command exits — the final printf-without-newline case.
+//
+// The slog records carry run_id + task + schedule so LiveSink can
+// route by run, and Loki can label / search by them.
+type lineEmitter struct {
+	inner    io.Writer
+	runID    string
+	task     string
+	schedule string
+	stream   string // "stdout" | "stderr"
+
+	mu  sync.Mutex // guards buf (Write may run on multiple goroutines for stderr+stdout)
+	buf []byte
+}
+
+// newLineEmitter wraps inner. stream must be "stdout" or "stderr" — it
+// becomes the prefix of the emitted entry_type.
+func newLineEmitter(inner io.Writer, runID, task, schedule, stream string) *lineEmitter {
+	return &lineEmitter{
+		inner:    inner,
+		runID:    runID,
+		task:     task,
+		schedule: schedule,
+		stream:   stream,
+	}
+}
+
+// Write forwards bytes to the inner writer first (so the terminal
+// rendering is unaffected), then splits the incoming bytes plus any
+// buffered partial line on '\n' and emits one slog record per
+// completed line. The return value reports what the inner writer
+// accepted, so exec's plumbing semantics stay intact.
+func (e *lineEmitter) Write(p []byte) (int, error) {
+	n, err := e.inner.Write(p)
+	// Even if the inner writer failed partway, emit slog for whatever
+	// bytes it did accept — better partial telemetry than none.
+	if n > 0 {
+		e.consume(p[:n])
+	}
+	return n, err
+}
+
+// consume buffers bytes and emits one slog record per newline. Holds
+// the mutex briefly to keep stdout and stderr writers from interleaving
+// half-lines into each other's buffers.
+func (e *lineEmitter) consume(p []byte) {
+	e.mu.Lock()
+	e.buf = append(e.buf, p...)
+	for {
+		i := bytes.IndexByte(e.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(e.buf[:i])
+		e.buf = e.buf[i+1:]
+		e.emit(line)
+	}
+	e.mu.Unlock()
+}
+
+// Flush emits any buffered partial line (a command that printed without
+// a trailing newline before exiting). Idempotent — leaves an empty
+// buffer.
+func (e *lineEmitter) Flush() {
+	e.mu.Lock()
+	if len(e.buf) > 0 {
+		e.emit(string(e.buf))
+		e.buf = e.buf[:0]
+	}
+	e.mu.Unlock()
+}
+
+// emit publishes one slog record with the line as msg. entry_type
+// drives routing: pretty handler suppresses it for stdout (already
+// rendered by the streaming writer), LiveSink encodes it as a frame,
+// Loki indexes it.
+func (e *lineEmitter) emit(line string) {
+	slog.Info(line,
+		"entry_type", e.stream+"_chunk",
+		"run_id", e.runID,
+		"task", e.task,
+		"schedule", e.schedule,
+		"stream", e.stream,
+	)
+}
+
+// NewAgentSlogBridge returns an agent.StreamHandler that fans each
+// stream event out to slog AND to the optional `downstream` handler.
+//
+// The slog records (entry_type=text_delta / thinking_delta /
+// tool_use_start / tool_result / turn_start) flow through the normal
+// handler chain: file → Loki for history, LiveSink → SSE for the
+// frontend's live pane. The pretty handler on stdout SUPPRESSES these
+// types (suppressChunks=true) because `downstream` — when set — is the
+// existing NewAgentStreamRenderer writing directly to the stream-pretty
+// writer; rendering them again from slog would double-print on stdout.
+//
+// When stdout isn't in pretty mode, downstream is nil; nothing renders
+// to stdout, but Loki + LiveSink still see every delta. That's exactly
+// the design contract: live SSE consumers get the visceral experience
+// regardless of how the operator configured stdout.
+func NewAgentSlogBridge(runID, task, schedule string, downstream agent.StreamHandler) agent.StreamHandler {
+	return func(e agent.StreamEvent) {
+		switch e.Type {
+		case agent.StreamEventTextDelta:
+			slog.Info(e.Text,
+				"entry_type", "text_delta",
+				"run_id", runID, "task", task, "schedule", schedule,
+			)
+		case agent.StreamEventThinkingDelta:
+			slog.Info(e.Text,
+				"entry_type", "thinking_delta",
+				"run_id", runID, "task", task, "schedule", schedule,
+			)
+		case agent.StreamEventToolUseStart:
+			slog.Info("tool use start",
+				"entry_type", "tool_use_start",
+				"run_id", runID, "task", task, "schedule", schedule,
+				"tool", e.ToolName,
+				"input", e.ToolInput,
+			)
+		case agent.StreamEventToolResult:
+			slog.Info("tool result",
+				"entry_type", "tool_result",
+				"run_id", runID, "task", task, "schedule", schedule,
+				"tool", e.ToolName,
+				"is_error", e.IsError,
+				"duration_ms", e.DurationMs,
+			)
+		case agent.StreamEventTurnStart:
+			slog.Info("turn start",
+				"entry_type", "turn_start",
+				"run_id", runID, "task", task, "schedule", schedule,
+				"turn_index", e.TurnIndex,
+			)
+		}
+		if downstream != nil {
+			downstream(e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Pivots the live event stream architecture from "SSE replay backed by the events table" to **three planes with distinct responsibilities**:

| Plane | Source | Endpoints | Use |
|---|---|---|---|
| **State** | SQLite `runs` / `tasks` tables | `GET /v1/runs`, `GET /v1/runs/{id}` | Red/green/blue status pills, filterable run list |
| **History** | `cronicle.jsonl` → Loki + on-disk transcripts | LogQL / Grafana | Search & debug past runs |
| **Live** *(this PR)* | LiveSink in-memory pub/sub | `GET /v1/runs/{id}/events` (SSE) | "What is happening RIGHT NOW?" — token-by-token, line-by-line |

The visceral live pane defaults to pretty ANSI bytes, so an xterm.js frontend renders a faithful mirror of what the producer's TTY shows.

Supersedes #93, which committed to keeping rich payload bytes in SQLite — a duplicate of cronicle.jsonl and the source of the unbounded-growth concern.

## What lands

**State plane**
- `state/seq.go` — `Tagger` slog handler injecting `seq` + `lifetime` so cross-plane deep-linking works (frontend can jump from a live frame to a Loki query at the same cursor).
- `state/live_sink.go` — pluggable-encoder pub/sub `slog.Handler`. Live-only; disconnect = miss.
- `state/sink.go` — drop-list for noisy entry_types (`stdout_chunk`, `text_delta`, etc.) so the events ledger stays small.
- `state/schema.go` v4 — rebuilds events table without `payload` column.

**Streaming wire-up**
- `stream.go` — `lineEmitter` wraps stdout/stderr to emit one slog record per newline. `NewAgentSlogBridge` wraps `agent.StreamHandler` to also emit slog records per stream event. Both feed file + Loki + LiveSink regardless of stdout pretty mode.
- `exec.go` — always uses `ExecuteWithStreamContext` so per-line emission fires for every shell task. The streaming-pretty stdout path is unchanged.

**Pretty handler**
- `log.go` — `prettyHandler` gains `suppressChunks` field. True for stdout (StreamingWriter / agent renderer already wrote those bytes directly); false for the LiveSink encoder (frontend NEEDS them). New render methods for `stdout_chunk` / `stderr_chunk` / `text_delta` / `thinking_delta` / `tool_use_start` / `tool_result`.

**Endpoint**
- `listen_control.go` — `GET /v1/runs/{id}/events` ships pre-encoded bytes from LiveSink as multi-line SSE `data:` frames. No replay, no Last-Event-ID parsing, no DB reads.

**CLI**
- `cmd/root.go` — `--live-format=pretty|json|text` persistent flag, default pretty.

## Wire format

```
event: cronicle
data: hello from tick

event: cronicle
data: step 2
```

Pretty bytes are ANSI multi-line; SSE spec requires one `data:` line per `\n`, browsers (`EventSource`) join with `\n` on receive. xterm.js renders ANSI codes faithfully.

## Test plan
- [x] `go test ./... -race` clean (12 new tests across `state/live_sink_test.go` and `listen_run_events_test.go`)
- [x] `lineEmitter` partial-line buffering exercised
- [x] LiveSink slow-consumer drop verified
- [x] Tagger monotonic seq verified
- [x] SSE multi-line splitting verified against the spec
- [ ] Manual: `curl -N /v1/runs/{id}/events` against a running producer, eyeball ANSI rendering in an xterm.js frontend
- [ ] Manual: `--live-format=json` produces parseable records

🤖 Generated with [Claude Code](https://claude.com/claude-code)