### PR TITLE
Embed time/tzdata so named timezones work on minimal containers

### DIFF
--- a/cronicle.go
+++ b/cronicle.go
@@ -15,7 +15,17 @@ limitations under the License.
 */
 package main
 
-import "github.com/jshiv/cronicle/cmd"
+import (
+	"github.com/jshiv/cronicle/cmd"
+
+	// Embed the IANA tz database into the binary. Without this, schedules
+	// like `timezone = "America/Los_Angeles"` fail to load on any system
+	// without tzdata installed (notably minimal alpine containers), and
+	// the config reload aborts — keeping the previous schedule set in
+	// memory and silently dropping newly-PUT schedules. Adds ~450KB to
+	// the binary in exchange for making it self-contained.
+	_ "time/tzdata"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Problem

cronicle's HCL reloader fails the moment any schedule sets a named timezone (\`America/Los_Angeles\`, \`Europe/London\`, etc.) and the runtime is deployed on an alpine container without tzdata. Producer logs:

\`\`\`
ERROR config reload failed; keeping previous schedules in place
  path=/work/cronicle.hcl error=\"unknown time zone America/Los_Angeles\"
\`\`\`

When the whole reload aborts, cronicle keeps the previously-loaded schedule set in memory — so newly-PUT schedules are silently dropped from the active set. The cronicle-infra HCL is up to date, but the listener's \`/v1/schedules\` only returns the schedules from before the bad one landed.

Reproduced live on the kind cluster: donkey-balls had 4 schedules in stored HCL, the listener returned only 2 (the two that pre-dated a \`daily_standup_brief\` block with \`timezone = \"America/Los_Angeles\"\`).

## Fix

Import \`_ \"time/tzdata\"\` in main. Go's stdlib bundles the IANA zone database into the binary itself; \`time.LoadLocation\` falls back to the embedded data when \`/usr/share/zoneinfo\` is absent. The runtime no longer depends on the OS having tzdata installed.

Cost: ~450KB binary growth. Tradeoff is portable-binary > smaller-binary for an orchestrator that has to handle any user-supplied zone string.

## Companion fix

[cronicle-infra#13](https://github.com/jshiv/cronicle-infra/pull/13) adds \`tzdata\` to the alpine apk install for the cronicled image, so deployments built before this lands also get the fix.

## Test plan
- [x] \`go test ./...\` clean
- [ ] Roll a new image and verify the listener picks up all schedules including tz-aware ones