### PR TITLE
Fix segfault on missing SSH deploy key + log git operations

### DIFF
--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -2,6 +2,7 @@ package cronicle
 
 import (
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -42,8 +43,15 @@ func (repo *Repo) Auth() (transport.AuthMethod, error) {
 			return nil, err
 		}
 		auth, err := ssh.NewPublicKeysFromFile("git", keyPath, "")
+		// NewPublicKeysFromFile returns (nil, err) when the key file is
+		// missing or unreadable. Checking err BEFORE touching auth fields
+		// avoids a nil-pointer SIGSEGV — the original bug here let a
+		// missing key path crash the process.
+		if err != nil {
+			return nil, fmt.Errorf("load ssh deploy key %q: %w", keyPath, err)
+		}
 		auth.HostKeyCallback = gossh.InsecureIgnoreHostKey()
-		return auth, err
+		return auth, nil
 	}
 
 	// auth := http.BasicAuth{Username: repo.user, Password: repo.password}
@@ -115,16 +123,25 @@ func Commit(worktreeDir string, msg string) {
 
 //Clone checks for the existance of worktreeDir/.git and clones if it does not exist
 //then executes Git = GetGit(worktreeDir)
+//
+//Logs each step (clone / skip / open) so operators can see git activity
+//in the pretty/json/text stdout streams — previously these operations
+//were silent and the only signal that cloning happened was the
+//directory appearing on disk.
 func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, error) {
 
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {
-
+		slog.Info("git clone", "url", url, "path", worktreeDir)
 		cloneOptions := git.CloneOptions{URL: url, Auth: *auth}
 
 		_, err := git.PlainClone(worktreeDir, false, &cloneOptions)
 		if err != nil {
+			slog.Error("git clone failed", "url", url, "path", worktreeDir, "error", err.Error())
 			return Git{}, err
 		}
+		slog.Info("git clone complete", "url", url, "path", worktreeDir)
+	} else {
+		slog.Info("git open", "path", worktreeDir, "note", "worktree already exists, skipping clone")
 	}
 
 	var g Git
@@ -170,29 +187,37 @@ func (g *Git) Checkout(branch string, commit string) error {
 		}
 	}
 
+	slog.Info("git fetch", "refs", "+refs/heads/*:refs/remotes/origin/*")
 	err := g.Repository.Fetch(&fetchOptions)
 	if err != nil {
 		switch err {
 		case git.NoErrAlreadyUpToDate:
+			slog.Info("git fetch: already up to date")
 		default:
+			slog.Error("git fetch failed", "error", err.Error())
 			return err
 		}
 	}
 
 	var checkoutOptions git.CheckoutOptions
+	var checkoutTarget string
 	if commit != "" {
 		h := plumbing.NewHash(commit)
 		checkoutOptions = git.CheckoutOptions{
 			Create: false, Force: true, Hash: h,
 		}
+		checkoutTarget = "commit=" + commit
 	} else {
 		b := plumbing.NewBranchReferenceName(branch)
 		checkoutOptions = git.CheckoutOptions{
 			Create: false, Force: true, Branch: b,
 		}
+		checkoutTarget = "branch=" + branch
 	}
 
+	slog.Info("git checkout", "target", checkoutTarget)
 	if err := g.Worktree.Checkout(&checkoutOptions); err != nil {
+		slog.Error("git checkout failed", "target", checkoutTarget, "error", err.Error())
 		return err
 	}
 

--- a/internal/cronicle/git_test.go
+++ b/internal/cronicle/git_test.go
@@ -109,4 +109,21 @@ var _ = Describe("git", func() {
 		os.RemoveAll("./cronicle-sample")
 	})
 
+	// Regression: pointing DeployKey at a missing file used to segfault
+	// inside (*Repo).Auth — ssh.NewPublicKeysFromFile returns (nil, err)
+	// and the code touched auth.HostKeyCallback before checking err.
+	// Expect a clean error now, not a panic.
+	It("Repo.Auth returns a clean error when the deploy key file does not exist", func() {
+		repo := cronicle.Repo{
+			URL:       "git@github.com:jshiv/cronicle-sample.git",
+			DeployKey: "/nonexistent/path/to/ssh_key",
+		}
+		auth, err := repo.Auth()
+		Expect(err).ToNot(BeNil())
+		Expect(auth).To(BeNil())
+		// Error message should name the offending key path so operators
+		// see what to fix.
+		Expect(err.Error()).To(ContainSubstring("/nonexistent/path/to/ssh_key"))
+	})
+
 })

