### PR TITLE
Surface worker events on SSE with format-consistent re-encoding

### DIFF
--- a/internal/cronicle/ingest_rehydrate.go
+++ b/internal/cronicle/ingest_rehydrate.go
@@ -1,0 +1,148 @@
+package cronicle
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// rehydrateRecord turns one JSONL line shipped by a worker's
+// eventShipper (worker_event_ship.go:Handle) back into the slog.Record
+// that produced it. Used by the runner's /v1/events ingest path so
+// worker-side records flow through the runner's LiveSink encoder —
+// SSE subscribers then see one consistent --live-format regardless of
+// whether the work happened locally or on a worker.
+//
+// The wire shape is whatever the worker's shipper writes: a flat JSON
+// object with `time`, `level`, `msg`, plus all slog attrs as top-level
+// keys. We reverse that here.
+//
+// Returns ok=false on malformed JSON or if `msg`/`time` are missing.
+// Caller drops the line in that case — the projection path already
+// counted it as accepted, but the live stream simply skips frames we
+// can't reconstruct rather than emitting garbage.
+//
+// Numeric values: workers ship Go integers as JSON numbers. To keep
+// Int64 vs Float64 kind fidelity (renderers call a.Value.Int64() on
+// integer attrs like `exit` and `duration_ms`), we use json.Number
+// and probe for integer-ness before falling back to float64.
+//
+// Slice values: when every element is a string we reconstruct the
+// []string the renderer expects (e.g. schedule_start's `tasks` attr,
+// agent_run_start's `skills_available`). Mixed-type slices fall back
+// to a JSON-stringified blob — those don't appear in current cronicle
+// records but the path stays safe.
+func rehydrateRecord(line []byte) (slog.Record, bool) {
+	dec := json.NewDecoder(bytes.NewReader(line))
+	dec.UseNumber()
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		return slog.Record{}, false
+	}
+
+	var t time.Time
+	if v, ok := m["time"].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			t = parsed
+		}
+	}
+
+	lvl := slog.LevelInfo
+	if v, ok := m["level"].(string); ok {
+		switch strings.ToUpper(v) {
+		case "DEBUG":
+			lvl = slog.LevelDebug
+		case "INFO":
+			lvl = slog.LevelInfo
+		case "WARN", "WARNING":
+			lvl = slog.LevelWarn
+		case "ERROR":
+			lvl = slog.LevelError
+		}
+	}
+
+	msg, _ := m["msg"].(string)
+
+	rec := slog.NewRecord(t, lvl, msg, 0)
+
+	// AddAttrs in a stable-ish order: deterministic key iteration via
+	// sorted keys keeps test assertions easier and the rendered output
+	// reproducible. Map iteration in Go is randomized; renderers don't
+	// care about order today but byte-for-byte test assertions would.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if k == "time" || k == "level" || k == "msg" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	for _, k := range keys {
+		rec.AddAttrs(jsonValueToAttr(k, m[k]))
+	}
+	return rec, true
+}
+
+// jsonValueToAttr maps a json.Decoder UseNumber result back to the
+// slog kind a renderer would expect for that key. We can't infer the
+// original kind from the JSON alone for numbers (a Go int and float
+// look identical when small), so we prefer Int64 when the json.Number
+// parses cleanly as one — that's what every cronicle int attr looks
+// like on the wire.
+func jsonValueToAttr(k string, v any) slog.Attr {
+	switch x := v.(type) {
+	case string:
+		return slog.String(k, x)
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return slog.Int64(k, i)
+		}
+		if f, err := x.Float64(); err == nil {
+			return slog.Float64(k, f)
+		}
+		return slog.String(k, x.String())
+	case bool:
+		return slog.Bool(k, x)
+	case nil:
+		return slog.String(k, "")
+	case []any:
+		if strs, ok := allStringSlice(x); ok {
+			// slog.Any preserves []string under .Any() — renderers like
+			// renderScheduleStart and renderAgentRunStart type-assert
+			// directly, so the kind must match exactly.
+			return slog.Any(k, strs)
+		}
+		b, _ := json.Marshal(x)
+		return slog.String(k, string(b))
+	case map[string]any:
+		b, _ := json.Marshal(x)
+		return slog.String(k, string(b))
+	default:
+		return slog.Any(k, v)
+	}
+}
+
+func allStringSlice(xs []any) ([]string, bool) {
+	out := make([]string, len(xs))
+	for i, x := range xs {
+		s, ok := x.(string)
+		if !ok {
+			return nil, false
+		}
+		out[i] = s
+	}
+	return out, true
+}
+
+// sortStrings is a tiny inline insertion sort. Not using sort.Strings
+// to keep the rehydrate path's working set small and avoid the import
+// for what's almost always <10 keys per record.
+func sortStrings(xs []string) {
+	for i := 1; i < len(xs); i++ {
+		for j := i; j > 0 && xs[j-1] > xs[j]; j-- {
+			xs[j-1], xs[j] = xs[j], xs[j-1]
+		}
+	}
+}

