### PR TITLE
Show git clone progress in pretty mode

### DIFF
--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -3,6 +3,7 @@ package cronicle
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -133,6 +134,16 @@ func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, err
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {
 		slog.Info("git clone", "url", url, "path", worktreeDir)
 		cloneOptions := git.CloneOptions{URL: url, Auth: *auth}
+		// In pretty mode, route go-git's progress sideband straight to
+		// stdout so the user sees the live "Counting objects" / "Receiving
+		// objects" lines (the same UX as the host `git` CLI). In file/Loki
+		// modes we deliberately omit Progress — those sinks already get
+		// the structured "git clone" / "git clone complete" slog records,
+		// and the per-percent overwrite lines (carriage-return updates)
+		// just produce noise in line-oriented log files.
+		if IsStreamingPretty() {
+			cloneOptions.Progress = os.Stdout
+		}
 
 		_, err := git.PlainClone(worktreeDir, false, &cloneOptions)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Route go-git's progress sideband to `os.Stdout` in the `Clone` path when `IsStreamingPretty()` is true, so operators get the live `Counting objects` / `Receiving objects` overwrite lines that `git` CLI users expect.
- Text/JSON/Loki modes are unchanged: they keep the structured `git clone` / `git clone complete` slog records and stay clean of carriage-return noise.

## Why pretty-only
The progress sideband emits `\r`-overwritten lines (`Receiving objects: 47% (5/10)` → `Receiving objects: 100% (10/10)`). In a TTY this animates in place; in a logfile or Loki it becomes a wall of duplicates. Gating on `IsStreamingPretty()` keeps the structured ledger pristine while giving the interactive UX where it actually renders.

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./internal/cronicle/...` passes (cronicle + state packages)
- [x] Smoke: tiny repo (octocat/Hello-World) — `Enumerating objects: 13, done.` shows between the slog records in pretty mode
- [x] Smoke: larger repo (spf13/cobra, ~4.5k objects) — `Counting objects: 100%` shows the overwrite frames in pretty mode
- [x] Same larger repo with `--log-format text` — no progress lines emitted; only the structured `git clone` / `git clone complete` slog records remain