--- a/internal/cronicle/init.go
+++ b/internal/cronicle/init.go
@@ -31,19 +31,24 @@ func Init(croniclePath string, cloneRepo string, deployKey string, defaultConf C
 		var cloneOptions git.CloneOptions
 		if deployKey != "" {
 			auth, err := ssh.NewPublicKeysFromFile("git", deployKey, "")
-			auth.HostKeyCallback = gossh.InsecureIgnoreHostKey()
+			// Same defensive ordering as (*Repo).Auth in git.go: check
+			// err BEFORE touching auth, otherwise a missing key file
+			// segfaults the init command.
 			if err != nil {
-				Fatal(err)
+				Fatal(fmt.Errorf("load ssh deploy key %q: %w", deployKey, err))
 			}
+			auth.HostKeyCallback = gossh.InsecureIgnoreHostKey()
 			cloneOptions = git.CloneOptions{URL: cloneRepo, Auth: auth}
 		} else {
 			cloneOptions = git.CloneOptions{URL: cloneRepo}
 		}
 
+		slog.Info("cloning repo", "url", cloneRepo, "path", absCroniclePath)
 		_, err = git.PlainClone(absCroniclePath, false, &cloneOptions)
 		if err != nil {
-			Fatal(err)
+			Fatal(fmt.Errorf("clone %s: %w", cloneRepo, err))
 		}
+		slog.Info("cloned", "url", cloneRepo, "path", absCroniclePath)
 	}
 
 	slantyedCyan := color.New(color.FgCyan, color.Italic).SprintFunc()
@@ -130,14 +135,14 @@ func (conf *Config) Init(croniclePath string) error {
 	if conf.Repo != nil {
 		auth, err := conf.Repo.Auth()
 		if err != nil {
-			return err
+			return fmt.Errorf("config repo auth: %w", err)
 		}
 		g, err := Clone(croniclePath, conf.Repo.URL, &auth)
 		if err != nil {
-			return err
+			return fmt.Errorf("clone config repo %s: %w", conf.Repo.URL, err)
 		}
 		if err := g.Checkout(conf.Repo.Branch, conf.Repo.Commit); err != nil {
-			return err
+			return fmt.Errorf("checkout config repo: %w", err)
 		}
 	}
 
@@ -149,11 +154,12 @@ func (conf *Config) Init(croniclePath string) error {
 			if task.Repo != nil {
 				auth, err := task.Repo.Auth()
 				if err != nil {
-					return err
+					return fmt.Errorf("schedule %q task %q repo auth: %w",
+						schedule.Name, task.Name, err)
 				}
 				if _, err := Clone(task.Path, task.Repo.URL, &auth); err != nil {
-					// if _, err := Clone(task.Path, task.Repo.URL, task.Repo.DeployKey); err != nil {
-					return err
+					return fmt.Errorf("schedule %q task %q clone %s: %w",
+						schedule.Name, task.Name, task.Repo.URL, err)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Two bugs found while smoke-testing a schedule-level `repo` block against a private SSH repo:

### Bug 1 — SIGSEGV when the deploy key file is missing

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0]

goroutine 1 [running]:
github.com/jshiv/cronicle/internal/cronicle.(*Repo).Auth
        internal/cronicle/git.go:45 +0x50
github.com/jshiv/cronicle/internal/cronicle.(*Config).Init
        internal/cronicle/init.go:150
\`\`\`

\`ssh.NewPublicKeysFromFile\` returns \`(nil, err)\` when the key file is missing. Both `git.go:44-45` and `init.go:33-34` set `auth.HostKeyCallback` BEFORE checking `err`, nil-derefing the `*PublicKeys` return.

**Fix:** check `err` first; wrap the error with the offending key path so operators see what to fix.

**After:**
\`\`\`
fatal error="schedule \"test\" task \"t\" repo auth: load ssh deploy key
            \"/nonexistent/path/id_ed25519\": open ...: no such file or directory"
\`\`\`

### Bug 2 — Git operations completely silent

Pretty / text / JSON stdout streams emitted **nothing** when cronicle cloned, fetched, or checked out a schedule/task repo. The only signal was the directory appearing on disk, which made misconfigured repos very confusing.

Added \`slog.Info\` at each step:

\`\`\`
11:46:25 git clone url=git@github.com:jshiv/cronicle-smoke.git path=...
11:46:26 git clone complete url=... path=...
11:46:26 git open path=... note="worktree already exists, skipping clone"
11:46:26 git fetch refs=+refs/heads/*:refs/remotes/origin/*
11:46:27 git checkout target=branch=main
\`\`\`

Renders as dim lifecycle lines in pretty stdout, structured JSON for Loki / file mirror.

### Bonus — error wrapping

Per-schedule and per-task auth/clone errors are now wrapped with schedule/task context so operators see WHICH repo failed:

\`\`\`
schedule "with-repo" task "ping" clone git@github.com:...: <underlying go-git error>
\`\`\`

## Test plan
- [x] New regression test \`Repo.Auth\` with nonexistent DeployKey returns clean error, error message contains the offending path
- [x] \`go test ./... -race\` clean (60 specs pass, up from 59)
- [x] Smoke: bad key path → exit 1 with structured error, no panic
- [x] Smoke: valid private repo (SSH ed25519) clones and runs, log shows clone → fetch → checkout sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)