--- a/internal/cronicle/ingest_rehydrate_test.go
+++ b/internal/cronicle/ingest_rehydrate_test.go
@@ -1,0 +1,70 @@
+package cronicle
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// TestRehydrateRecord_RoundtripIntKind: the renderers read integer
+// attrs via a.Value.Int64() — if rehydrate produces Float64Kind for
+// JSON numbers, .Int64() panics. This test pins the contract: any
+// JSON number that parses as int64 must come back as Int64Kind.
+func TestRehydrateRecord_RoundtripIntKind(t *testing.T) {
+	line := []byte(`{"time":"2026-05-11T12:00:00Z","level":"INFO","msg":"shell complete","entry_type":"shell_run","run_id":"R1","schedule":"s","task":"t","exit":0,"duration_ms":1234,"success":true}`)
+	rec, ok := rehydrateRecord(line)
+	if !ok {
+		t.Fatal("rehydrate: ok=false")
+	}
+	got := map[string]slog.Kind{}
+	rec.Attrs(func(a slog.Attr) bool {
+		got[a.Key] = a.Value.Kind()
+		return true
+	})
+	for _, k := range []string{"exit", "duration_ms"} {
+		if got[k] != slog.KindInt64 {
+			t.Errorf("attr %q: kind=%v, want Int64", k, got[k])
+		}
+	}
+	if got["success"] != slog.KindBool {
+		t.Errorf("attr success: kind=%v, want Bool", got["success"])
+	}
+	if got["task"] != slog.KindString {
+		t.Errorf("attr task: kind=%v, want String", got["task"])
+	}
+}
+
+// TestRehydrateRecord_StringSliceKind: schedule_start ships a
+// "tasks":["a","b"] attr that renderScheduleStart type-asserts as
+// []string via a.Value.Any().([]string). The rehydrate must preserve
+// that shape — anything else makes the DAG line render as a generic
+// "tasks=[a b]" instead of the pretty list.
+func TestRehydrateRecord_StringSliceKind(t *testing.T) {
+	line := []byte(`{"time":"2026-05-11T12:00:00Z","level":"INFO","msg":"schedule started","entry_type":"schedule_start","run_id":"R1","schedule":"daily","tasks":["a","b","c"]}`)
+	rec, ok := rehydrateRecord(line)
+	if !ok {
+		t.Fatal("rehydrate: ok=false")
+	}
+	var tasks []string
+	rec.Attrs(func(a slog.Attr) bool {
+		if a.Key != "tasks" {
+			return true
+		}
+		v, ok := a.Value.Any().([]string)
+		if !ok {
+			t.Fatalf("tasks attr: underlying type = %T, want []string", a.Value.Any())
+		}
+		tasks = v
+		return false
+	})
+	if len(tasks) != 3 || tasks[0] != "a" || tasks[2] != "c" {
+		t.Fatalf("tasks: %v", tasks)
+	}
+}
+
+// TestRehydrateRecord_MalformedReturnsFalse: garbage in → ok=false,
+// caller drops the frame. We don't want partial records reaching SSE.
+func TestRehydrateRecord_MalformedReturnsFalse(t *testing.T) {
+	if _, ok := rehydrateRecord([]byte(`{not valid`)); ok {
+		t.Fatal("expected ok=false for malformed JSON")
+	}
+}

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -510,14 +510,18 @@ func (s *listenServer) handleIngestEvents(w http.ResponseWriter, r *http.Request
 		// distributed-mode workers stay invisible to the live stream even
 		// though their events are persisted just fine.
 		//
-		// We pass the worker's original JSONL bytes through unchanged. The
-		// Inject contract is "as if these came through Handle"; the encoder
-		// the runner's own LiveSink uses would only re-encode the same data,
-		// and re-encoding worker-side ANSI/pretty bytes would lose color
-		// fidelity (workers ship JSON over the wire regardless of operator
-		// --live-format choice). Subscribers get exactly what the worker's
-		// file/jsonl record looks like; the SSE handler doesn't care.
-		liveSink.Inject(ev.RunID, ev.Schedule, ev.Task, append([]byte(nil), line...))
+		// Rehydrate the worker's JSON line back into a slog.Record and
+		// route it through liveSink.Handle. This puts worker records on
+		// the same encode path the runner's own slog chain uses, so SSE
+		// subscribers see ONE wire format (whatever --live-format chose)
+		// regardless of whether the work ran locally or on a worker. The
+		// alternative — Inject with raw bytes — leaks JSON-on-the-wire
+		// into a pretty subscriber's pane, which is jarring for agent
+		// runs where the user expects the same ANSI-rendered output as
+		// a local run.
+		if rec, ok := rehydrateRecord(line); ok {
+			_ = liveSink.Handle(r.Context(), rec)
+		}
 		accepted++
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -476,6 +476,10 @@ func (s *listenServer) handleIngestEvents(w http.ResponseWriter, r *http.Request
 		http.Error(w, "state store not enabled", http.StatusServiceUnavailable)
 		return
 	}
+	// liveSink may be nil when the state subsystem is wired without a
+	// live plane (older test harnesses). Inject is a no-op on nil, so the
+	// only cost of resolving it here is one accessor call per request.
+	liveSink := s.currentLiveSink()
 	body := http.MaxBytesReader(w, r.Body, maxEventBatchBytes)
 	defer body.Close()
 
@@ -500,6 +504,20 @@ func (s *listenServer) handleIngestEvents(w http.ResponseWriter, r *http.Request
 			dropped++
 			continue
 		}
+		// Fan worker-shipped events out to SSE subscribers on the runner.
+		// Without this, /v1/runs/{id}/events and /v1/schedules/{name}/events
+		// only ever see records produced by the runner's own slog chain —
+		// distributed-mode workers stay invisible to the live stream even
+		// though their events are persisted just fine.
+		//
+		// We pass the worker's original JSONL bytes through unchanged. The
+		// Inject contract is "as if these came through Handle"; the encoder
+		// the runner's own LiveSink uses would only re-encode the same data,
+		// and re-encoding worker-side ANSI/pretty bytes would lose color
+		// fidelity (workers ship JSON over the wire regardless of operator
+		// --live-format choice). Subscribers get exactly what the worker's
+		// file/jsonl record looks like; the SSE handler doesn't care.
+		liveSink.Inject(ev.RunID, ev.Schedule, ev.Task, append([]byte(nil), line...))
 		accepted++
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/cronicle/listen_events_test.go
+++ b/internal/cronicle/listen_events_test.go
@@ -248,18 +248,110 @@ func TestIngest_FanoutsToLiveSink(t *testing.T) {
 		if frame == "" {
 			t.Fatal("empty SSE frame — subscriber received nothing")
 		}
-		// We pass the worker's bytes through verbatim, so the frame's
-		// `data:` line carries the original JSON. Asserting on the
-		// run_id substring is enough to prove fan-out; format-fidelity
-		// is a separate concern (see commit message).
-		if !strings.Contains(frame, "WORKER-R1") {
-			t.Fatalf("subscriber missed the worker event; frame=%q", frame)
+		// After rehydrate + re-encode, the subscriber sees the runner's
+		// pretty form, NOT the worker's raw JSON. renderStdoutChunk
+		// renders only the message line; the run_id stays in the
+		// routing tags (used by fan-out filter) but doesn't appear in
+		// the encoded payload.
+		if !strings.Contains(frame, "data: hello from worker") {
+			t.Fatalf("subscriber missed pretty-rendered chunk; frame=%q", frame)
 		}
-		if !strings.Contains(frame, "hello from worker") {
-			t.Fatalf("subscriber missed event body; frame=%q", frame)
+		// JSON wire-shape leakage check: if the run_id key appears in
+		// the frame, we're back to raw-JSON pass-through and the format
+		// unification regressed.
+		if strings.Contains(frame, `"run_id"`) {
+			t.Fatalf("frame leaked raw JSON shape; want pretty encoding only; frame=%q", frame)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out — worker event did not reach SSE subscriber")
+	}
+}
+
+// TestIngest_AgentDeltaRendersPretty: workers run agents in distributed
+// mode (the heavy work). Text deltas (token-by-token model output) MUST
+// reach the SSE pane in the same ANSI-pretty form a runner-local agent
+// would produce — anything else means a frontend operator gets raw JSON
+// when watching a worker-executed agent, while a runner-executed agent
+// shows clean text. The whole point of unifying the wire format on the
+// runner side is that the operator can't tell the difference.
+//
+// Mechanically: rehydrate must reconstruct a slog.Record that
+// renderTextDelta accepts. The renderer reads r.Message directly and
+// writes it without a trailing newline (the model controls its own
+// formatting), so the SSE frame's `data:` line carries the token
+// exactly as the model produced it.
+func TestIngest_AgentDeltaRendersPretty(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	defer store.Close()
+
+	ls := state.NewLiveSink(newLiveEncoder(LiveFormatPretty))
+	srv := &listenServer{
+		token:       "secret",
+		stateSrc:    func() *state.Store { return store },
+		liveSinkSrc: func() *state.LiveSink { return ls },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", srv.handleIngestEvents)
+	mux.HandleFunc("/v1/runs/", srv.handleRunRoute)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	subReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/runs/AGENT-RUN/events", nil)
+	subReq.Header.Set("Authorization", "Bearer secret")
+	subResp, err := http.DefaultClient.Do(subReq)
+	if err != nil {
+		t.Fatalf("subscribe GET: %v", err)
+	}
+	defer subResp.Body.Close()
+
+	frames := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(subResp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var cur []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				frame := strings.Join(cur, "\n")
+				cur = nil
+				if strings.HasPrefix(frame, ": ping") {
+					continue
+				}
+				frames <- frame
+				return
+			}
+			cur = append(cur, line)
+		}
+		frames <- ""
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Worker ships a single agent text_delta carrying the model's token.
+	// Numeric attrs (output_tokens) go through json.Number so the
+	// rehydrate produces Int64Kind — same as a runner-local record.
+	body := `{"time":"2026-05-11T12:00:00Z","level":"INFO","msg":"The quick brown fox","entry_type":"text_delta","run_id":"AGENT-RUN","schedule":"agent-demo","task":"summarize","output_tokens":4}`
+	rr := httptest.NewRecorder()
+	srv.handleIngestEvents(rr, ingestRequest(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ingest: got %d", rr.Code)
+	}
+
+	select {
+	case frame := <-frames:
+		// renderTextDelta writes just r.Message — no decoration, no
+		// newline added. SSE frame is then `event: cronicle` / `data: The quick brown fox`.
+		if !strings.Contains(frame, "data: The quick brown fox") {
+			t.Fatalf("agent delta did not render as pretty text; frame=%q", frame)
+		}
+		if strings.Contains(frame, `"entry_type"`) {
+			t.Fatalf("frame leaked raw JSON shape from worker; frame=%q", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out — agent delta did not reach SSE subscriber")
 	}
 }
 

--- a/internal/cronicle/listen_events_test.go
+++ b/internal/cronicle/listen_events_test.go
@@ -1,12 +1,14 @@
 package cronicle
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jshiv/cronicle/internal/cronicle/state"
 )
@@ -150,6 +152,114 @@ func TestIngest_BodyTooLarge(t *testing.T) {
 	srv.handleIngestEvents(rr, req)
 	if rr.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("got %d, want 413; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestIngest_FanoutsToLiveSink: distributed-mode workers POST their
+// slog records to /v1/events. The runner must republish them to the
+// in-memory LiveSink so SSE subscribers (which only see the runner's
+// own slog chain via Handle) get visibility into worker-executed work.
+//
+// Without this fan-out, /v1/runs/{id}/events on the runner would show
+// runner-locally-executed records only — worker records would persist
+// to SQLite fine but never reach the live stream. That's the visibility
+// gap a frontend operator hits when they trigger a job that lands on a
+// worker node and see an empty SSE pane.
+//
+// This test wires the real ingest endpoint to a real LiveSink, opens
+// a real SSE subscription over httptest, POSTs a JSONL line, and
+// verifies the subscriber receives the event bytes verbatim.
+func TestIngest_FanoutsToLiveSink(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	defer store.Close()
+
+	ls := state.NewLiveSink(newLiveEncoder(LiveFormatPretty))
+	srv := &listenServer{
+		token:       "secret",
+		stateSrc:    func() *state.Store { return store },
+		liveSinkSrc: func() *state.LiveSink { return ls },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/events", srv.handleIngestEvents)
+	mux.HandleFunc("/v1/runs/", srv.handleRunRoute)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// Subscriber side: open an SSE GET on the run_id the worker will
+	// publish under. The subscription must be alive before the POST or
+	// the LiveSink fan-out has no consumer to deliver to (LiveSink is
+	// pub/sub with no replay buffer — the same shape the production code
+	// uses).
+	subReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/runs/WORKER-R1/events", nil)
+	subReq.Header.Set("Authorization", "Bearer secret")
+	subResp, err := http.DefaultClient.Do(subReq)
+	if err != nil {
+		t.Fatalf("subscribe GET: %v", err)
+	}
+	defer subResp.Body.Close()
+	if subResp.StatusCode != 200 {
+		t.Fatalf("subscribe: got %d", subResp.StatusCode)
+	}
+
+	frames := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(subResp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var cur []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				frame := strings.Join(cur, "\n")
+				cur = nil
+				if strings.HasPrefix(frame, ": ping") {
+					continue
+				}
+				frames <- frame
+				return
+			}
+			cur = append(cur, line)
+		}
+		frames <- ""
+	}()
+
+	// Give the SSE handler a beat to Subscribe before the POST fires.
+	time.Sleep(50 * time.Millisecond)
+
+	// Worker-shipper side: POST one JSONL event. Shape matches what
+	// worker_event_ship.go writes — generic JSON with time/level/msg
+	// plus the entry_type/run_id/schedule/task routing attrs.
+	body := `{"time":"2026-05-11T12:00:00Z","level":"INFO","msg":"hello from worker","entry_type":"stdout_chunk","run_id":"WORKER-R1","schedule":"distributed","task":"remote-task","stream":"stdout"}`
+	rr := httptest.NewRecorder()
+	srv.handleIngestEvents(rr, ingestRequest(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ingest: got %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp ingestResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.Accepted != 1 {
+		t.Fatalf("accepted: got %d, want 1", resp.Accepted)
+	}
+
+	select {
+	case frame := <-frames:
+		if frame == "" {
+			t.Fatal("empty SSE frame — subscriber received nothing")
+		}
+		// We pass the worker's bytes through verbatim, so the frame's
+		// `data:` line carries the original JSON. Asserting on the
+		// run_id substring is enough to prove fan-out; format-fidelity
+		// is a separate concern (see commit message).
+		if !strings.Contains(frame, "WORKER-R1") {
+			t.Fatalf("subscriber missed the worker event; frame=%q", frame)
+		}
+		if !strings.Contains(frame, "hello from worker") {
+			t.Fatalf("subscriber missed event body; frame=%q", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out — worker event did not reach SSE subscriber")
 	}
 }
 

--- a/internal/cronicle/state/live_sink.go
+++ b/internal/cronicle/state/live_sink.go
@@ -174,24 +174,6 @@ func (s *LiveSink) Handle(_ context.Context, r slog.Record) error {
 func (s *LiveSink) WithAttrs(_ []slog.Attr) slog.Handler { return s }
 func (s *LiveSink) WithGroup(_ string) slog.Handler      { return s }
 
-// Inject forwards pre-encoded bytes to subscribers as if they had come
-// through Handle, bypassing the LiveSink's Encoder. Useful when a caller
-// already has the exact wire bytes they want subscribers to see and
-// wants to skip the encode step entirely.
-//
-// The runner's /v1/events ingest path does NOT use Inject — it
-// rehydrates worker JSON back to a slog.Record and calls Handle, so
-// subscribers see one consistent --live-format regardless of where the
-// work ran. Inject is kept for cases where format bypass is intentional
-// (e.g. a future bridge that ferries pre-rendered bytes from a
-// non-slog source).
-func (s *LiveSink) Inject(runID, schedule, task string, line []byte) {
-	if s == nil || runID == "" || len(line) == 0 {
-		return
-	}
-	s.fanout(recordTags{runID: runID, schedule: schedule, task: task}, line)
-}
-
 // fanout walks the subscriber set under the mutex, then sends under no
 // lock. Slow consumers get a non-blocking drop — better to lose a few
 // frames in one tab than stall every other tab watching the same run.

--- a/internal/cronicle/state/live_sink.go
+++ b/internal/cronicle/state/live_sink.go
@@ -175,11 +175,16 @@ func (s *LiveSink) WithAttrs(_ []slog.Attr) slog.Handler { return s }
 func (s *LiveSink) WithGroup(_ string) slog.Handler      { return s }
 
 // Inject forwards pre-encoded bytes to subscribers as if they had come
-// through Handle. Used by the distributed-mode ingest path (POST
-// /v1/events) where worker records arrive at the producer as bytes,
-// not through the producer's slog handler chain, so Handle never sees
-// them. Caller passes the routing tags it already decoded from the
-// Event struct.
+// through Handle, bypassing the LiveSink's Encoder. Useful when a caller
+// already has the exact wire bytes they want subscribers to see and
+// wants to skip the encode step entirely.
+//
+// The runner's /v1/events ingest path does NOT use Inject — it
+// rehydrates worker JSON back to a slog.Record and calls Handle, so
+// subscribers see one consistent --live-format regardless of where the
+// work ran. Inject is kept for cases where format bypass is intentional
+// (e.g. a future bridge that ferries pre-rendered bytes from a
+// non-slog source).
 func (s *LiveSink) Inject(runID, schedule, task string, line []byte) {
 	if s == nil || runID == "" || len(line) == 0 {
 		return

--- a/internal/cronicle/state/live_sink_test.go
+++ b/internal/cronicle/state/live_sink_test.go
@@ -339,32 +339,6 @@ func TestLiveSink_DoubleUnsubscribeIsSafe(t *testing.T) {
 	unsub() // would panic if not idempotent
 }
 
-// TestLiveSink_InjectFanout: Inject takes pre-encoded bytes and
-// delivers them as if they came through Handle. Used by the ingest
-// path (POST /v1/events) where worker events arrive as bytes from a
-// remote worker rather than through this process's slog chain.
-func TestLiveSink_InjectFanout(t *testing.T) {
-	ls := NewLiveSink(trivialEncoder)
-	ch, unsub := ls.Subscribe(Filter{RunID: "R"})
-	defer unsub()
-
-	line := []byte("hello from worker\n")
-	ls.Inject("R", "sched", "task1", line)
-
-	select {
-	case got := <-ch:
-		if string(got) != string(line) {
-			t.Fatalf("payload mismatch: got %s", got)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("Inject did not deliver")
-	}
-
-	// Empty runID and empty line are no-ops.
-	ls.Inject("", "sched", "task1", line)
-	ls.Inject("R", "sched", "task1", nil)
-}
-
 // TestLiveSink_ConcurrentSubscribePublish: lots of subscribers, lots
 // of publishes, race detector must be happy.
 func TestLiveSink_ConcurrentSubscribePublish(t *testing.T) {


### PR DESCRIPTION
## Summary

Distributed-mode workers were invisible to the SSE live stream. Workers ship slog records via `POST /v1/events`; the runner persisted them to SQLite but never republished them to the in-memory `LiveSink`, so `/v1/runs/{id}/events` and `/v1/schedules/{name}/events` on the runner only surfaced runner-locally-executed tasks. Frontends watching a run that landed on a worker saw an empty SSE pane.

Workers are where the heavy work runs — agents, long shell tasks — so unified visual fidelity matters. This PR makes worker output indistinguishable from runner-local output on SSE.

## Change

1. **`internal/cronicle/ingest_rehydrate.go`** (new) — `rehydrateRecord(line)` turns a worker's JSONL line back into the `slog.Record` that produced it. Reverses `worker_event_ship.go`'s serialization with kind fidelity:
   - JSON numbers → `Int64Kind` when they parse cleanly as int64 (renderers call `.Int64()` on `exit`, `duration_ms`, etc.)
   - `[]string` slices reconstructed for `schedule_start.tasks`, `agent_run_start.skills_available`
   - Sorted attr order for reproducible encoding

2. **`internal/cronicle/listen.go`** — `handleIngestEvents` now calls `liveSink.Handle(ctx, rec)` with the rehydrated record. This routes worker events through the same encoder runner-local records use, so subscribers see one consistent `--live-format` regardless of where the work ran.

3. **`internal/cronicle/state/live_sink.go`** — `Inject` docstring updated. The method is kept for hypothetical raw-bytes bypass cases but is no longer used by the ingest path.

## Why rehydrate-and-Handle vs. raw bytes pass-through

The first cut of this fix used `LiveSink.Inject(line)` to forward worker bytes verbatim. That left subscribers seeing mixed wire formats: pretty ANSI for runner-local records, raw JSON for worker records. For agent runs (the most visible distributed-mode use case), the operator would see clean token-by-token text from runner-local agents and a wall of JSON for worker agents — same agent, different output.

Rehydrate + Handle costs one `json.Decoder.Decode` and one re-encode per ingested event. Workers ship ~10s of events/sec at peak, so the overhead is negligible. The UX win is worth the complexity.

## Test plan

- [x] `TestRehydrateRecord_RoundtripIntKind` — `exit`, `duration_ms` come back as `Int64Kind`; booleans as `Bool`; strings as `String`. Pins the contract the renderers depend on.
- [x] `TestRehydrateRecord_StringSliceKind` — `tasks:["a","b","c"]` reconstructs as `[]string`, type assertion that `renderScheduleStart` does succeeds.
- [x] `TestRehydrateRecord_MalformedReturnsFalse` — bad JSON drops the frame cleanly; no partial records reach SSE.
- [x] `TestIngest_FanoutsToLiveSink` — full HTTP path; subscriber receives `data: hello from worker`, no JSON shape leakage (`"run_id"` literal must not appear in the pretty frame).
- [x] `TestIngest_AgentDeltaRendersPretty` — `text_delta` from a worker renders as pretty SSE; `entry_type` JSON key absent from the frame.
- [x] 20× stress run of the two new fan-out tests — no flakes.
- [x] Full `go test ./internal/cronicle/...` passes (existing run-events / schedule-events / firehose / ingest tests all still green).