### PR TITLE
Fix run rollup when agent fails before any token usage

### DIFF
--- a/internal/cronicle/ingest_rehydrate_test.go
+++ b/internal/cronicle/ingest_rehydrate_test.go
@@ -2,6 +2,7 @@ package cronicle
 
 import (
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -66,5 +67,32 @@ func TestRehydrateRecord_StringSliceKind(t *testing.T) {
 func TestRehydrateRecord_MalformedReturnsFalse(t *testing.T) {
 	if _, ok := rehydrateRecord([]byte(`{not valid`)); ok {
 		t.Fatal("expected ok=false for malformed JSON")
+	}
+}
+
+// TestRenderAgentRunFooter_IntCostUsd: regression — when an agent
+// failed before any token usage (e.g. missing API key), cost_usd lands
+// on the wire as JSON `0`, which rehydrate decodes as Int64. The footer
+// renderer previously called a.Value.Float64() unconditionally and
+// panicked, aborting the rest of the worker→producer ingest batch and
+// leaving the run row stuck on status=running. valueFloat64 must tolerate
+// either kind.
+func TestRenderAgentRunFooter_IntCostUsd(t *testing.T) {
+	line := []byte(`{"time":"2026-05-16T17:04:00Z","level":"ERROR","msg":"agent run failed","entry_type":"agent_run","run_id":"R1","schedule":"s","task":"t","cost_usd":0,"duration_ms":1318,"input_tokens":0,"output_tokens":0,"cache_read":0,"stop_reason":"","success":false,"error":"no creds"}`)
+	rec, ok := rehydrateRecord(line)
+	if !ok {
+		t.Fatal("rehydrate: ok=false")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("renderAgentRunFooter panicked: %v", r)
+		}
+	}()
+	var buf strings.Builder
+	if err := renderAgentRunFooter(&buf, rec); err != nil {
+		t.Fatalf("renderAgentRunFooter: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("renderAgentRunFooter produced no output")
 	}
 }

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -921,7 +921,23 @@ func (s *listenServer) handleIngestEvents(w http.ResponseWriter, r *http.Request
 		// runs where the user expects the same ANSI-rendered output as
 		// a local run.
 		if rec, ok := rehydrateRecord(line); ok {
-			_ = liveSink.Handle(r.Context(), rec)
+			// liveSink.Handle dispatches into the pretty/JSON encoders;
+			// a kind mismatch in one of the renderers (historically a
+			// JSON-roundtripped Float64 cost_usd arriving as Int64)
+			// would panic and abort the entire batch — including the
+			// schedule_complete event that finalizes the run row,
+			// leaving the run stuck on "running" forever. Recover so
+			// one bad frame degrades to "live SSE skips that frame"
+			// rather than "state.db loses the rest of the batch".
+			func() {
+				defer func() {
+					if rec := recover(); rec != nil {
+						slog.Error("live sink panic on ingested event",
+							"error", fmt.Sprint(rec))
+					}
+				}()
+				_ = liveSink.Handle(r.Context(), rec)
+			}()
 		}
 		accepted++
 	}

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -657,12 +657,40 @@ func attrInt64(r slog.Record, key string) int64 {
 	var n int64
 	r.Attrs(func(a slog.Attr) bool {
 		if a.Key == key {
-			n = a.Value.Int64()
+			n = valueInt64(a.Value)
 			return false
 		}
 		return true
 	})
 	return n
+}
+
+// valueInt64 reads a slog.Value as int64, tolerating Float64 (e.g. when an
+// integer attr round-tripped through JSON and arrived as float). Falls
+// back to 0 for unhandled kinds. Used in place of a bare a.Value.Int64()
+// so a kind mismatch (which would otherwise panic) silently degrades.
+func valueInt64(v slog.Value) int64 {
+	switch v.Kind() {
+	case slog.KindInt64, slog.KindUint64:
+		return v.Int64()
+	case slog.KindFloat64:
+		return int64(v.Float64())
+	}
+	return 0
+}
+
+// valueFloat64 mirrors valueInt64 for float-typed attrs (e.g. cost_usd).
+// Worker→producer event shipping JSON-encodes Float64(0) as `0`, which
+// the rehydrate path then reads as Int64 (json.Number prefers integer
+// when it parses cleanly); reading as Float64() would panic.
+func valueFloat64(v slog.Value) float64 {
+	switch v.Kind() {
+	case slog.KindFloat64:
+		return v.Float64()
+	case slog.KindInt64, slog.KindUint64:
+		return float64(v.Int64())
+	}
+	return 0
 }
 
 // attrBool fetches a bool-valued attribute by key, returning false if missing.
@@ -733,15 +761,20 @@ func renderAgentRunFooter(out io.Writer, r slog.Record) error {
 	r.Attrs(func(a slog.Attr) bool {
 		switch a.Key {
 		case "cost_usd":
-			costStr = fmt.Sprintf("%.6f", a.Value.Float64())
+			// Worker-shipped events round-trip through JSON; a float value
+			// of 0 (or any whole number) arrives as Int64 after the
+			// rehydrate path (ingest_rehydrate.go:jsonValueToAttr prefers
+			// Int64 when json.Number parses cleanly). Reading it as
+			// Float64() would panic. Use the resilient reader.
+			costStr = fmt.Sprintf("%.6f", valueFloat64(a.Value))
 		case "duration_ms":
-			durationMs = a.Value.Int64()
+			durationMs = valueInt64(a.Value)
 		case "input_tokens":
-			in = a.Value.Int64()
+			in = valueInt64(a.Value)
 		case "output_tokens":
-			outTokens = a.Value.Int64()
+			outTokens = valueInt64(a.Value)
 		case "cache_read":
-			cacheRead = a.Value.Int64()
+			cacheRead = valueInt64(a.Value)
 		case "stop_reason":
 			stop = a.Value.String()
 		case "transcript":


### PR DESCRIPTION
## Summary

Runs are stuck on \`status=running\` (no \`ended_at\`) whenever the agent task fails before emitting token usage — most commonly when \`ANTHROPIC_API_KEY\` is missing on a new deployment. Reproduced live on a fresh project: triggered the schedule, task failed in 1.3s with \"no Anthropic credentials found\", \`schedule_complete\` was emitted to cronicle.jsonl (visible in Loki) but the run row never got the rollup UPDATE.

## Root cause

The producer pod logged this panic on every worker→producer event POST for that run:

\`\`\`
http: panic serving 10.244.0.x: Value kind is Int64, not Float64
log/slog.Value.Float64(...)
internal/cronicle.renderAgentRunFooter.func1 → log.go:736
internal/cronicle/state.(*LiveSink).Handle → ...
internal/cronicle.(*listenServer).handleIngestEvents → listen.go:924
\`\`\`

The agent emits \`slog.Float64(\"cost_usd\", res.CostUSD)\`. When \`CostUSD == 0\`, the worker's eventShipper JSON-marshals it as the integer literal \`0\`. \`rehydrateRecord\` reads JSON numbers via \`json.Number\` and prefers \`Int64\` when they parse cleanly as integers (so \`exit\`, \`duration_ms\`, etc. retain their kind for the renderers that call \`.Int64()\`). On the producer side, \`renderAgentRunFooter\` then calls \`a.Value.Float64()\` on what's now an Int64 — boom.

The panic aborts the per-line loop inside \`handleIngestEvents\` for the rest of that batch. \`schedule_complete\` and \`agent_run\` were in the same batch, so the state.db never sees them. The run row stays on \`status=running\` forever.

## Fix

Two changes, defense-in-depth:

**1. Kind-tolerant readers in \`renderAgentRunFooter\`** (\`log.go\`). New \`valueFloat64\` / \`valueInt64\` helpers read either kind. \`attrInt64\` now uses \`valueInt64\` too. Includes a regression test (\`TestRenderAgentRunFooter_IntCostUsd\`) that feeds the exact round-tripped wire shape — \`cost_usd:0\` as a JSON integer — through \`rehydrateRecord\` → \`renderAgentRunFooter\` and asserts no panic.

**2. Panic recovery around \`liveSink.Handle\`** (\`listen.go\`). The state.db Apply (the rollup source of truth) is upstream of liveSink in the loop, so it was always safe in theory — but the panic was still aborting the FOR loop because Go's HTTP server recover catches it at the request boundary, not the inner statement. The new local \`defer recover\` keeps any future renderer kind mismatch from cascading.

## Test plan

- [x] Full test suite green (\`go test ./...\`)
- [x] New \`TestRenderAgentRunFooter_IntCostUsd\` covers the exact panic path
- [ ] Live verification: deploy this build to the kind cluster, trigger an agent task on a project with no ANTHROPIC_API_KEY, confirm the run flips to \`status=failed\` with \`ended_at\` set