### PR TITLE
Use listener run_id in per-task transcript filename when set

### DIFF
--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -108,7 +108,7 @@ func (task *Task) Exec(t time.Time) exec.Result {
 
 		if FileLoggingEnabled {
 			commit, email := task.gitMeta()
-			if path, err := writeShellTranscript(task.ScheduleName, task.Name, task.Path,
+			if path, err := writeShellTranscript(task.RunID, task.ScheduleName, task.Name, task.Path,
 				task.Env, startedAt, finishedAt, result, commit, email); err == nil {
 				task.lastTranscript = path
 			}
@@ -141,7 +141,16 @@ func (task *Task) gitMeta() (commit, email string) {
 // fields stay on one line. task.Log is skipped for agent tasks because this
 // function owns the agent's logging end-to-end.
 func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
-	runID := fmt.Sprintf("%s-%s-%s", t.UTC().Format("20060102T150405Z"), task.ScheduleName, task.Name)
+	// Prefer the listener-assigned per-fire run_id so the transcript filename
+	// is findable from /v1/runs/{id} ({run_id}-{task}.jsonl). Fall back to the
+	// timestamp-derived form when running outside the listener (e.g. direct
+	// `cronicle exec` against a local file).
+	var runID string
+	if task.RunID != "" {
+		runID = fmt.Sprintf("%s-%s", task.RunID, task.Name)
+	} else {
+		runID = fmt.Sprintf("%s-%s-%s", t.UTC().Format("20060102T150405Z"), task.ScheduleName, task.Name)
+	}
 
 	// Skills: load all listed SKILL.md files up-front so a misconfigured
 	// skill (missing file, bad frontmatter) fails the run before any API

--- a/internal/cronicle/transcript.go
+++ b/internal/cronicle/transcript.go
@@ -11,10 +11,14 @@ import (
 )
 
 // writeShellTranscript writes a per-run JSONL transcript for a shell task to
-// .cronicle/runs/{ts}-{schedule}-{task}.jsonl. Returns "" if file logging is
-// disabled. The schema mirrors the agent transcript: three lines (request /
-// response / accounting), so consumers can read both task types uniformly.
-func writeShellTranscript(scheduleName, taskName, taskPath string, env []string,
+// .cronicle/runs/{run_id}-{task}.jsonl when runID is set (the listener-fired
+// path), else .cronicle/runs/{ts}-{schedule}-{task}.jsonl (legacy / direct
+// `cronicle exec` path). Returns "" if file logging is disabled. The schema
+// mirrors the agent transcript: three lines (request / response / accounting),
+// so consumers can read both task types uniformly. Keying by the run_id makes
+// the file findable from the listener's /v1/runs/{id} response without a
+// schedule+task lookup.
+func writeShellTranscript(runID, scheduleName, taskName, taskPath string, env []string,
 	started, finished time.Time, res exec.Result,
 	gitCommit, gitAuthor string) (string, error) {
 	if !FileLoggingEnabled {
@@ -24,8 +28,13 @@ func writeShellTranscript(scheduleName, taskName, taskPath string, env []string,
 	if err := os.MkdirAll(runsDir, 0o755); err != nil {
 		return "", err
 	}
-	name := fmt.Sprintf("%s-%s-%s.jsonl",
-		started.UTC().Format("20060102T150405Z"), scheduleName, taskName)
+	var name string
+	if runID != "" {
+		name = fmt.Sprintf("%s-%s.jsonl", runID, taskName)
+	} else {
+		name = fmt.Sprintf("%s-%s-%s.jsonl",
+			started.UTC().Format("20060102T150405Z"), scheduleName, taskName)
+	}
 	p := filepath.Join(runsDir, name)
 	f, err := os.Create(p)
 	if err != nil {


### PR DESCRIPTION
## Summary
Per-task transcripts (\`writeShellTranscript\` and the agent transcript writer in \`pkg/agent\`) now produce \`{run_id}-{task}.jsonl\` whenever the listener has assigned a per-fire \`Schedule.RunID\` (propagated to \`Task.RunID\` in \`dag.go\`'s \`ExecuteTasks\`). The legacy \`{ts}-{schedule}-{task}.jsonl\` form is preserved for direct \`cronicle exec\` runs that have no listener context.

## Why
Control-plane consumers (cronicle-infra's per-run transcript blob store and the cronicle-web viewer) want to look transcripts up by listener run_id without an extra schedule+task lookup. The previous filename used trigger timestamp + schedule + task, none of which appears in \`/v1/runs/{id}\` responses, so a 404 round-trip was unavoidable from the UI.

After this patch the filename's prefix segment matches the run_id verbatim — a control-plane GET can compose the on-disk key from the listener's response alone.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/cronicle/...\` clean
- [x] Smoke against k8s cluster: triggered \`heartbeat\`, \`long_build\`, \`quick_writer\`, \`code_review\` schedules. Worker scanner uploaded 4 files; filenames matched listener \`/v1/runs\` ids:
  - \`20260512T002936Z-fbe2469a-haiku.jsonl\` ↔ run_id \`20260512T002936Z-fbe2469a\`, schedule \`quick_writer\`
  - \`20260512T002936Z-685d9d88-review.jsonl\` ↔ run_id \`20260512T002936Z-685d9d88\`, schedule \`code_review\`
- [x] Cost tracking still works: \`quick_writer\` \$0.002, \`code_review\` \$0.010
- [ ] Verify legacy direct-exec path (\`cronicle exec --path …\`) still produces \`{ts}-{schedule}-{task}.jsonl\` form