### PR TITLE
Pluggable secret source + in-tree SecretStore on state.Backend

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,11 +55,20 @@ The run command will log schedule information to stdout including git commit inf
 			listenToken = os.Getenv("CRONICLE_LISTEN_TOKEN")
 		}
 
+		ctx, stop := signal.NotifyContext(context.Background(),
+			syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
 		runOptions := cronicle.RunOptions{
 			RunWorker:   runWorker,
 			LogToFile:   logToFile,
 			ListenAddr:  listenAddr,
 			ListenToken: listenToken,
+			// Defer secret-source startup until AFTER cronicle has opened
+			// state.db — the secretstore binds to that backend, so it has
+			// to land in the right order. The hook closes over `cmd` so
+			// flag lookups continue to work.
+			PostStateStoreHook: func() error { return startSecretSource(ctx, cmd) },
 		}
 
 		// One-shot mode: --cron + --command bootstraps a synthetic
@@ -83,10 +92,8 @@ The run command will log schedule information to stdout including git commit inf
 		if configSource != "" {
 			// Source-aware dispatch: open the source (file/http/s3/pg),
 			// boot the scheduler against it, register heartbeat +
-			// config_refresh entries.
-			ctx, stop := signal.NotifyContext(context.Background(),
-				syscall.SIGINT, syscall.SIGTERM)
-			defer stop()
+			// config_refresh entries. PostStateStoreHook (set above) wires
+			// the secret-source pump after state.db is open.
 			if err := cronicle.RunFromSource(ctx, configSource, workdir, runOptions); err != nil {
 				slog.Error("cronicle run --config-source failed", "err", err.Error())
 				os.Exit(1)
@@ -94,6 +101,9 @@ The run command will log schedule information to stdout including git commit inf
 			return
 		}
 
+		// File-source path. cronicle.Run opens state.db, then fires the
+		// PostStateStoreHook (which binds the secret-source pump), then
+		// blocks running the scheduler.
 		cronicle.Run(path, runOptions)
 
 	},
@@ -114,6 +124,7 @@ func init() {
 	runCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); stdout is unaffected and remains controlled by --log-format")
 	runCmd.Flags().String("listen", "", "host:port to expose the remote-trigger HTTP API (e.g. :8765). Empty disables. Requires --listen-token.")
 	runCmd.Flags().String("listen-token", "", "bearer token for the remote-trigger HTTP API (or env CRONICLE_LISTEN_TOKEN). Required when --listen is set.")
+	addSecretSourceFlags(runCmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/secret.go
+++ b/cmd/secret.go
@@ -1,0 +1,225 @@
+/*
+Copyright © 2026 The Cronicle Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+// `cronicle secret` is the CLI control plane for the in-tree secret
+// store. Two transports, same surface:
+//
+//   - Default: opens .cronicle/state.db on disk via state.Open() and
+//     operates against the SQLite SecretStore directly. Works without
+//     a running cronicle, but only for the in-tree sqlite backend.
+//
+//   - --remote URL [--token T]: PUT/DELETE/GET against the listener's
+//     /v1/secrets API. Backend-agnostic — the listener forwards to
+//     whatever state.Backend the running cronicle has bound, so this
+//     is the right path for Postgres-backed (cronicle-infra hosted)
+//     or any future-backend setups. Tokens default to
+//     env CRONICLE_LISTEN_TOKEN.
+//
+// Subcommands:
+//   cronicle secret set NAME                  value from stdin
+//   cronicle secret set NAME --value V        value on the flag (discouraged)
+//   cronicle secret get NAME                  prints value to stdout
+//   cronicle secret list                      names only
+//   cronicle secret rm NAME                   delete
+
+// nameRE mirrors the listener's validator and the $secret.NAME regex
+// in secretstore — UPPER_SNAKE_CASE only.
+var nameRE = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+var secretCmd = &cobra.Command{
+	Use:   "secret",
+	Short: "Manage cronicle's secret store (local state.db or remote listener)",
+	Long: `cronicle secret manages the in-tree secret store that backs
+$secret.NAME resolution at task dispatch.
+
+By default, reads and writes go directly against the local
+.cronicle/state.db file (the same store the running cronicle uses).
+Pair with --workdir to target a specific cronicle workdir; defaults
+to "." (the current directory).
+
+For a remote / Postgres-backed cronicle, pass --remote http://host:port
+--token T to route through the listener's /v1/secrets API. The
+listener is backend-agnostic, so this works against any state.Backend
+(sqlite, Postgres, future). Falls back to env CRONICLE_REMOTE and
+CRONICLE_LISTEN_TOKEN.`,
+}
+
+var secretSetCmd = &cobra.Command{
+	Use:   "set NAME",
+	Short: "Upsert a secret value (reads value from stdin by default)",
+	Long: `Stores (NAME, value) in the secret store.
+
+Value is read from stdin by default so it doesn't appear in process
+listings or shell history. Pipe it in:
+
+    echo -n "sk-ant-..." | cronicle secret set ANTHROPIC_API_KEY
+
+Or use --value for the unsafe-but-quick form (the value will be visible
+in 'ps' output and shell history).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		if !nameRE.MatchString(name) {
+			return fmt.Errorf("name must match UPPER_SNAKE_CASE (got %q)", name)
+		}
+		value, _ := cmd.Flags().GetString("value")
+		if value == "" {
+			b, err := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+			if err != nil {
+				return fmt.Errorf("read stdin: %w", err)
+			}
+			value = strings.TrimRight(string(b), "\n")
+		}
+		if value == "" {
+			return fmt.Errorf("value required (pipe to stdin or pass --value)")
+		}
+		actor, _ := cmd.Flags().GetString("actor")
+		client, err := openSecretClient(cmd)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+		if err := client.Put(name, value, actor); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "set: %s\n", name)
+		return nil
+	},
+}
+
+var secretGetCmd = &cobra.Command{
+	Use:   "get NAME",
+	Short: "Print a secret's value to stdout (use with care)",
+	Long: `Prints the stored value as a single line on stdout. Intended
+for scripting + debug; emits no trailing newline so the output composes
+cleanly into other tools.
+
+Refuses to print when stdout is a TTY unless --force is passed, to
+avoid an accidental shoulder-surf when used interactively.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		force, _ := cmd.Flags().GetBool("force")
+		if isTerminal(os.Stdout) && !force {
+			return fmt.Errorf("stdout is a TTY; pass --force to print plaintext to terminal")
+		}
+		client, err := openSecretClient(cmd)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+		v, ok, err := client.Get(name)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("no such secret: %s", name)
+		}
+		fmt.Fprint(cmd.OutOrStdout(), v)
+		return nil
+	},
+}
+
+var secretListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List secret NAMES in the store (values never printed)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := openSecretClient(cmd)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+		names, etag, err := client.List()
+		if err != nil {
+			return err
+		}
+		if len(names) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "(no secrets)")
+			return nil
+		}
+		tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintf(tw, "NAME\tSTORE_ETAG\n")
+		for _, n := range names {
+			fmt.Fprintf(tw, "%s\t%s\n", n, etag)
+		}
+		return tw.Flush()
+	},
+}
+
+var secretRmCmd = &cobra.Command{
+	Use:     "rm NAME",
+	Aliases: []string{"delete", "remove"},
+	Short:   "Remove a secret by name",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		actor, _ := cmd.Flags().GetString("actor")
+		client, err := openSecretClient(cmd)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+		ok, err := client.Delete(args[0], actor)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("no such secret: %s", args[0])
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "removed: %s\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(secretCmd)
+	secretCmd.AddCommand(secretSetCmd)
+	secretCmd.AddCommand(secretGetCmd)
+	secretCmd.AddCommand(secretListCmd)
+	secretCmd.AddCommand(secretRmCmd)
+
+	// --workdir is shared so every subcommand targets the same state.db
+	// path the running cronicle would. Default "." matches `cronicle run`.
+	// Ignored when --remote is used.
+	for _, c := range []*cobra.Command{secretSetCmd, secretGetCmd, secretListCmd, secretRmCmd} {
+		c.Flags().String("workdir", ".", "cronicle workdir (state.db is at WORKDIR/.cronicle/state.db). Ignored when --remote is set.")
+	}
+	// --remote / --token route through the listener instead of a local
+	// state.db. Registered on every subcommand so the help is uniform.
+	addRemoteFlags(secretSetCmd, secretGetCmd, secretListCmd, secretRmCmd)
+
+	secretSetCmd.Flags().String("value", "",
+		"secret value (UNSAFE — appears in ps/shell history; prefer piping to stdin)")
+	secretSetCmd.Flags().String("actor", "cli",
+		"audit label recorded against this write")
+	secretRmCmd.Flags().String("actor", "cli",
+		"audit label recorded against this delete")
+	secretGetCmd.Flags().Bool("force", false,
+		"allow printing plaintext when stdout is a TTY")
+}
+
+// isTerminal returns true if f is connected to a terminal. Best-effort —
+// portable code path uses os.Stat to check for the char-device bit which
+// is reliable on every platform cronicle targets.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/secret_client.go
+++ b/cmd/secret_client.go
@@ -1,0 +1,291 @@
+/*
+Copyright © 2026 The Cronicle Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+	"github.com/spf13/cobra"
+)
+
+// secretClient abstracts the storage seam for the `cronicle secret`
+// subcommand. Two impls:
+//
+//   localClient  — opens .cronicle/state.db on disk via state.Open()
+//                  and operates against the SQLite SecretStore directly.
+//                  Backend-aware: works for whatever the local sqlite
+//                  binary speaks. Doesn't reach a Postgres-backed
+//                  cronicle-infra deployment.
+//
+//   remoteClient — speaks the listener's bearer-auth'd /v1/secrets API
+//                  (PUT, DELETE, GET). Backend-agnostic: the listener
+//                  forwards to whatever state.Backend the running
+//                  cronicle has bound — sqlite, Postgres, or any future
+//                  backend that satisfies the SecretStore interface.
+//
+// Both implement the same five methods so each subcommand body is a
+// straight function call; the routing happens in openSecretClient.
+type secretClient interface {
+	Put(name, value, actor string) error
+	Get(name string) (value string, ok bool, err error)
+	List() (names []string, etag string, err error)
+	Delete(name, actor string) (ok bool, err error)
+	Close() error
+}
+
+// openSecretClient picks local vs remote based on flags / env. The
+// rule: `--remote URL` (or env CRONICLE_REMOTE) routes through HTTP;
+// anything else opens the local .cronicle/state.db.
+//
+// Remote auth: `--token` flag → env CRONICLE_LISTEN_TOKEN → empty. An
+// empty token will cause the listener to 401; we don't pre-validate
+// here so an operator who runs against an unauthenticated /healthz-
+// style endpoint still gets a clear server-side error.
+func openSecretClient(cmd *cobra.Command) (secretClient, error) {
+	remote, _ := cmd.Flags().GetString("remote")
+	if remote == "" {
+		remote = os.Getenv("CRONICLE_REMOTE")
+	}
+	if remote != "" {
+		token, _ := cmd.Flags().GetString("token")
+		if token == "" {
+			token = os.Getenv("CRONICLE_LISTEN_TOKEN")
+		}
+		return newRemoteClient(remote, token)
+	}
+	return openLocalClient(cmd)
+}
+
+// addRemoteFlags registers --remote and --token on every secret
+// subcommand. Centralized so the help text stays consistent.
+func addRemoteFlags(cmds ...*cobra.Command) {
+	for _, c := range cmds {
+		c.Flags().String("remote", "",
+			"cronicle listener URL (e.g. http://producer:8765). When set, "+
+				"talks to the listener's /v1/secrets API instead of opening "+
+				"the local state.db. Falls back to env CRONICLE_REMOTE.")
+		c.Flags().String("token", "",
+			"bearer token for --remote. Falls back to env CRONICLE_LISTEN_TOKEN. "+
+				"Prefer the env var so the token doesn't appear in 'ps' / shell history.")
+	}
+}
+
+// --- local impl: backed by *state.Store ------------------------------------
+
+type localClient struct{ s *state.Store }
+
+func openLocalClient(cmd *cobra.Command) (secretClient, error) {
+	workdir, _ := cmd.Flags().GetString("workdir")
+	if workdir == "" {
+		workdir = "."
+	}
+	abs, err := filepath.Abs(workdir)
+	if err != nil {
+		return nil, err
+	}
+	dbPath := filepath.Join(abs, ".cronicle", "state.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no state.db at %s — run `cronicle run` once in this workdir, "+
+				"or pass --remote http://… --token … to manage a remote cronicle", dbPath)
+		}
+		return nil, err
+	}
+	s, err := state.Open(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	return &localClient{s: s}, nil
+}
+
+func (c *localClient) Put(name, value, actor string) error {
+	return c.s.PutSecret(name, value, actor)
+}
+func (c *localClient) Get(name string) (string, bool, error) {
+	return c.s.GetSecret(name)
+}
+func (c *localClient) List() ([]string, string, error) {
+	names, err := c.s.ListSecretNames()
+	if err != nil {
+		return nil, "", err
+	}
+	etag, _ := c.s.SecretsEtag()
+	return names, etag, nil
+}
+func (c *localClient) Delete(name, actor string) (bool, error) {
+	return c.s.DeleteSecret(name, actor)
+}
+func (c *localClient) Close() error { return c.s.Close() }
+
+// --- remote impl: backed by the listener's /v1/secrets API ----------------
+
+type remoteClient struct {
+	base   string // base URL without trailing slash
+	token  string
+	client *http.Client
+}
+
+func newRemoteClient(base, token string) (*remoteClient, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --remote URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("--remote must be http(s): got %s", base)
+	}
+	return &remoteClient{
+		base:  strings.TrimRight(base, "/"),
+		token: token,
+		// Short overall timeout — the listener responds in low-ms;
+		// anything longer indicates trouble worth surfacing.
+		client: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+func (c *remoteClient) Close() error { return nil }
+
+// auth applies Authorization + X-Cronicle-Actor headers.
+func (c *remoteClient) auth(req *http.Request, actor string) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if actor != "" {
+		req.Header.Set("X-Cronicle-Actor", actor)
+	}
+}
+
+// statusError builds a clear error message for non-2xx responses.
+// 401/403 get a hint about token configuration since that's the most
+// common operator slip.
+func statusError(resp *http.Response, op string) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	hint := ""
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		hint = " — check --token / CRONICLE_LISTEN_TOKEN"
+	}
+	return fmt.Errorf("%s: %s%s: %s", op, resp.Status, hint, strings.TrimSpace(string(body)))
+}
+
+func (c *remoteClient) Put(name, value, actor string) error {
+	body, err := json.Marshal(struct {
+		Value string `json:"value"`
+	}{value})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPut, c.base+"/v1/secrets/"+name, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.auth(req, actor)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return statusError(resp, "PUT secret")
+}
+
+// Get over HTTP currently fetches the full map and picks one — the
+// listener returns the whole envelope on /v1/secrets. The wire cost
+// is small (single-digit KB for typical secret sets) and avoids
+// growing the listener's API surface for the rare CLI-side `secret
+// get` use case.
+func (c *remoteClient) Get(name string) (string, bool, error) {
+	all, _, err := c.fetchAll()
+	if err != nil {
+		return "", false, err
+	}
+	v, ok := all[name]
+	return v, ok, nil
+}
+
+func (c *remoteClient) List() ([]string, string, error) {
+	values, etag, err := c.fetchAll()
+	if err != nil {
+		return nil, "", err
+	}
+	names := make([]string, 0, len(values))
+	for n := range values {
+		names = append(names, n)
+	}
+	// Stable order matches the local path.
+	sortStrings(names)
+	return names, etag, nil
+}
+
+func (c *remoteClient) fetchAll() (map[string]string, string, error) {
+	req, err := http.NewRequest(http.MethodGet, c.base+"/v1/secrets", nil)
+	if err != nil {
+		return nil, "", err
+	}
+	c.auth(req, "")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", statusError(resp, "GET secrets")
+	}
+	var env struct {
+		Values map[string]string `json:"values"`
+		ETag   string            `json:"etag"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, "", fmt.Errorf("decode secrets response: %w", err)
+	}
+	if env.Values == nil {
+		env.Values = map[string]string{}
+	}
+	return env.Values, env.ETag, nil
+}
+
+func (c *remoteClient) Delete(name, actor string) (bool, error) {
+	req, err := http.NewRequest(http.MethodDelete, c.base+"/v1/secrets/"+name, nil)
+	if err != nil {
+		return false, err
+	}
+	c.auth(req, actor)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, statusError(resp, "DELETE secret")
+	}
+}
+
+// sortStrings is here because we don't want to drag in sort just for
+// the slice form when the package is already stdlib-heavy.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/cmd/secret_client.go
+++ b/cmd/secret_client.go
@@ -158,6 +158,36 @@ func newRemoteClient(base, token string) (*remoteClient, error) {
 
 func (c *remoteClient) Close() error { return nil }
 
+// secretsURL builds the absolute URL for the secrets endpoints. Two
+// base shapes are supported transparently:
+//
+//   cronicle listener         base = http://producer:8765
+//                             → http://producer:8765/v1/secrets[/{name}]
+//
+//   cronicle-infra api        base = https://api/v1/deployments/{id}
+//                             → https://api/v1/deployments/{id}/secrets[/{name}]
+//
+// The discriminator is whether the base path already contains "/v1/" —
+// if it does, the operator is pointing at an api with a scoped prefix
+// (cronicle-infra), and we just append "/secrets...". Otherwise we
+// assume a bare cronicle listener and stack the standard "/v1/secrets..."
+// suffix on. Cheap, predictable, no special flags.
+func (c *remoteClient) secretsURL(name string) string {
+	u, err := url.Parse(c.base)
+	var prefix string
+	if err == nil && strings.Contains(u.Path, "/v1/") {
+		// base already includes /v1/<something>/, just append /secrets...
+		prefix = c.base + "/secrets"
+	} else {
+		// bare base (no /v1/ in path) — listener shape.
+		prefix = c.base + "/v1/secrets"
+	}
+	if name == "" {
+		return prefix
+	}
+	return prefix + "/" + name
+}
+
 // auth applies Authorization + X-Cronicle-Actor headers.
 func (c *remoteClient) auth(req *http.Request, actor string) {
 	if c.token != "" {
@@ -187,7 +217,7 @@ func (c *remoteClient) Put(name, value, actor string) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodPut, c.base+"/v1/secrets/"+name, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPut, c.secretsURL(name), bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -233,7 +263,7 @@ func (c *remoteClient) List() ([]string, string, error) {
 }
 
 func (c *remoteClient) fetchAll() (map[string]string, string, error) {
-	req, err := http.NewRequest(http.MethodGet, c.base+"/v1/secrets", nil)
+	req, err := http.NewRequest(http.MethodGet, c.secretsURL(""), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -260,7 +290,7 @@ func (c *remoteClient) fetchAll() (map[string]string, string, error) {
 }
 
 func (c *remoteClient) Delete(name, actor string) (bool, error) {
-	req, err := http.NewRequest(http.MethodDelete, c.base+"/v1/secrets/"+name, nil)
+	req, err := http.NewRequest(http.MethodDelete, c.secretsURL(name), nil)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/secret_source.go
+++ b/cmd/secret_source.go
@@ -1,0 +1,171 @@
+/*
+Copyright © 2026 The Cronicle Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+	"github.com/jshiv/cronicle/internal/cronicle/secretsource"
+	"github.com/jshiv/cronicle/internal/cronicle/secretstore"
+	"github.com/spf13/cobra"
+)
+
+// addSecretSourceFlags registers the four secret-source flags on a
+// command. Centralized so `cronicle run` and `cronicle worker` share
+// the exact same surface area and defaults — operators learn it once.
+//
+// Defaults are deliberately blank: when the flag is unset (and the env
+// fallback is empty), startSecretSource derives a source from context
+// — see deriveDefaultSpec. This keeps "no flags, just works" true for
+// the standalone CLI shape while still letting operators pin a source
+// explicitly when they want one.
+func addSecretSourceFlags(cmd *cobra.Command) {
+	cmd.Flags().String("secret-source", "",
+		"pluggable secret ingestion source — env://, file:///abs/path.json, "+
+			"http(s)://host/path, or state:// (CLI/HTTP-managed only). "+
+			"When unset, cronicle derives a sensible default: workers use "+
+			"--producer for HTTP fetch, producers (--listen) use state://, "+
+			"standalone uses env://. Falls back to env CRONICLE_SECRET_SOURCE.")
+	cmd.Flags().String("secret-source-token", "",
+		"bearer token sent as Authorization: Bearer ... on every http(s) secret-source fetch. "+
+			"Workers infer it from --producer-token when unset. "+
+			"Falls back to env CRONICLE_SECRET_SOURCE_TOKEN.")
+	cmd.Flags().Duration("secret-refresh-interval", secretstore.DefaultRefreshInterval,
+		"how often to re-poll the secret source (sub-second is wasteful; default 5s).")
+	cmd.Flags().Duration("secret-stale-ttl", secretstore.DefaultStaleTTL,
+		"refuse to dispense secrets if the most recent successful refresh is older than this. "+
+			"Default 5m. Set to 0 to disable staleness gating (not recommended in production).")
+}
+
+// startSecretSource binds the process-wide secret store to the local
+// state.Backend and (optionally) starts an ingestion pump. Always
+// binds the backend so $secret.NAME resolution works even when no
+// source is configured — operators can manage entirely via
+// `cronicle secret set ...` or the listener's PUT /v1/secrets.
+//
+// Bearer auth handling intentionally prefers env-var supply (so the
+// token never appears in `ps aux`), but accepts a flag for the local-
+// dev shape.
+func startSecretSource(ctx context.Context, cmd *cobra.Command) error {
+	be := cronicle.StateStore()
+	if be == nil {
+		// No state backend — runtime is in a degenerate state. Don't
+		// fail the boot path; secret resolution will return
+		// ErrNotConfigured, which is the right signal for tests/
+		// minimal runs.
+		return nil
+	}
+	secretstore.Default().SetBackend(be)
+
+	spec, _ := cmd.Flags().GetString("secret-source")
+	if spec == "" {
+		spec = os.Getenv("CRONICLE_SECRET_SOURCE")
+	}
+	token, _ := cmd.Flags().GetString("secret-source-token")
+	if token == "" {
+		token = os.Getenv("CRONICLE_SECRET_SOURCE_TOKEN")
+	}
+
+	// Smart-defaults pass: if the operator gave nothing, pick something
+	// sensible from the rest of the command's flags. The mapping:
+	//
+	//   cronicle worker --producer X --producer-token Y
+	//      → ingest from X/v1/secrets, bearer = Y
+	//   cronicle run --listen :PORT --listen-token T
+	//      → state:// (the producer's local state.db IS the truth;
+	//        the listener serves it to workers)
+	//   anything else (standalone, no listen)
+	//      → env:// (the shell IS the secret source)
+	if spec == "" {
+		derivedSpec, derivedToken := deriveDefaultSpec(cmd)
+		spec = derivedSpec
+		if token == "" {
+			token = derivedToken
+		}
+	}
+
+	interval, _ := cmd.Flags().GetDuration("secret-refresh-interval")
+	staleTTL, _ := cmd.Flags().GetDuration("secret-stale-ttl")
+
+	// state:// is special — it means "the state.db IS the truth, no
+	// ingestion pump." Skip Open + refresh, just bind the backend
+	// (already done above) and we're done.
+	if spec == "" || spec == "state://" {
+		slog.Info("secret source: state-backed (no ingestion)", "spec", spec)
+		// Disable staleness gating: there's no refresh signal to be stale.
+		secretstore.Default().StaleTTL(0)
+		return nil
+	}
+
+	src, err := secretsource.Open(ctx, spec)
+	if err != nil {
+		return fmt.Errorf("secret source: %w", err)
+	}
+	if token != "" {
+		bearer, ok := src.(interface {
+			WithBearer(string) *secretsource.HTTPSource
+		})
+		if !ok {
+			return fmt.Errorf("secret source: --secret-source-token is only meaningful for http(s) sources (got %s)", src.String())
+		}
+		bearer.WithBearer(token)
+	}
+
+	slog.Info("secret source enabled",
+		"source", src.String(),
+		"refresh", interval.String(),
+		"stale_ttl", staleTTL.String(),
+	)
+	if err := secretstore.StartDefault(ctx, be, src, interval, staleTTL); err != nil {
+		return fmt.Errorf("secret store start: %w", err)
+	}
+	return nil
+}
+
+// deriveDefaultSpec picks a sensible source spec from the command's
+// other flags. The mapping mirrors the table in addSecretSourceFlags's
+// doc. Returns ("", "") when nothing useful can be inferred — caller
+// falls through to env://.
+//
+// We only inspect flag values that exist on the command; we never
+// register them here, so the lookup is harmless on commands that don't
+// declare them (cobra returns the empty string).
+func deriveDefaultSpec(cmd *cobra.Command) (spec, token string) {
+	// Worker shape: --producer X --producer-token Y → HTTP fetch.
+	producer := flagOrEmpty(cmd, "producer")
+	if producer != "" {
+		producerToken := flagOrEmpty(cmd, "producer-token")
+		if producerToken == "" {
+			producerToken = os.Getenv("CRONICLE_LISTEN_TOKEN")
+		}
+		// Strip any trailing slash for clean joining.
+		base := strings.TrimRight(producer, "/")
+		return base + "/v1/secrets", producerToken
+	}
+
+	// Producer shape: --listen + --listen-token → state.db is the truth.
+	listen := flagOrEmpty(cmd, "listen")
+	if listen != "" {
+		return "state://", ""
+	}
+
+	// Standalone shape: the operator's shell IS the secret source.
+	return "env://", ""
+}
+
+func flagOrEmpty(cmd *cobra.Command, name string) string {
+	f := cmd.Flag(name)
+	if f == nil {
+		return ""
+	}
+	return f.Value.String()
+}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -84,6 +84,10 @@ job claims so only one worker executes any given run.
 			WorkerID:    workerID,
 			Path:        path,
 			LogToFile:   logToFile,
+			// Bind the secret-source pump AFTER state.db is open inside
+			// StartHTTPWorker. Smart-defaults will derive `http://<producer>/v1/secrets`
+			// from --producer/--producer-token when --secret-source is unset.
+			PostStateStoreHook: func() error { return startSecretSource(ctx, cmd) },
 		})
 		if err != nil && err != context.Canceled {
 			slog.Error("worker exited", "error", err.Error())
@@ -99,4 +103,5 @@ func init() {
 	workerCmd.Flags().String("producer-token", "", "Bearer token for the producer's HTTP API. Falls back to $CRONICLE_LISTEN_TOKEN.")
 	workerCmd.Flags().String("worker-id", "", "Stable identifier for this worker in the producer's claim/ack records. Default: <hostname>-<pid>.")
 	workerCmd.Flags().Bool("log-to-file", false, "Mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); per-run agent transcripts go to path/.cronicle/runs/.")
+	addSecretSourceFlags(workerCmd)
 }

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -58,6 +58,12 @@ func Run(cronicleFile string, runOptions RunOptions) {
 		slog.Warn("state store open failed; projection disabled", "error", err.Error())
 	}
 
+	if runOptions.PostStateStoreHook != nil {
+		if err := runOptions.PostStateStoreHook(); err != nil {
+			Fatal(err)
+		}
+	}
+
 	//TODO: WaitGroup is currently only used for testing, could be used in Producer
 	var wg sync.WaitGroup
 	wg.Add(1) //Ensure WaitGroup counter > 0
@@ -116,6 +122,13 @@ type RunOptions struct {
 	// (the listener refuses to bind otherwise — see internal/cronicle/listen.go).
 	ListenAddr  string
 	ListenToken string
+	// PostStateStoreHook fires after EnableStateStore returns
+	// (successfully or not — caller can check StateStore() != nil) and
+	// before the cron loop, listener, or queue start. Lets the cmd
+	// layer bind the secret-source pump to the state.Backend without
+	// requiring cronicle.Run to know about secretsource internals.
+	// Errors abort startup.
+	PostStateStoreHook func() error
 }
 
 //StartCron pushes all schedules in the given config to the cron scheduler

--- a/internal/cronicle/cron_source.go
+++ b/internal/cronicle/cron_source.go
@@ -93,6 +93,12 @@ func RunFromSource(ctx context.Context, spec, workdir string, runOptions RunOpti
 		slog.Warn("state store open failed; projection disabled", "error", err.Error())
 	}
 
+	if runOptions.PostStateStoreHook != nil {
+		if err := runOptions.PostStateStoreHook(); err != nil {
+			return fmt.Errorf("post-state-store hook: %w", err)
+		}
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(1) // hold the goroutine open
 

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -9,10 +9,59 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/jshiv/cronicle/internal/cronicle/secretstore"
 	"github.com/jshiv/cronicle/pkg/agent"
 	"github.com/jshiv/cronicle/pkg/exec"
 	"gopkg.in/matryer/try.v1"
 )
+
+// splitAPIKey pulls an ANTHROPIC_API_KEY entry out of the env slice
+// and returns (value, remainder). Used by the agent dispatch path so
+// the Anthropic API key flows to cfg.APIKey (which is passed to the
+// SDK via option.WithAPIKey) without ever needing to be in any
+// subprocess's env. Returns ("", env) when no such entry is present
+// — the agent then falls back to whatever the SDK's own env lookup
+// finds, which is fine for direct-run scenarios where the operator
+// set ANTHROPIC_API_KEY on cronicle's own process.
+func splitAPIKey(env []string) (apiKey string, rest []string) {
+	const prefix = "ANTHROPIC_API_KEY="
+	rest = make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) && apiKey == "" {
+			apiKey = entry[len(prefix):]
+			continue
+		}
+		rest = append(rest, entry)
+	}
+	return apiKey, rest
+}
+
+// resolveEnv expands $secret.NAME references in env using the
+// process-wide secret store. Behavior matrix:
+//
+//	store not configured → env passed through unchanged (no expansion
+//	                       attempted). Lets a cronicle run without a
+//	                       --secret-source flag keep working — values
+//	                       that happen to contain "$secret.X" pass
+//	                       through as literals, same as today.
+//	store configured     → expansion required; any unresolved reference
+//	                       fails the task before subprocesses spawn.
+//
+// The second mode is the right default once secrets are wired —
+// dispensing a stale literal "$secret.X" string to a tool would
+// silently produce broken behavior (auth failure, etc.), and the
+// store-configured signal is the operator's commitment that
+// references should resolve.
+func resolveEnv(env []string) ([]string, error) {
+	if len(env) == 0 {
+		return env, nil
+	}
+	store := secretstore.Default()
+	if !store.Configured() {
+		return env, nil
+	}
+	return store.ExpandEnv(env)
+}
 
 //Exec executes task.Command at task.Path and returns the exec.Result struct
 //prior to execution, the command will replace any ${date}, ${datetime}, ${timestamp}
@@ -99,10 +148,26 @@ func (task *Task) Exec(t time.Time) exec.Result {
 			runCtx = context.Background()
 		}
 		startedAt := time.Now()
+		// Resolve $secret.NAME references against the live secret store
+		// before handing env to the subprocess. With no secret source
+		// configured this is a passthrough; with one configured, the
+		// secret values are substituted in-place. Either way, the
+		// task.Env stored on the Task struct stays unchanged so HCL
+		// serialization round-trips cleanly.
+		shellEnv, secretErr := resolveEnv(task.Env)
+		if secretErr != nil {
+			result = exec.Result{
+				Command:    cmd,
+				Error:      secretErr,
+				Stderr:     secretErr.Error(),
+				ExitStatus: 1,
+			}
+			return result
+		}
 		// Always use the streaming entry point so per-line slog records
 		// fire; pkg/exec captures stdout/stderr into the Result either
 		// way, so the shell_run terminal event payload is unchanged.
-		result = exec.ExecuteWithStreamContext(runCtx, cmd, task.Path, task.Env, stdoutEmitter, stderrEmitter)
+		result = exec.ExecuteWithStreamContext(runCtx, cmd, task.Path, shellEnv, stdoutEmitter, stderrEmitter)
 		finishedAt := time.Now()
 		task.lastDurationMs = finishedAt.Sub(startedAt).Milliseconds()
 
@@ -260,7 +325,32 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 			gitAuth = a
 		}
 	}
-	cfg.Tools = buildAgentTools(task.Agent.Tools, task.Path, task.Env, gitAuth, task.ScratchDir, toolWriter)
+	// Resolve $secret.NAME references in the task's env array before
+	// any subprocess sees it. resolvedEnv carries plaintext secret
+	// values — it's passed to bash/MCP subprocesses via the existing
+	// per-tool wiring; it's also where we pull cfg.APIKey from for
+	// the agent's API client. The unmodified task.Env stays on the
+	// Task struct so HCL round-trips and so audit logging never gets
+	// plaintext values via that field.
+	resolvedEnv, secretErr := resolveEnv(task.Env)
+	if secretErr != nil {
+		return exec.Result{
+			Command:    []string{"agent", task.Agent.Model},
+			Error:      secretErr,
+			Stderr:     secretErr.Error(),
+			ExitStatus: 1,
+		}
+	}
+	// Pull ANTHROPIC_API_KEY (if present in resolved env) out and into
+	// cfg.APIKey explicitly. This means we DON'T have to put it in the
+	// agent process's env to make the SDK happy, and we DON'T leak it
+	// into the bash tool / MCP children that get resolvedEnv passed
+	// through. Other env entries continue to flow to subprocesses.
+	if apiKey, restEnv := splitAPIKey(resolvedEnv); apiKey != "" {
+		cfg.APIKey = apiKey
+		resolvedEnv = restEnv
+	}
+	cfg.Tools = buildAgentTools(task.Agent.Tools, task.Path, resolvedEnv, gitAuth, task.ScratchDir, toolWriter)
 	if skillTool != nil {
 		cfg.Tools = append(cfg.Tools, skillTool)
 	}
@@ -298,7 +388,7 @@ func (task *Task) execAgent(t time.Time, r *strings.Replacer) exec.Result {
 			mcps[i].Command[j] = r.Replace(c)
 		}
 	}
-	mcpHandles, mcpTools, mcpErr := LaunchMCPServers(runCtx, mcps, task.Env, toolWriter)
+	mcpHandles, mcpTools, mcpErr := LaunchMCPServers(runCtx, mcps, resolvedEnv, toolWriter)
 	if mcpErr != nil {
 		return exec.Result{
 			Command:    []string{"agent", task.Agent.Model},

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -98,6 +98,8 @@ func startListener(addr, token string, queue chan<- []byte) {
 	mux.HandleFunc("/v1/runner/state", s.handleRunnerState)
 	mux.HandleFunc("/v1/runner/drain", s.handleRunnerDrain)
 	mux.HandleFunc("/v1/runner/undrain", s.handleRunnerUndrain)
+	mux.HandleFunc("/v1/secrets", s.handleSecretsRoot)
+	mux.HandleFunc("/v1/secrets/", s.handleSecretByName)
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/internal/cronicle/listen_secrets.go
+++ b/internal/cronicle/listen_secrets.go
@@ -1,0 +1,146 @@
+package cronicle
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Listener endpoints for the in-tree secret store (state.Backend's
+// SecretStore role).
+//
+//   GET    /v1/secrets               → {"values":{NAME:value, ...}, "etag":"..."}
+//                                       (bearer + If-None-Match honored)
+//   PUT    /v1/secrets/{name}        body: {"value":"..."}  → upsert
+//   DELETE /v1/secrets/{name}        → remove
+//
+// All endpoints require the listener bearer token, same as the rest of
+// the API. Plaintext flows over the wire on GET and PUT — operators
+// should pair this with TLS at any non-trusted hop (the listener
+// itself doesn't terminate TLS; that's the deployment's responsibility,
+// same as for /v1/jobs).
+
+// validSecretName mirrors the convention used by cronicle-web and the
+// $secret.NAME regex in secretstore — UPPER_SNAKE_CASE, leading letter.
+// Anything else gets rejected at the listener so we don't accidentally
+// admit lowercase/punctuation names that won't resolve via
+// $secret.X at dispatch time.
+var validSecretName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+func (s *listenServer) handleSecretsRoot(w http.ResponseWriter, r *http.Request) {
+	if !s.authed(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	be := s.stateSrc()
+	if be == nil {
+		http.Error(w, `{"error":"state backend not bound"}`, http.StatusServiceUnavailable)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		etag, err := be.SecretsEtag()
+		if err != nil {
+			http.Error(w, jsonError(err), http.StatusInternalServerError)
+			return
+		}
+		if inm := r.Header.Get("If-None-Match"); inm != "" && inm == etag {
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		values, err := be.ListSecrets()
+		if err != nil {
+			http.Error(w, jsonError(err), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Values map[string]string `json:"values"`
+			ETag   string            `json:"etag"`
+		}{values, etag})
+	default:
+		w.Header().Set("Allow", "GET")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *listenServer) handleSecretByName(w http.ResponseWriter, r *http.Request) {
+	if !s.authed(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	be := s.stateSrc()
+	if be == nil {
+		http.Error(w, `{"error":"state backend not bound"}`, http.StatusServiceUnavailable)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/v1/secrets/")
+	if name == "" || strings.Contains(name, "/") {
+		http.Error(w, `{"error":"secret name required (path: /v1/secrets/{name})"}`, http.StatusBadRequest)
+		return
+	}
+	if !validSecretName.MatchString(name) {
+		http.Error(w, `{"error":"name must match UPPER_SNAKE_CASE"}`, http.StatusBadRequest)
+		return
+	}
+
+	actor := r.Header.Get("X-Cronicle-Actor")
+	switch r.Method {
+	case http.MethodPut:
+		var body struct {
+			Value string `json:"value"`
+		}
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, jsonError(err), http.StatusBadRequest)
+			return
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, jsonError(err), http.StatusBadRequest)
+			return
+		}
+		if body.Value == "" {
+			http.Error(w, `{"error":"value required"}`, http.StatusBadRequest)
+			return
+		}
+		if err := be.PutSecret(name, body.Value, actor); err != nil {
+			http.Error(w, jsonError(err), http.StatusInternalServerError)
+			return
+		}
+		slog.Info("listener: secret upserted", "name", name, "actor", actor)
+		etag, _ := be.SecretsEtag()
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusNoContent)
+
+	case http.MethodDelete:
+		ok, err := be.DeleteSecret(name, actor)
+		if err != nil {
+			http.Error(w, jsonError(err), http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		slog.Info("listener: secret deleted", "name", name, "actor", actor)
+		etag, _ := be.SecretsEtag()
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		w.Header().Set("Allow", "PUT, DELETE")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func jsonError(err error) string {
+	b, _ := json.Marshal(struct {
+		Error string `json:"error"`
+	}{err.Error()})
+	return string(b)
+}

--- a/internal/cronicle/secretsource/dispatch.go
+++ b/internal/cronicle/secretsource/dispatch.go
@@ -1,0 +1,66 @@
+package secretsource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Open parses a secret-source spec and returns the matching Source.
+//
+// Accepted forms:
+//   - file:///abs/path/secrets.json
+//   - /abs/path/secrets.json     (no scheme → treated as file)
+//   - relative/path.json         (no scheme → treated as file)
+//   - http://host/path
+//   - https://host/path
+//
+// The no-scheme fallback mirrors configsource so operators don't need
+// to learn two different conventions. Anything containing "://" is
+// dispatched by URL scheme.
+//
+// ctx is currently unused — file and http construction don't need a
+// round-trip — but it's part of the signature so future sources
+// (vault, kms, etc.) can use it without breaking callers.
+func Open(_ context.Context, spec string) (Source, error) {
+	if spec == "" {
+		return nil, fmt.Errorf("secret source spec is empty")
+	}
+	if !strings.Contains(spec, "://") {
+		return NewFileSource(spec)
+	}
+	u, err := url.Parse(spec)
+	if err != nil {
+		return nil, fmt.Errorf("invalid secret source url: %w", err)
+	}
+	switch u.Scheme {
+	case "file":
+		if u.Host != "" && u.Host != "localhost" {
+			return nil, fmt.Errorf(
+				"file:// requires an absolute path (use file:///path or just /path), got host=%q in %q",
+				u.Host, spec)
+		}
+		return NewFileSource(u.Path)
+	case "http", "https":
+		return NewHTTPSource(spec)
+	case "env":
+		// env:// exposes the cronicle process's own env vars. Operator
+		// scopes via ?prefix=APP_ or ?names=A,B,C; bare env:// exposes
+		// every UPPER_SNAKE_CASE name (matches secret-name convention).
+		q := u.Query()
+		prefix := q.Get("prefix")
+		var names []string
+		if v := q.Get("names"); v != "" {
+			for _, n := range strings.Split(v, ",") {
+				if n = strings.TrimSpace(n); n != "" {
+					names = append(names, n)
+				}
+			}
+		}
+		return NewEnvSource(prefix, names), nil
+	default:
+		return nil, fmt.Errorf("unsupported secret source scheme %q in %q (want env/file/http/https)",
+			u.Scheme, spec)
+	}
+}

--- a/internal/cronicle/secretsource/dispatch_test.go
+++ b/internal/cronicle/secretsource/dispatch_test.go
@@ -1,0 +1,64 @@
+package secretsource
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpen_filePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	if err := os.WriteFile(path, []byte(`{"values":{}}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Bare path → FileSource.
+	s, err := Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("bare path: %v", err)
+	}
+	if !strings.HasPrefix(s.String(), "file://") {
+		t.Errorf("bare path should dispatch to file source: %q", s.String())
+	}
+
+	// file:// scheme → FileSource.
+	s, err = Open(context.Background(), "file://"+path)
+	if err != nil {
+		t.Fatalf("file:// scheme: %v", err)
+	}
+	if !strings.HasPrefix(s.String(), "file://") {
+		t.Errorf("file:// scheme should dispatch to file source: %q", s.String())
+	}
+}
+
+func TestOpen_httpURL(t *testing.T) {
+	s, err := Open(context.Background(), "http://example.com/v1/secrets")
+	if err != nil {
+		t.Fatalf("http url: %v", err)
+	}
+	if !strings.HasPrefix(s.String(), "http://") {
+		t.Errorf("http url should dispatch to http source: %q", s.String())
+	}
+}
+
+func TestOpen_emptySpec(t *testing.T) {
+	if _, err := Open(context.Background(), ""); err == nil {
+		t.Error("empty spec should error")
+	}
+}
+
+func TestOpen_unsupportedScheme(t *testing.T) {
+	if _, err := Open(context.Background(), "vault://my-secret"); err == nil {
+		t.Error("unsupported scheme should error")
+	}
+}
+
+func TestOpen_fileURLRejectsRelative(t *testing.T) {
+	// file://host/path is ambiguous; tell the user explicitly.
+	if _, err := Open(context.Background(), "file://relative/path"); err == nil {
+		t.Error("file://relative/... should error")
+	}
+}

--- a/internal/cronicle/secretsource/env.go
+++ b/internal/cronicle/secretsource/env.go
@@ -1,0 +1,137 @@
+package secretsource
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// EnvSource exposes the cronicle process's own env as a secret source.
+// Useful for the standalone-CLI shape: the operator exports values via
+// the shell (or systemd, docker -e, etc.) and cronicle's task dispatch
+// resolves $secret.NAME against them — no external service, no file
+// to manage, just process env.
+//
+// Spec forms:
+//
+//	env://                 // expose every env var matching UPPER_SNAKE_CASE
+//	env://?prefix=APP_     // expose only vars whose name starts with APP_
+//	                       // (prefix is stripped from the exposed name)
+//	env://?names=A,B,C     // expose only the named vars (no prefix strip)
+//
+// Why filter at all: a default-everything export would happily hand
+// out PATH, HOME, USER, etc. when an HCL author wrote $secret.PATH —
+// surprising and arguably leaky. Limiting to UPPER_SNAKE_CASE matches
+// the secret-name convention already used elsewhere in cronicle and
+// excludes most non-secret OS variables.
+//
+// Etag: sha256 over the sorted "name=value" lines. Cheap and stable;
+// the refresh loop short-circuits when nothing changed.
+type EnvSource struct {
+	prefix string
+	names  map[string]struct{} // nil → "everything matching shape"
+	spec   string              // for String()
+}
+
+// NewEnvSource constructs an EnvSource from a parsed URL's query string.
+// Used by Open; direct callers can construct an empty EnvSource for
+// "expose everything UPPER_SNAKE_CASE."
+func NewEnvSource(prefix string, names []string) *EnvSource {
+	s := &EnvSource{prefix: prefix}
+	if len(names) > 0 {
+		s.names = make(map[string]struct{}, len(names))
+		for _, n := range names {
+			n = strings.TrimSpace(n)
+			if n != "" {
+				s.names[n] = struct{}{}
+			}
+		}
+	}
+	parts := []string{"env://"}
+	if prefix != "" {
+		parts = append(parts, "?prefix="+prefix)
+	} else if len(names) > 0 {
+		parts = append(parts, "?names="+strings.Join(names, ","))
+	}
+	s.spec = strings.Join(parts, "")
+	return s
+}
+
+// looksLikeSecretName matches UPPER_SNAKE_CASE — same shape used by
+// cronicle-web's isValidSecretName. Keeps EnvSource from accidentally
+// exposing lower-case OS vars like "HOME"/"USER" via $secret.X.
+func looksLikeSecretName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_':
+			continue
+		case r >= 'A' && r <= 'Z':
+			continue
+		case r >= '0' && r <= '9' && i > 0:
+			continue
+		default:
+			return false
+		}
+	}
+	// First char must be a letter, not digit/underscore.
+	r := rune(s[0])
+	return r >= 'A' && r <= 'Z'
+}
+
+func (s *EnvSource) Fetch(_ context.Context, prevEtag string) (map[string]string, string, bool, error) {
+	out := map[string]string{}
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		name, value := kv[:eq], kv[eq+1:]
+		// names= filter takes precedence over prefix=, mirroring how
+		// most CLIs treat exact lists as more specific than patterns.
+		if s.names != nil {
+			if _, ok := s.names[name]; !ok {
+				continue
+			}
+		} else if s.prefix != "" {
+			if !strings.HasPrefix(name, s.prefix) {
+				continue
+			}
+			name = strings.TrimPrefix(name, s.prefix)
+		} else {
+			if !looksLikeSecretName(name) {
+				continue
+			}
+		}
+		out[name] = value
+	}
+	etag := envEtag(out)
+	if etag == prevEtag {
+		return nil, etag, false, nil
+	}
+	return out, etag, true, nil
+}
+
+// envEtag is sha256 over "k=v\n" lines sorted by key. Stable across
+// runs so the refresh loop's first post-startup tick reports
+// changed=false instead of re-applying an identical map.
+func envEtag(values map[string]string) string {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h := sha256.New()
+	for _, k := range keys {
+		fmt.Fprintf(h, "%s=%s\n", k, values[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (s *EnvSource) String() string { return s.spec }

--- a/internal/cronicle/secretsource/file.go
+++ b/internal/cronicle/secretsource/file.go
@@ -1,0 +1,76 @@
+package secretsource
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FileSource reads the secret map from a JSON file on disk. Intended
+// for local development and testing — no fancy watching, no etag fast
+// path, just stat-and-hash on each Fetch.
+//
+// File format:
+//
+//	{
+//	  "values": {
+//	    "ANTHROPIC_API_KEY": "sk-ant-...",
+//	    "GITHUB_TOKEN": "ghp_..."
+//	  }
+//	}
+//
+// The `{values:{}}` envelope mirrors the HTTP wire format so test
+// fixtures double as wire-shape examples.
+//
+// File mode is checked on every read — if it's world-readable we emit
+// a warning into the returned error so dev users notice. Production
+// users should be on HTTPSource, not this.
+type FileSource struct {
+	Path string
+}
+
+// NewFileSource resolves the path absolutely so log lines are
+// unambiguous. The file doesn't have to exist at construction time;
+// it's checked on each Fetch.
+func NewFileSource(path string) (*FileSource, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	return &FileSource{Path: abs}, nil
+}
+
+func (s *FileSource) Fetch(_ context.Context, prevEtag string) (map[string]string, string, bool, error) {
+	body, err := os.ReadFile(s.Path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, prevEtag, false, ErrNotFound
+		}
+		return nil, prevEtag, false, err
+	}
+	sum := sha256.Sum256(body)
+	etag := hex.EncodeToString(sum[:])
+	if etag == prevEtag {
+		return nil, etag, false, nil
+	}
+	var env struct {
+		Values map[string]string `json:"values"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, prevEtag, false, fmt.Errorf("secret source: decode %s: %w", s.Path, err)
+	}
+	if env.Values == nil {
+		env.Values = map[string]string{}
+	}
+	return env.Values, etag, true, nil
+}
+
+func (s *FileSource) String() string {
+	return "file://" + s.Path
+}

--- a/internal/cronicle/secretsource/file_test.go
+++ b/internal/cronicle/secretsource/file_test.go
@@ -1,0 +1,73 @@
+package secretsource
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileSource_roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	if err := os.WriteFile(path, []byte(`{"values":{"FOO":"bar"}}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s, err := NewFileSource(path)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	got, etag1, changed, err := s.Fetch(context.Background(), "")
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if !changed || got["FOO"] != "bar" {
+		t.Errorf("first fetch: changed=%v values=%v", changed, got)
+	}
+
+	// Same contents, same etag, no change.
+	_, etag2, changed, err := s.Fetch(context.Background(), etag1)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if changed || etag2 != etag1 {
+		t.Errorf("unchanged contents should yield changed=false; got changed=%v", changed)
+	}
+
+	// Edit contents → new etag, new map.
+	if err := os.WriteFile(path, []byte(`{"values":{"FOO":"baz","NEW":"x"}}`), 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got3, etag3, changed, err := s.Fetch(context.Background(), etag1)
+	if err != nil {
+		t.Fatalf("third fetch: %v", err)
+	}
+	if !changed || etag3 == etag1 || got3["FOO"] != "baz" || got3["NEW"] != "x" {
+		t.Errorf("post-edit fetch: changed=%v etag=%q values=%v", changed, etag3, got3)
+	}
+}
+
+func TestFileSource_missingIsNotFound(t *testing.T) {
+	s, err := NewFileSource(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	_, _, _, err = s.Fetch(context.Background(), "")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileSource_invalidJSONErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	if err := os.WriteFile(path, []byte(`{not json}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s, _ := NewFileSource(path)
+	_, _, _, err := s.Fetch(context.Background(), "")
+	if err == nil {
+		t.Errorf("invalid JSON should error")
+	}
+}

--- a/internal/cronicle/secretsource/http.go
+++ b/internal/cronicle/secretsource/http.go
@@ -1,0 +1,148 @@
+package secretsource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// HTTPSource pulls the name → value map from an HTTP(S) GET endpoint.
+//
+// Wire contract:
+//
+//	GET <url>
+//	  Authorization: Bearer <token>  (optional)
+//	  If-None-Match:  <prev-etag>    (optional)
+//	→ 200 OK  with ETag: <opaque>  and body {"values":{NAME:"value", ...}}
+//	→ 304 Not Modified  (etag matched, no body)
+//	→ 401/403           (auth rejected; ErrUnauthorized)
+//	→ 404               (source absent; ErrNotFound)
+//	→ anything else     (transient error; refresh loop keeps prior cache)
+//
+// The `{values: {...}}` envelope (rather than a flat map) leaves room
+// for future fields — next_refresh hints, advisories — without
+// breaking parsers.
+//
+// Auth: bearer token via WithBearer or constructed from the
+// CRONICLE_SECRET_SOURCE_TOKEN env at the caller. Tokens never appear
+// in String() output.
+//
+// Transport: cronicle ships with the default Go http.Client (system
+// TLS roots). For local-dev plaintext (in-cluster service DNS), an
+// http:// URL works; for anything internet-facing, use https://.
+type HTTPSource struct {
+	URL     string
+	Client  *http.Client
+	Headers http.Header
+}
+
+// NewHTTPSource constructs an HTTPSource for the given URL. The
+// default client has a 30s timeout — refresh ticks are seconds-scale
+// so long-running fetches indicate trouble worth surfacing as a warn.
+func NewHTTPSource(rawurl string) (*HTTPSource, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid http url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("not an http(s) url: %s", rawurl)
+	}
+	return &HTTPSource{
+		URL:     rawurl,
+		Client:  &http.Client{Timeout: 30 * time.Second},
+		Headers: http.Header{},
+	}, nil
+}
+
+// WithBearer sets an Authorization header for every fetch. Returns
+// the source for chaining at construction sites.
+func (s *HTTPSource) WithBearer(token string) *HTTPSource {
+	s.Headers.Set("Authorization", "Bearer "+token)
+	return s
+}
+
+// WithHeader sets an arbitrary header for every fetch. Replaces any
+// previous value for the same key. Useful for x-actor / trace headers
+// callers want propagated.
+func (s *HTTPSource) WithHeader(key, value string) *HTTPSource {
+	s.Headers.Set(key, value)
+	return s
+}
+
+func (s *HTTPSource) Fetch(ctx context.Context, prevEtag string) (map[string]string, string, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
+	if err != nil {
+		return nil, prevEtag, false, err
+	}
+	for k, vs := range s.Headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	if prevEtag != "" {
+		req.Header.Set("If-None-Match", prevEtag)
+	}
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, prevEtag, false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return nil, prevEtag, false, nil
+	case http.StatusNotFound:
+		return nil, prevEtag, false, ErrNotFound
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, prevEtag, false, ErrUnauthorized
+	case http.StatusOK:
+		// fall through
+	default:
+		return nil, prevEtag, false,
+			fmt.Errorf("secret source: %s: %s", redactURL(s.URL), resp.Status)
+	}
+
+	etag := resp.Header.Get("ETag")
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB ceiling — secret bundles aren't large
+	if err != nil {
+		return nil, prevEtag, false, err
+	}
+	var env struct {
+		Values map[string]string `json:"values"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, prevEtag, false, fmt.Errorf("secret source: decode body: %w", err)
+	}
+	if env.Values == nil {
+		// Treat as empty rather than error — an authorized request that
+		// returns no secrets is a legitimate empty state, not a fault.
+		env.Values = map[string]string{}
+	}
+	if etag != "" && etag == prevEtag {
+		// Server didn't honor If-None-Match but the etag is unchanged.
+		// Treat as no-op so the refresh loop doesn't re-audit.
+		return nil, etag, false, nil
+	}
+	return env.Values, etag, true, nil
+}
+
+func (s *HTTPSource) String() string {
+	return redactURL(s.URL)
+}
+
+// redactURL strips userinfo and query string before any log emission.
+// Query params on a secret-source URL are unlikely but if they exist
+// they may contain identifying tokens — drop them defensively.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.User = nil
+	u.RawQuery = ""
+	return u.String()
+}

--- a/internal/cronicle/secretsource/http_test.go
+++ b/internal/cronicle/secretsource/http_test.go
@@ -1,0 +1,153 @@
+package secretsource
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHTTPSource_firstFetchAndConditional(t *testing.T) {
+	version := 1
+	val := "v1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		etag := strconv.Itoa(version)
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		_, _ = w.Write([]byte(`{"values":{"ANTHROPIC_API_KEY":"` + val + `"}}`))
+	}))
+	defer srv.Close()
+
+	s, err := NewHTTPSource(srv.URL)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	got, etag1, changed, err := s.Fetch(context.Background(), "")
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if !changed {
+		t.Errorf("first fetch should return changed=true")
+	}
+	if etag1 != "1" {
+		t.Errorf("etag: want 1, got %q", etag1)
+	}
+	if got["ANTHROPIC_API_KEY"] != "v1" {
+		t.Errorf("value mismatch: %v", got)
+	}
+
+	// Same etag: 304, changed=false.
+	_, etag2, changed, err := s.Fetch(context.Background(), etag1)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if changed {
+		t.Errorf("304 should yield changed=false")
+	}
+	if etag2 != etag1 {
+		t.Errorf("etag should be preserved on 304")
+	}
+
+	// Bump server, expect change.
+	version = 2
+	val = "v2"
+	got3, etag3, changed, err := s.Fetch(context.Background(), etag1)
+	if err != nil {
+		t.Fatalf("third fetch: %v", err)
+	}
+	if !changed || etag3 != "2" || got3["ANTHROPIC_API_KEY"] != "v2" {
+		t.Errorf("post-bump fetch: changed=%v etag=%q values=%v", changed, etag3, got3)
+	}
+}
+
+func TestHTTPSource_404IsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	s, _ := NewHTTPSource(srv.URL)
+	_, _, _, err := s.Fetch(context.Background(), "")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestHTTPSource_401IsUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	s, _ := NewHTTPSource(srv.URL)
+	_, _, _, err := s.Fetch(context.Background(), "")
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("want ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestHTTPSource_bearerHeaderSent(t *testing.T) {
+	gotAuth := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"values":{}}`))
+	}))
+	defer srv.Close()
+	s, _ := NewHTTPSource(srv.URL)
+	s.WithBearer("topsecret")
+	if _, _, _, err := s.Fetch(context.Background(), ""); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if gotAuth != "Bearer topsecret" {
+		t.Errorf("auth header: want Bearer topsecret, got %q", gotAuth)
+	}
+}
+
+func TestHTTPSource_stringRedactsCredsAndQuery(t *testing.T) {
+	s, err := NewHTTPSource("https://alice:hunter2@api.example.com/v1/secrets?actor=worker&trace=abc")
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	got := s.String()
+	for _, bad := range []string{"alice", "hunter2", "actor=", "trace="} {
+		if strings.Contains(got, bad) {
+			t.Errorf("String() leaked %q: %q", bad, got)
+		}
+	}
+}
+
+func TestHTTPSource_emptyValuesIsNotAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", "v1")
+		_, _ = w.Write([]byte(`{"values":null}`))
+	}))
+	defer srv.Close()
+	s, _ := NewHTTPSource(srv.URL)
+	got, _, changed, err := s.Fetch(context.Background(), "")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if !changed || got == nil || len(got) != 0 {
+		t.Errorf("want empty-map, changed=true; got changed=%v values=%v", changed, got)
+	}
+}
+
+func TestHTTPSource_responseBodyTooLarge(t *testing.T) {
+	// A misbehaving server can't drown us in memory: enforce a 1 MiB
+	// ceiling. We don't error on overflow — we just truncate, which
+	// causes the JSON decode to fail and yield a clear error.
+	big := strings.Repeat("x", 2<<20)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"values":{"X":"` + big + `"}}`))
+	}))
+	defer srv.Close()
+	s, _ := NewHTTPSource(srv.URL)
+	_, _, _, err := s.Fetch(context.Background(), "")
+	if err == nil {
+		t.Errorf("oversized body should fail with a decode error")
+	}
+}

--- a/internal/cronicle/secretsource/source.go
+++ b/internal/cronicle/secretsource/source.go
@@ -1,0 +1,54 @@
+// Package secretsource pulls a name → value map from a pluggable
+// backing store: a JSON file on disk, or an HTTP endpoint. Mirrors
+// internal/cronicle/configsource — same etag-based polling contract,
+// same source interface shape, so the runtime can refresh secrets
+// with the same machinery it already uses for HCL config.
+//
+// What this package is NOT: a long-term secret manager. Values flow
+// through process memory only; the source decides how plaintext is
+// retrieved (the canonical platform shape is "talk to a control plane
+// that holds ciphertext + DEK and returns plaintext over an
+// authenticated channel"). This package is the plumbing in cronicle,
+// not the storage.
+//
+// Threading: Source.Fetch may be called concurrently. The cron loop is
+// single-threaded today, but tests exercise concurrent paths.
+package secretsource
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound is the sentinel returned by Source.Fetch when the source
+// itself is absent — the file doesn't exist, the HTTP endpoint returns
+// 404. Distinct from a transient I/O error: a refresh loop should warn
+// once and continue retrying without dropping the cached map.
+var ErrNotFound = errors.New("secret source not found")
+
+// ErrUnauthorized is returned by HTTPSource when the server rejects
+// the request (401/403). Distinct because callers usually want to
+// surface this immediately — a token-rotation issue won't fix itself
+// on the next tick.
+var ErrUnauthorized = errors.New("secret source rejected credentials")
+
+// Source is the pluggable backing store for cronicle's secret map.
+//
+// Implementations MUST:
+//   - Return (values, etag, true, nil) on the first call (prevEtag == "")
+//     with the full map.
+//   - Return (nil, prevEtag, false, nil) when the underlying content is
+//     unchanged since prevEtag — callers use this to skip the diff +
+//     audit pass on every refresh tick.
+//   - Be safe for concurrent Fetch calls.
+//
+// values is name → plaintext. The map MUST NOT include any value the
+// caller didn't request — there's no opaque per-row metadata; what
+// you return is what the agent dispatch sees.
+type Source interface {
+	Fetch(ctx context.Context, prevEtag string) (values map[string]string, etag string, changed bool, err error)
+
+	// String returns a short, redacted description for log lines:
+	// scheme + target, never credentials, never values.
+	String() string
+}

--- a/internal/cronicle/secretstore/expand.go
+++ b/internal/cronicle/secretstore/expand.go
@@ -1,0 +1,102 @@
+package secretstore
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// SECRET_REF_RE matches $secret.NAME references in a value string.
+// Mirrors the cronicle-web/cronicle-infra convention. The negative
+// lookbehind isn't supported in Go's RE2 engine, so we handle the
+// $$secret.X literal-dollar escape with a post-filter below.
+//
+// Name shape: UPPER_SNAKE — first char A-Z, rest A-Z/0-9/_. Anything
+// else fails validation upstream and would never appear here.
+var SECRET_REF_RE = regexp.MustCompile(`\$secret\.([A-Z][A-Z0-9_]*)`)
+
+// ExpandValue replaces every $secret.NAME in s with the matching
+// value from the Store. Unresolved references produce a clear error
+// listing all the missing names — partial expansion is never
+// returned, so callers don't have to inspect the result for "did
+// this still contain a $secret reference?".
+//
+// Escape: a literal "$$secret.X" is preserved as "$secret.X" (one
+// dollar, no expansion). Matches the convention HCL/shell tooling
+// uses to opt out of expansion.
+func (s *Store) ExpandValue(in string) (string, error) {
+	// Handle escape first by replacing $$ → \x00\x01 placeholder so
+	// the regex below doesn't see them, then restore at the end.
+	const escSentinel = "\x00\x01"
+	work := strings.ReplaceAll(in, "$$", escSentinel)
+
+	var missing []string
+	out := SECRET_REF_RE.ReplaceAllStringFunc(work, func(match string) string {
+		// Re-extract the name from the match. ReplaceAllStringFunc gives
+		// us the whole match, not the capture group, so we slice past
+		// the literal "$secret." prefix.
+		name := strings.TrimPrefix(match, "$secret.")
+		v, ok, err := s.Get(name)
+		if err != nil {
+			// Surface the store-level error via missing — the caller's
+			// "missing references" error message subsumes it.
+			missing = append(missing, name+" ("+err.Error()+")")
+			return match
+		}
+		if !ok {
+			missing = append(missing, name)
+			return match
+		}
+		return v
+	})
+	out = strings.ReplaceAll(out, escSentinel, "$")
+	if len(missing) > 0 {
+		return "", fmt.Errorf("unresolved secret references: %s", strings.Join(missing, ", "))
+	}
+	return out, nil
+}
+
+// ExpandEnv applies ExpandValue to every entry of an env slice (each
+// "KEY=VALUE" line). Returns a new slice; the input is not mutated.
+// On any unresolved reference, returns the (partial, but unused)
+// slice and the error — callers MUST check err before using the
+// slice. We return the partial work too so test assertions can show
+// where the expansion broke.
+func (s *Store) ExpandEnv(env []string) ([]string, error) {
+	out := make([]string, 0, len(env))
+	var firstErr error
+	for _, entry := range env {
+		// We expand the whole line, including the key. Practically the
+		// $secret. references only appear in the VALUE side of
+		// KEY=VALUE, but expanding the line means we don't need to
+		// parse the KEY=VALUE split and handle quoting subtleties.
+		expanded, err := s.ExpandValue(entry)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		out = append(out, expanded)
+	}
+	return out, firstErr
+}
+
+// LookupRef returns the value of a bare "$secret.NAME" string, or the
+// resolved value when name was found. Convenience for task dispatch
+// pulling a single value (e.g. ANTHROPIC_API_KEY for cfg.APIKey)
+// without going through the full env slice.
+//
+// Returns ("", false, nil) when ref doesn't match the $secret.NAME
+// pattern — callers can pass any string and act on the boolean.
+func (s *Store) LookupRef(ref string) (string, bool, error) {
+	m := SECRET_REF_RE.FindStringSubmatch(ref)
+	if len(m) != 2 || m[0] != ref {
+		return "", false, nil
+	}
+	v, ok, err := s.Get(m[1])
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
+		return "", false, fmt.Errorf("unresolved secret reference: %s", ref)
+	}
+	return v, true, nil
+}

--- a/internal/cronicle/secretstore/expand_test.go
+++ b/internal/cronicle/secretstore/expand_test.go
@@ -1,0 +1,106 @@
+package secretstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func newStoreWith(t *testing.T, values map[string]string) *Store {
+	t.Helper()
+	be := memBackend(t)
+	for k, v := range values {
+		if err := be.PutSecret(k, v, "test"); err != nil {
+			t.Fatalf("PutSecret: %v", err)
+		}
+	}
+	s := New().SetBackend(be).StaleTTL(0)
+	if err := s.Start(context.Background(), nil, 0); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	return s
+}
+
+func TestExpandValue_basicReplacement(t *testing.T) {
+	s := newStoreWith(t, map[string]string{
+		"ANTHROPIC_API_KEY": "sk-ant-xxx",
+		"GITHUB_TOKEN":      "ghp_yyy",
+	})
+
+	cases := []struct {
+		in, want string
+	}{
+		{"ANTHROPIC_API_KEY=$secret.ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY=sk-ant-xxx"},
+		{"GITHUB_TOKEN=$secret.GITHUB_TOKEN", "GITHUB_TOKEN=ghp_yyy"},
+		{"PLAIN=hello", "PLAIN=hello"},
+		{"COMBINED=prefix-$secret.GITHUB_TOKEN-suffix", "COMBINED=prefix-ghp_yyy-suffix"},
+	}
+	for _, c := range cases {
+		got, err := s.ExpandValue(c.in)
+		if err != nil {
+			t.Errorf("ExpandValue(%q): err %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ExpandValue(%q): want %q, got %q", c.in, c.want, got)
+		}
+	}
+}
+
+func TestExpandValue_unresolvedErrors(t *testing.T) {
+	s := newStoreWith(t, map[string]string{"FOO": "bar"})
+	_, err := s.ExpandValue("X=$secret.MISSING_ONE Y=$secret.MISSING_TWO")
+	if err == nil {
+		t.Fatal("missing refs should error")
+	}
+	for _, want := range []string{"MISSING_ONE", "MISSING_TWO"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestExpandValue_dollarEscape(t *testing.T) {
+	s := newStoreWith(t, map[string]string{"FOO": "bar"})
+	got, err := s.ExpandValue("LITERAL=$$secret.FOO")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "LITERAL=$secret.FOO" {
+		t.Errorf("escape: want LITERAL=$secret.FOO, got %q", got)
+	}
+}
+
+func TestExpandEnv_partialFailureReturnsFirstError(t *testing.T) {
+	s := newStoreWith(t, map[string]string{"OK": "value"})
+	_, err := s.ExpandEnv([]string{
+		"GOOD=$secret.OK",
+		"BAD=$secret.NOPE",
+	})
+	if err == nil {
+		t.Fatal("partial failure should error")
+	}
+	if !strings.Contains(err.Error(), "NOPE") {
+		t.Errorf("error should mention missing name, got %q", err.Error())
+	}
+}
+
+func TestLookupRef(t *testing.T) {
+	s := newStoreWith(t, map[string]string{"FOO": "bar"})
+
+	v, ok, err := s.LookupRef("$secret.FOO")
+	if err != nil || !ok || v != "bar" {
+		t.Errorf("hit: v=%q ok=%v err=%v", v, ok, err)
+	}
+
+	// Non-ref string → ok=false, no error.
+	_, ok, err = s.LookupRef("plain-value")
+	if ok || err != nil {
+		t.Errorf("non-ref: ok=%v err=%v", ok, err)
+	}
+
+	// Ref that doesn't resolve → error.
+	if _, _, err := s.LookupRef("$secret.MISSING"); err == nil {
+		t.Errorf("missing ref should error")
+	}
+}

--- a/internal/cronicle/secretstore/store.go
+++ b/internal/cronicle/secretstore/store.go
@@ -1,0 +1,314 @@
+// Package secretstore is the bridge between cronicle's pluggable
+// secretsource layer and the in-tree state.Backend's SecretStore role.
+//
+// Architecture (post-redesign): the state.db is the canonical store.
+// Everything reads from there at dispatch time. --secret-source
+// values are *ingestion paths* that populate state.db on each refresh
+// tick; they are not consulted on the hot path. Benefits:
+//
+//   - One read path for $secret.NAME resolution, regardless of
+//     ingestion source.
+//   - Survives runtime restarts (values are at-rest in state.db).
+//   - Switching the state Backend (sqlite → Postgres via cronicle-infra)
+//     carries the secret layer along — same SecretStore role.
+//   - `cronicle secret set/list/rm` and the listener's /v1/secrets
+//     endpoints are first-class write paths, peers of refresh
+//     ingestion rather than parallel subsystems.
+//
+// Security stance:
+//   - Audit on change logs names only, never values. The refresh loop
+//     compares incoming map vs state.db's current list and emits added/
+//     removed/rotated entries by name.
+//   - Stale TTL gates dispensing: if the most recent successful refresh
+//     is older than StaleTTL, Get returns ErrStale rather than handing
+//     out potentially-revoked values.
+//   - Subprocess env scrubbing (in pkg/exec) ensures secrets dispensed
+//     to a bash tool's env don't leak via os.Environ inheritance.
+package secretstore
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/secretsource"
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// ErrStale is returned when the most recent successful ingest is older
+// than StaleTTL. Callers must fail the current operation — the explicit
+// failure signal is the whole point of staleness gating (revocation
+// must not silently regress to old values).
+var ErrStale = errors.New("secretstore: cached values are stale (refresh has been failing)")
+
+// ErrNotConfigured is returned when no Backend has been bound. Distinct
+// from "name not found" so callers can produce a clearer error than
+// silent "$secret.X resolved to empty."
+var ErrNotConfigured = errors.New("secretstore: not configured (no state backend bound)")
+
+// Default refresh / staleness. Refresh is frequent enough that
+// rotations take effect within seconds; TTL is long enough that brief
+// outages don't fail tasks but short enough that an extended outage
+// doesn't let revoked secrets keep flowing for hours.
+const (
+	DefaultRefreshInterval = 5 * time.Second
+	DefaultStaleTTL        = 5 * time.Minute
+)
+
+// Store is the dispatch-facing read façade. All resolution
+// ($secret.NAME → value) flows through Get/ExpandValue/ExpandEnv. The
+// Store does NOT cache values in process memory — every Get is a
+// Backend.GetSecret call so the canonical source of truth is the
+// state.db row, not an in-process snapshot that could drift.
+//
+// staleTTL is enforced against the most recent successful *ingest*:
+// if the refresh loop has been failing long enough, Get refuses to
+// dispense. When no ingestion source is configured (`state://` or
+// pure CLI-managed mode), staleness gating is bypassed — the state.db
+// IS the source.
+type Store struct {
+	mu             sync.RWMutex
+	backend        state.SecretStore
+	lastIngest     time.Time
+	lastSourceETag string
+	source         secretsource.Source // nil when no ingestion configured
+	staleTTL       time.Duration
+
+	// now is injectable so staleness tests don't have to sleep.
+	now func() time.Time
+}
+
+// New constructs an unconfigured Store. Most callers want Start
+// (binds Backend + spawns refresh loop); this exists for tests that
+// drive the Store directly.
+func New() *Store {
+	return &Store{staleTTL: DefaultStaleTTL, now: time.Now}
+}
+
+// SetBackend installs the state.SecretStore implementation reads
+// flow through. Call BEFORE Start when an ingestion source will be
+// driving writes; or call alone for the "manage via CLI/HTTP only"
+// shape.
+func (s *Store) SetBackend(b state.SecretStore) *Store {
+	s.mu.Lock()
+	s.backend = b
+	s.mu.Unlock()
+	return s
+}
+
+// StaleTTL overrides the threshold. 0 disables gating — appropriate
+// for backends with no ingest pump (state.db is the truth).
+func (s *Store) StaleTTL(d time.Duration) *Store {
+	s.mu.Lock()
+	s.staleTTL = d
+	s.mu.Unlock()
+	return s
+}
+
+// Configured reports whether SetBackend has been called.
+func (s *Store) Configured() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.backend != nil
+}
+
+// Get returns the value for name from the state Backend. Errors:
+//   - ErrNotConfigured when SetBackend hasn't been called
+//   - ErrStale when an ingestion source is bound and its last
+//     successful refresh is older than staleTTL
+//   - backend I/O error otherwise
+//
+// ok=false (no error) when name is simply not in the store.
+func (s *Store) Get(name string) (value string, ok bool, err error) {
+	s.mu.RLock()
+	be := s.backend
+	src := s.source
+	last := s.lastIngest
+	ttl := s.staleTTL
+	now := s.now()
+	s.mu.RUnlock()
+
+	if be == nil {
+		return "", false, ErrNotConfigured
+	}
+	// Staleness only applies when an ingestion source is wired AND a
+	// ttl is set. The CLI/HTTP-only case (no source) skips this gate.
+	if src != nil && ttl > 0 && !last.IsZero() && now.Sub(last) > ttl {
+		return "", false, ErrStale
+	}
+	return be.GetSecret(name)
+}
+
+// Names returns the sorted secret names from the backend, for audit
+// inspection. Errors bubble unchanged.
+func (s *Store) Names() ([]string, error) {
+	s.mu.RLock()
+	be := s.backend
+	s.mu.RUnlock()
+	if be == nil {
+		return nil, ErrNotConfigured
+	}
+	return be.ListSecretNames()
+}
+
+// Start binds an ingestion source and launches the refresh loop. The
+// initial sync fetch hydrates the backend before returning so startup
+// fails loudly on a misconfigured source.
+//
+// When src is nil, no refresh loop runs — the Backend is the source
+// of truth, populated via CLI / HTTP / direct PutSecret. This is the
+// shape the state:// source uses.
+func (s *Store) Start(ctx context.Context, src secretsource.Source, interval time.Duration) error {
+	s.mu.Lock()
+	if s.backend == nil {
+		s.mu.Unlock()
+		return ErrNotConfigured
+	}
+	s.source = src
+	s.mu.Unlock()
+
+	if src == nil {
+		return nil
+	}
+	if interval <= 0 {
+		interval = DefaultRefreshInterval
+	}
+	if err := s.refreshOnce(ctx); err != nil {
+		return err
+	}
+	go s.refreshLoop(ctx, interval)
+	return nil
+}
+
+func (s *Store) refreshLoop(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := s.refreshOnce(ctx); err != nil {
+				slog.Warn("secretstore: refresh failed; keeping last good state.db rows",
+					"source", s.sourceString(), "err", err.Error())
+			}
+		}
+	}
+}
+
+// refreshOnce pulls from the configured source and writes any
+// changes into the Backend. Audit logs names of added/removed/
+// rotated entries — values are never logged.
+func (s *Store) refreshOnce(ctx context.Context) error {
+	s.mu.RLock()
+	src := s.source
+	be := s.backend
+	prevSourceEtag := s.lastSourceETag
+	s.mu.RUnlock()
+	if src == nil || be == nil {
+		return nil
+	}
+
+	values, etag, changed, err := src.Fetch(ctx, prevSourceEtag)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	if !changed {
+		s.mu.Lock()
+		s.lastIngest = now
+		if etag != "" {
+			s.lastSourceETag = etag
+		}
+		s.mu.Unlock()
+		return nil
+	}
+
+	// Diff against current Backend state for audit.
+	current, err := be.ListSecrets()
+	if err != nil {
+		return err
+	}
+	added, removed, rotated := diff(current, values)
+
+	// Apply. Errors from individual writes are non-fatal at the
+	// store-level: we keep applying the rest so a transient single-
+	// row failure doesn't abort an entire refresh.
+	for _, name := range append(added, rotated...) {
+		if err := be.PutSecret(name, values[name], "secretstore:refresh"); err != nil {
+			slog.Warn("secretstore: put failed", "name", name, "err", err.Error())
+		}
+	}
+	for _, name := range removed {
+		if _, err := be.DeleteSecret(name, "secretstore:refresh"); err != nil {
+			slog.Warn("secretstore: delete failed", "name", name, "err", err.Error())
+		}
+	}
+
+	s.mu.Lock()
+	s.lastIngest = now
+	s.lastSourceETag = etag
+	s.mu.Unlock()
+
+	if len(added)+len(removed)+len(rotated) > 0 {
+		slog.Info("secretstore: refresh applied",
+			"source", src.String(),
+			"etag", etag,
+			"added", added,
+			"removed", removed,
+			"rotated", rotated,
+		)
+	}
+	return nil
+}
+
+// diff compares two name → value maps. Values are inspected to detect
+// rotations but never logged.
+func diff(current, incoming map[string]string) (added, removed, rotated []string) {
+	for k, vNew := range incoming {
+		if vOld, ok := current[k]; !ok {
+			added = append(added, k)
+		} else if vOld != vNew {
+			rotated = append(rotated, k)
+		}
+	}
+	for k := range current {
+		if _, ok := incoming[k]; !ok {
+			removed = append(removed, k)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	sort.Strings(rotated)
+	return
+}
+
+func (s *Store) sourceString() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.source == nil {
+		return ""
+	}
+	return s.source.String()
+}
+
+// ---- process-wide singleton -----------------------------------------------
+
+var defaultStore = New()
+
+// Default returns the process-wide Store. Always non-nil; before
+// SetBackend is called, Get returns ErrNotConfigured.
+func Default() *Store { return defaultStore }
+
+// StartDefault is the convenience the worker startup path calls. Binds
+// the backend and starts the refresh loop in one call.
+func StartDefault(ctx context.Context, be state.SecretStore, src secretsource.Source, interval, staleTTL time.Duration) error {
+	defaultStore.SetBackend(be)
+	if staleTTL > 0 {
+		defaultStore.StaleTTL(staleTTL)
+	}
+	return defaultStore.Start(ctx, src, interval)
+}

--- a/internal/cronicle/secretstore/store_test.go
+++ b/internal/cronicle/secretstore/store_test.go
@@ -1,0 +1,230 @@
+package secretstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// fakeSource is a configurable secretsource.Source for store tests.
+// values, changed, etag, err can be swapped between calls; tests
+// observe behavior via fetchCount and lastPrevEtag.
+type fakeSource struct {
+	mu           sync.Mutex
+	values       map[string]string
+	etag         string
+	changed      bool
+	err          error
+	fetchCount   int
+	lastPrevEtag string
+}
+
+func (f *fakeSource) Fetch(_ context.Context, prevEtag string) (map[string]string, string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fetchCount++
+	f.lastPrevEtag = prevEtag
+	return f.values, f.etag, f.changed, f.err
+}
+func (f *fakeSource) String() string { return "fake://" }
+
+// memBackend opens an in-memory state.Store. Used as the SecretStore
+// backend for every test below — mirrors the real wiring, sqlite-on-disk
+// optional.
+func memBackend(t *testing.T) *state.Store {
+	t.Helper()
+	be, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = be.Close() })
+	return be
+}
+
+func TestStore_unconfiguredReturnsErr(t *testing.T) {
+	s := New()
+	if s.Configured() {
+		t.Error("New() store should not be Configured")
+	}
+	_, _, err := s.Get("ANYTHING")
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Errorf("want ErrNotConfigured, got %v", err)
+	}
+}
+
+func TestStore_initialFetchHydratesBackend(t *testing.T) {
+	be := memBackend(t)
+	src := &fakeSource{
+		values:  map[string]string{"FOO": "bar"},
+		etag:    "v1",
+		changed: true,
+	}
+	s := New().SetBackend(be)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx, src, 100*time.Millisecond); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Source value should have made it into the backend.
+	v, ok, err := be.GetSecret("FOO")
+	if err != nil || !ok || v != "bar" {
+		t.Errorf("backend not hydrated: ok=%v v=%q err=%v", ok, v, err)
+	}
+	// And reads through the store should see it.
+	v, ok, err = s.Get("FOO")
+	if err != nil || !ok || v != "bar" {
+		t.Errorf("Get: ok=%v v=%q err=%v", ok, v, err)
+	}
+}
+
+func TestStore_startWithoutSourceIsOK(t *testing.T) {
+	// state:// shape: backend bound, no ingestion source. Get works
+	// against whatever's already in the backend.
+	be := memBackend(t)
+	_ = be.PutSecret("PRELOADED", "x", "test")
+
+	s := New().SetBackend(be).StaleTTL(0)
+	if err := s.Start(context.Background(), nil, 0); err != nil {
+		t.Fatalf("Start(nil source): %v", err)
+	}
+	v, ok, err := s.Get("PRELOADED")
+	if err != nil || !ok || v != "x" {
+		t.Errorf("Get(preloaded): ok=%v v=%q err=%v", ok, v, err)
+	}
+}
+
+func TestStore_initialFetchFailureBubblesUp(t *testing.T) {
+	be := memBackend(t)
+	src := &fakeSource{err: errors.New("boom")}
+	s := New().SetBackend(be)
+	err := s.Start(context.Background(), src, 100*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("Start should surface initial fetch error, got %v", err)
+	}
+}
+
+func TestStore_refreshPicksUpRotationsInBackend(t *testing.T) {
+	be := memBackend(t)
+	src := &fakeSource{
+		values:  map[string]string{"FOO": "v1"},
+		etag:    "1",
+		changed: true,
+	}
+	s := New().SetBackend(be)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx, src, 10*time.Millisecond); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	src.mu.Lock()
+	src.values = map[string]string{"FOO": "v2"}
+	src.etag = "2"
+	src.changed = true
+	src.mu.Unlock()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		v, ok, _ := be.GetSecret("FOO")
+		if ok && v == "v2" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("backend never observed rotated value")
+}
+
+func TestStore_etagPassedToSourceOnSubsequentFetches(t *testing.T) {
+	be := memBackend(t)
+	src := &fakeSource{values: map[string]string{}, etag: "etag-A", changed: true}
+	s := New().SetBackend(be)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx, src, 10*time.Millisecond); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		src.mu.Lock()
+		got := src.lastPrevEtag
+		src.mu.Unlock()
+		if got == "etag-A" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("subsequent fetch never used prevEtag from previous result")
+}
+
+func TestStore_staleTTLBlocksGet(t *testing.T) {
+	be := memBackend(t)
+	_ = be.PutSecret("FOO", "v", "test")
+
+	src := &fakeSource{values: map[string]string{"FOO": "v"}, etag: "1", changed: true}
+	s := New().SetBackend(be)
+	frozen := time.Unix(1_700_000_000, 0)
+	s.now = func() time.Time { return frozen }
+
+	if err := s.Start(context.Background(), src, time.Hour); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	s.StaleTTL(1 * time.Minute)
+
+	frozen = frozen.Add(2 * time.Minute)
+	_, _, err := s.Get("FOO")
+	if !errors.Is(err, ErrStale) {
+		t.Errorf("want ErrStale after TTL, got %v", err)
+	}
+}
+
+func TestStore_staleTTLDoesNotApplyWithoutSource(t *testing.T) {
+	// state:// case: no ingestion source. Staleness shouldn't fire.
+	be := memBackend(t)
+	_ = be.PutSecret("FOO", "v", "test")
+
+	s := New().SetBackend(be)
+	s.now = func() time.Time { return time.Unix(2_000_000_000, 0) }
+	s.StaleTTL(1 * time.Minute) // arbitrary; should be ignored
+	if err := s.Start(context.Background(), nil, 0); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	v, ok, err := s.Get("FOO")
+	if err != nil || !ok || v != "v" {
+		t.Errorf("staleness must not gate when no source is bound; got ok=%v v=%q err=%v", ok, v, err)
+	}
+}
+
+func TestStore_diffAuditLogsNamesNotValues(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	be := memBackend(t)
+	src := &fakeSource{
+		values:  map[string]string{"API_KEY": "topsecret-12345"},
+		etag:    "1",
+		changed: true,
+	}
+	s := New().SetBackend(be)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx, src, time.Hour); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "API_KEY") {
+		t.Errorf("audit should include name: %s", out)
+	}
+	if strings.Contains(out, "topsecret-12345") {
+		t.Errorf("audit MUST NOT include value: %s", out)
+	}
+}

--- a/internal/cronicle/state/backend.go
+++ b/internal/cronicle/state/backend.go
@@ -25,6 +25,7 @@ type Backend interface {
 	WorkerRegistry
 	RetryAPI
 	ControlChannel
+	SecretStore
 
 	// Close releases the underlying connection. Implementations must be
 	// safe to call multiple times; the in-tree *Store guards against it.
@@ -120,6 +121,54 @@ type RetryAPI interface {
 type ControlChannel interface {
 	Subscribe(workerID string) (<-chan ControlMsg, func())
 	PushControl(workerID string, msg ControlMsg) bool
+}
+
+// SecretStore is the in-tree key/value store backing $secret.NAME
+// resolution at task dispatch. Lives on Backend so a swap of the
+// state backend (sqlite → Postgres → any future implementation)
+// carries the secrets layer automatically — no parallel configuration.
+//
+// Values are plaintext at the API level; the implementation decides
+// at-rest encoding. The in-tree sqlite *Store keeps them in `secrets`
+// rows alongside the rest of the state plane; cronicle-infra's
+// PostgresStore satisfies the same interface against its existing
+// AEAD-encrypted `secrets` table (so the platform path retains
+// envelope encryption).
+//
+// Concurrency: implementations must be safe for concurrent calls —
+// the ingestion pump (refresh loop) writes, the listener's GET
+// handler reads, task dispatch reads, all potentially overlapping.
+type SecretStore interface {
+	// PutSecret upserts (name, value). version bumps on every call;
+	// updated_by is captured for audit. Empty actor is permitted.
+	PutSecret(name, value, actor string) error
+
+	// GetSecret returns the current value for name. ok=false when no
+	// such row exists; err is non-nil only on real I/O failure.
+	GetSecret(name string) (value string, ok bool, err error)
+
+	// ListSecrets returns the full name → value map. Callers SHOULD
+	// avoid logging the returned map; the listener's GET handler is
+	// the only path that hands plaintext over the wire (bearer-auth
+	// gated).
+	ListSecrets() (map[string]string, error)
+
+	// ListSecretNames returns only the names, sorted. Used by the
+	// audit-friendly inspection paths (`cronicle secret list`, the
+	// listener's HEAD-style metadata, etc.) that should never see
+	// plaintext.
+	ListSecretNames() ([]string, error)
+
+	// DeleteSecret removes a row by name. Not-found is a no-op (no
+	// error) — idempotency makes the CLI/HTTP paths simpler. ok
+	// reports whether a row actually existed; bumps the etag counter
+	// either way so HTTP observers learn about deletes.
+	DeleteSecret(name, actor string) (ok bool, err error)
+
+	// SecretsEtag returns an opaque monotonic version covering the
+	// whole secrets table. Increments on every Put/Delete. Used by
+	// the listener's GET to serve If-None-Match-aware responses.
+	SecretsEtag() (string, error)
 }
 
 // Compile-time guarantee that the in-tree *Store satisfies Backend.

--- a/internal/cronicle/state/schema.go
+++ b/internal/cronicle/state/schema.go
@@ -257,4 +257,42 @@ CREATE TABLE IF NOT EXISTS runner_state (
 INSERT OR IGNORE INTO runner_state(id) VALUES (1);
 `
 
-const targetSchemaVersion = 8
+// schemaSQL_v9 adds the secrets table — the in-tree key/value store
+// the SecretStore role on Backend reads + writes. Storage matches the
+// rest of the runtime-control state plane (one common pathway) rather
+// than sitting alongside in a sibling subsystem.
+//
+// `version` is a monotonic per-row counter, bumped on every upsert.
+// SecretsEtag() returns max(version) over the table; HTTP serves it as
+// the ETag so workers' If-None-Match short-circuits unchanged
+// responses. Deletes also bump version (via a marker row? no — see
+// below): the SQLite implementation uses a separate `secrets_version`
+// singleton that's incremented on every mutation, so deletes are
+// visible to etag-based observers without needing tombstones.
+//
+// `value` is plaintext at the row level. File mode on state.db is
+// 0600, mirroring how cronicle handles transcripts. AEAD-at-rest
+// (XChaCha20-Poly1305 with a DEK from env, mirroring cronicle-infra's
+// pipeline) is a follow-up — adding it later is an in-place column
+// swap, the SecretStore API surface doesn't change.
+//
+// Audit columns (updated_at, updated_by) are minimal on purpose; the
+// rich audit trail flows through slog → events table → Loki, same as
+// the rest of the runtime-control surface.
+const schemaSQL_v9 = `
+CREATE TABLE IF NOT EXISTS secrets (
+    name        TEXT PRIMARY KEY,
+    value       TEXT NOT NULL,
+    version     INTEGER NOT NULL DEFAULT 1,
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_by  TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS secrets_meta (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    etag_counter    INTEGER NOT NULL DEFAULT 0
+);
+INSERT OR IGNORE INTO secrets_meta(id) VALUES (1);
+`
+
+const targetSchemaVersion = 9

--- a/internal/cronicle/state/secrets.go
+++ b/internal/cronicle/state/secrets.go
@@ -1,0 +1,160 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// SecretStore implementation backed by the v9 `secrets` + `secrets_meta`
+// tables. Reads are cheap PK lookups; writes touch two rows (the
+// secret row + the monotonic etag counter) in a single transaction so
+// SecretsEtag() always reflects the latest mutation.
+
+// PutSecret upserts (name, value) and bumps the global etag. version
+// on the row increments via ON CONFLICT, so the column tracks per-row
+// edit count (useful for audit "secret X was rotated N times").
+func (s *Store) PutSecret(name, value, actor string) error {
+	if name == "" {
+		return errors.New("state.PutSecret: empty name")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("state.PutSecret: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`
+		INSERT INTO secrets (name, value, version, updated_at, updated_by)
+		VALUES (?, ?, 1, datetime('now'), ?)
+		ON CONFLICT(name) DO UPDATE SET
+		    value      = excluded.value,
+		    version    = secrets.version + 1,
+		    updated_at = datetime('now'),
+		    updated_by = excluded.updated_by`,
+		name, value, actor,
+	); err != nil {
+		return fmt.Errorf("state.PutSecret: upsert: %w", err)
+	}
+	if err := bumpSecretsEtag(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("state.PutSecret: commit: %w", err)
+	}
+	return nil
+}
+
+// GetSecret returns the value for name. (name not found) → (empty, false, nil).
+// Errors are reserved for real I/O / scan failures.
+func (s *Store) GetSecret(name string) (string, bool, error) {
+	var value string
+	row := s.db.QueryRow(`SELECT value FROM secrets WHERE name = ?`, name)
+	switch err := row.Scan(&value); {
+	case err == nil:
+		return value, true, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("state.GetSecret: %w", err)
+	}
+}
+
+// ListSecrets returns the full name → value map. The map is freshly
+// allocated; callers may mutate it without affecting the store.
+func (s *Store) ListSecrets() (map[string]string, error) {
+	rows, err := s.db.Query(`SELECT name, value FROM secrets`)
+	if err != nil {
+		return nil, fmt.Errorf("state.ListSecrets: query: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var name, value string
+		if err := rows.Scan(&name, &value); err != nil {
+			return nil, fmt.Errorf("state.ListSecrets: scan: %w", err)
+		}
+		out[name] = value
+	}
+	return out, rows.Err()
+}
+
+// ListSecretNames returns just the names, sorted. Used by paths that
+// should never touch plaintext (CLI list, audit log lines).
+func (s *Store) ListSecretNames() ([]string, error) {
+	rows, err := s.db.Query(`SELECT name FROM secrets ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("state.ListSecretNames: query: %w", err)
+	}
+	defer rows.Close()
+	out := make([]string, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("state.ListSecretNames: scan: %w", err)
+		}
+		out = append(out, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Defensive: sqlite ORDER BY is already sorted, but normalize in
+	// case a future backend doesn't.
+	sort.Strings(out)
+	return out, nil
+}
+
+// DeleteSecret removes name if present. Bumps the etag whether or not
+// a row was removed — the caller asked, that's a control-plane event
+// observers may care about regardless. ok reports actual deletion so
+// the CLI can print "removed" vs "no such secret".
+func (s *Store) DeleteSecret(name, actor string) (bool, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("state.DeleteSecret: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.Exec(`DELETE FROM secrets WHERE name = ?`, name)
+	if err != nil {
+		return false, fmt.Errorf("state.DeleteSecret: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("state.DeleteSecret: rows affected: %w", err)
+	}
+	if err := bumpSecretsEtag(tx); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("state.DeleteSecret: commit: %w", err)
+	}
+	// actor is captured by future audit hooks; today we just consume
+	// it to satisfy the interface so callers don't drift.
+	_ = actor
+	return n > 0, nil
+}
+
+// SecretsEtag returns the monotonic counter as a decimal string.
+// Format is opaque to callers; only equality + ordering matter.
+func (s *Store) SecretsEtag() (string, error) {
+	var n int64
+	row := s.db.QueryRow(`SELECT etag_counter FROM secrets_meta WHERE id = 1`)
+	if err := row.Scan(&n); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Row should always exist after migration v9 (INSERT OR
+			// IGNORE in the migration). Defensive 0 keeps callers
+			// from blowing up if the row was somehow deleted.
+			return "0", nil
+		}
+		return "", fmt.Errorf("state.SecretsEtag: %w", err)
+	}
+	return strconv.FormatInt(n, 10), nil
+}
+
+func bumpSecretsEtag(tx *sql.Tx) error {
+	if _, err := tx.Exec(`UPDATE secrets_meta SET etag_counter = etag_counter + 1 WHERE id = 1`); err != nil {
+		return fmt.Errorf("state: bump secrets etag: %w", err)
+	}
+	return nil
+}

--- a/internal/cronicle/state/secrets_test.go
+++ b/internal/cronicle/state/secrets_test.go
@@ -1,0 +1,125 @@
+package state
+
+import "testing"
+
+func TestSecretStore_putGetRoundtrip(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.PutSecret("ANTHROPIC_API_KEY", "sk-ant-xxx", "test"); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+	v, ok, err := s.GetSecret("ANTHROPIC_API_KEY")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if !ok || v != "sk-ant-xxx" {
+		t.Errorf("get: ok=%v v=%q", ok, v)
+	}
+}
+
+func TestSecretStore_missingReturnsOkFalse(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	v, ok, err := s.GetSecret("DOES_NOT_EXIST")
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+	if ok || v != "" {
+		t.Errorf("missing should return ok=false; got ok=%v v=%q", ok, v)
+	}
+}
+
+func TestSecretStore_putBumpsRowVersion(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	_ = s.PutSecret("FOO", "v1", "a")
+	_ = s.PutSecret("FOO", "v2", "a")
+
+	var version int
+	row := s.db.QueryRow(`SELECT version FROM secrets WHERE name = 'FOO'`)
+	if err := row.Scan(&version); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("rotation should bump version; got %d", version)
+	}
+	v, _, _ := s.GetSecret("FOO")
+	if v != "v2" {
+		t.Errorf("value not updated: %q", v)
+	}
+}
+
+func TestSecretStore_etagMonotonicAcrossMutations(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	prev, _ := s.SecretsEtag()
+	for i, op := range []func(){
+		func() { _ = s.PutSecret("A", "1", "") },
+		func() { _ = s.PutSecret("B", "1", "") },
+		func() { _ = s.PutSecret("A", "2", "") },   // rotation
+		func() { _, _ = s.DeleteSecret("A", "") },   // deletion
+		func() { _, _ = s.DeleteSecret("ZZZ", "") }, // no-op delete: must still bump
+	} {
+		op()
+		got, err := s.SecretsEtag()
+		if err != nil {
+			t.Fatalf("etag %d: %v", i, err)
+		}
+		if got == prev {
+			t.Errorf("etag did not advance after op %d (was %q, still %q)", i, prev, got)
+		}
+		prev = got
+	}
+}
+
+func TestSecretStore_listSecretsAndNames(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	_ = s.PutSecret("C", "c-val", "")
+	_ = s.PutSecret("A", "a-val", "")
+	_ = s.PutSecret("B", "b-val", "")
+
+	names, err := s.ListSecretNames()
+	if err != nil {
+		t.Fatalf("ListSecretNames: %v", err)
+	}
+	want := []string{"A", "B", "C"}
+	if len(names) != 3 || names[0] != want[0] || names[1] != want[1] || names[2] != want[2] {
+		t.Errorf("names: want %v, got %v", want, names)
+	}
+
+	values, err := s.ListSecrets()
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if values["A"] != "a-val" || values["B"] != "b-val" || values["C"] != "c-val" {
+		t.Errorf("values: %v", values)
+	}
+}
+
+func TestSecretStore_deleteRemovesAndReportsOK(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	_ = s.PutSecret("X", "x-val", "")
+
+	ok, err := s.DeleteSecret("X", "")
+	if err != nil || !ok {
+		t.Fatalf("delete present: ok=%v err=%v", ok, err)
+	}
+	_, present, _ := s.GetSecret("X")
+	if present {
+		t.Errorf("X should be gone after delete")
+	}
+
+	ok, err = s.DeleteSecret("X", "")
+	if err != nil {
+		t.Fatalf("delete absent: %v", err)
+	}
+	if ok {
+		t.Errorf("delete-of-absent should return ok=false (got true)")
+	}
+}

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -170,6 +170,13 @@ func (s *Store) migrate() error {
 			return fmt.Errorf("state.migrate v8: %w", err)
 		}
 	}
+	// v9: secrets table + secrets_meta(etag_counter) — the in-tree
+	// store backing the SecretStore role on Backend.
+	if current < 9 {
+		if _, err := s.db.Exec(schemaSQL_v9); err != nil {
+			return fmt.Errorf("state.migrate v9: %w", err)
+		}
+	}
 	if current >= targetSchemaVersion {
 		return nil
 	}

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -74,7 +74,13 @@ func (b *BashTool) Execute(ctx context.Context, input json.RawMessage) (string, 
 	}
 
 	cmd := []string{"/bin/sh", "-c", args.Command}
-	res := exec.ExecuteWithStreamContext(ctx, cmd, b.Workspace, b.Env, b.StdoutW, b.StderrW)
+	// Scrubbed env: an agent-emitted `env`/`printenv` must not be able to
+	// read worker-process state. The bash subprocess sees only the
+	// allowlisted parent vars (PATH/HOME/USER/locale/SHELL) plus b.Env —
+	// which the task dispatch path has already populated with task.Env
+	// after $secret.NAME expansion. Secrets the task didn't explicitly
+	// list never reach this process.
+	res := exec.ExecuteScrubbedStreamContext(ctx, cmd, b.Workspace, b.Env, b.StdoutW, b.StderrW)
 
 	stdout := stripANSI(res.Stdout)
 	stderr := stripANSI(res.Stderr)

--- a/internal/cronicle/worker_http.go
+++ b/internal/cronicle/worker_http.go
@@ -50,6 +50,11 @@ type HTTPWorkerOptions struct {
 	// for its currently-claimed job. Default visibility/3 = ~100s
 	// when the producer's visibility is 5 minutes.
 	HeartbeatEvery time.Duration
+	// PostStateStoreHook fires after the worker's local state store is
+	// open and before the long-poll loop starts. Used by the cmd layer
+	// to bind the secret-source pump (which writes into state.Backend)
+	// without coupling cronicle.StartHTTPWorker to secretsource details.
+	PostStateStoreHook func() error
 }
 
 // StartHTTPWorker runs the long-poll consumer loop. Blocks until ctx
@@ -91,6 +96,11 @@ func StartHTTPWorker(ctx context.Context, opts HTTPWorkerOptions) error {
 	// chain.
 	if err := EnableStateStore(":memory:"); err != nil {
 		return fmt.Errorf("StartHTTPWorker: state store: %w", err)
+	}
+	if opts.PostStateStoreHook != nil {
+		if err := opts.PostStateStoreHook(); err != nil {
+			return fmt.Errorf("StartHTTPWorker: post-state-store hook: %w", err)
+		}
 	}
 	// Ship event records back to the producer so its projection sees
 	// what really happened (schedule_start, shell_run, agent_run,

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -33,6 +33,35 @@ type runOptions struct {
 	stdoutW      io.Writer
 	stderrW      io.Writer
 	useProcGroup bool // when true, child runs in its own pgid so cancellation kills its subprocesses
+	// scrubEnv selects the env policy:
+	//   false (default) — child inherits the entire parent env (os.Environ())
+	//                     plus opts.env. Long-standing behavior; callers that
+	//                     run user-defined commands (shell tasks) rely on it.
+	//   true            — child inherits only a small benign allowlist (PATH,
+	//                     HOME, USER, LANG, LC_ALL, TZ) plus opts.env. Used
+	//                     by the bash tool so an agent-emitted `env`/`set`
+	//                     command can't read worker-process state.
+	scrubEnv bool
+}
+
+// scrubbedInheritKeys is the env var allowlist that ExecuteScrubbed*
+// passes through from the parent process. Kept intentionally short:
+// only the variables a typical interactive shell command needs to
+// behave normally. Anything else must come in via opts.env.
+//
+// Notably absent: ANTHROPIC_API_KEY, GITHUB_TOKEN, CRONICLE_* — the
+// whole point of scrubbed mode is to NOT leak these into agent-
+// controlled subprocesses. cronicle's secretstore dispenses these
+// per-task instead, gated by what the task's HCL env array declares.
+var scrubbedInheritKeys = []string{
+	"PATH",
+	"HOME",
+	"USER",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TZ",
+	"SHELL",
 }
 
 // run is the canonical implementation. All four public entry points
@@ -61,8 +90,19 @@ func run(command []string, opts runOptions) Result {
 		cmd = goexec.CommandContext(ctx, command[0], command[1:]...)
 	}
 	cmd.Dir = opts.dir
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, opts.env...)
+	if opts.scrubEnv {
+		// Scrubbed mode: only the allowlisted parent vars pass through.
+		base := make([]string, 0, len(scrubbedInheritKeys)+len(opts.env))
+		for _, k := range scrubbedInheritKeys {
+			if v, ok := os.LookupEnv(k); ok {
+				base = append(base, k+"="+v)
+			}
+		}
+		cmd.Env = append(base, opts.env...)
+	} else {
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, opts.env...)
+	}
 
 	if opts.useProcGroup {
 		configureProcessGroup(cmd)
@@ -162,6 +202,26 @@ func ExecuteWithStreamContext(ctx context.Context, command []string, dir string,
 		stdoutW:      stdoutW,
 		stderrW:      stderrW,
 		useProcGroup: true,
+	})
+}
+
+// ExecuteScrubbedStreamContext is ExecuteWithStreamContext but with a
+// scrubbed parent env: the child inherits only the PATH/HOME/USER/
+// LANG/LC_ALL/LC_CTYPE/TZ/SHELL allowlist from os.Environ. Everything
+// else comes from env. Use this for subprocesses driven by untrusted
+// or semi-trusted callers — the agent's bash tool, future MCP-driven
+// shells — so the worker-process env (which may have been hardened
+// against secret leakage, but may still carry CRONICLE_* deployment
+// metadata) doesn't leak through.
+func ExecuteScrubbedStreamContext(ctx context.Context, command []string, dir string, env []string, stdoutW, stderrW io.Writer) Result {
+	return run(command, runOptions{
+		ctx:          ctx,
+		dir:          dir,
+		env:          env,
+		stdoutW:      stdoutW,
+		stderrW:      stderrW,
+		useProcGroup: true,
+		scrubEnv:     true,
 	})
 }
 

--- a/pkg/exec/scrubbed_test.go
+++ b/pkg/exec/scrubbed_test.go
@@ -1,0 +1,74 @@
+package exec
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestScrubbed_blocksParentLeak verifies that ExecuteScrubbedStreamContext
+// does NOT leak the parent's env to the child. The whole point of this
+// mode is that an agent-driven `env` or `printenv` shouldn't be able
+// to read worker-process state.
+func TestScrubbed_blocksParentLeak(t *testing.T) {
+	const key = "CRONICLE_TEST_LEAK_CANARY"
+	if err := os.Setenv(key, "should-not-leak"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer os.Unsetenv(key)
+
+	// Spawn /bin/sh -c 'env' under scrubbed mode and confirm the canary
+	// isn't in the captured output. PATH (allowlisted) should still be.
+	res := ExecuteScrubbedStreamContext(context.Background(),
+		[]string{"/bin/sh", "-c", "env"},
+		".", nil, nil, nil)
+	if res.ExitStatus != 0 {
+		t.Fatalf("env exit=%d stderr=%q", res.ExitStatus, res.Stderr)
+	}
+	if strings.Contains(res.Stdout, key) || strings.Contains(res.Stdout, "should-not-leak") {
+		t.Errorf("scrubbed env leaked canary:\n%s", res.Stdout)
+	}
+	// PATH should be present (it's on the allowlist) — proves we're not
+	// just empty-env'ing the child.
+	if !strings.Contains(res.Stdout, "PATH=") {
+		t.Errorf("scrubbed env should include PATH:\n%s", res.Stdout)
+	}
+}
+
+// TestScrubbed_taskEnvIsHonored verifies that opts.env entries DO reach
+// the child even in scrubbed mode. The scrubbing only affects parent-
+// env inheritance; explicitly-passed values flow through.
+func TestScrubbed_taskEnvIsHonored(t *testing.T) {
+	res := ExecuteScrubbedStreamContext(context.Background(),
+		[]string{"/bin/sh", "-c", "echo $FOO"},
+		".", []string{"FOO=fromTaskEnv"}, nil, nil)
+	if res.ExitStatus != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.ExitStatus, res.Stderr)
+	}
+	if strings.TrimSpace(res.Stdout) != "fromTaskEnv" {
+		t.Errorf("task env value should reach child: %q", res.Stdout)
+	}
+}
+
+// TestExecuteWithStreamContext_inheritsParentEnv guards the legacy
+// behavior: callers using the non-scrubbed entry point still see the
+// parent env. This is a long-standing contract that shell-task
+// dispatch relies on.
+func TestExecuteWithStreamContext_inheritsParentEnv(t *testing.T) {
+	const key = "CRONICLE_TEST_INHERIT_PROOF"
+	if err := os.Setenv(key, "yes"); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer os.Unsetenv(key)
+
+	res := ExecuteWithStreamContext(context.Background(),
+		[]string{"/bin/sh", "-c", "echo $" + key},
+		".", nil, nil, nil)
+	if res.ExitStatus != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.ExitStatus, res.Stderr)
+	}
+	if strings.TrimSpace(res.Stdout) != "yes" {
+		t.Errorf("legacy entry point should inherit parent env: %q", res.Stdout)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a first-class secrets layer for cronicle. Design goal: one read
path for `$secret.NAME` resolution regardless of where the values
came from, plus a backend-agnostic management surface so a swap from
sqlite (standalone) to Postgres (cronicle-infra hosted) carries
secrets along automatically.

### Architecture in one diagram

```
INGESTION                                     DISPATCH

env://       ┐
file://      ├──→ refresh loop ──→ state.db ──→ task dispatch
http(s)://   ┘    (writes diffs)        ↑
                                        │
cronicle secret set/rm ─────────────────┤      always reads
PUT/DELETE /v1/secrets/{name} ──────────┘      from state.Backend
```

`state.Backend` is the seam. The in-tree sqlite `*Store` implements
`SecretStore` against a new `secrets` table; cronicle-infra's
`PostgresStore` can satisfy the same interface against its existing
AEAD-encrypted table. The CLI, the listener, and task dispatch all
go through the interface — backend swap is invisible.

### What's in the PR

**`state.Backend` gains a `SecretStore` role**
- Migration v9: `secrets(name, value, version, updated_at, updated_by)`
  + `secrets_meta(etag_counter)` for monotonic ETags.
- sqlite implementation in `state/secrets.go`.

**`secretsource` package — pluggable ingestion**
Mirrors `configsource` (`Fetch` + etag short-circuit). Schemes:
- `env://[?prefix=APP_|?names=A,B]` — process env (UPPER_SNAKE filter)
- `file:///abs/path.json` — `{"values":{NAME:"value"}}`, sha256 etag
- `http(s)://host/path` — bearer auth, `If-None-Match`, 1MiB read cap
- `state://` — no ingestion (state.db is the truth; CLI/HTTP managed)

**`secretstore` package — ingestion pump + dispatch reader**
- Refresh loop pulls from a Source, writes diffs into the bound
  `state.Backend`.
- `Get` / `ExpandValue` / `ExpandEnv` read from the Backend on every
  call.
- Audit-on-change logs added/removed/rotated names (never values).
- `StaleTTL` gates dispensing when refresh has been failing.

**Task dispatch**
- `execAgent` resolves `$secret.NAME` from the store, pulls
  `ANTHROPIC_API_KEY` out into `cfg.APIKey` so it never enters
  subprocess env.
- `pkg/exec` gains `ExecuteScrubbedStreamContext` (allowlist parent-
  env inheritance: PATH/HOME/USER/LANG/LC_ALL/LC_CTYPE/TZ/SHELL only).
- `BashTool` uses scrubbed mode — agent-driven `env`/`printenv` no
  longer enumerates worker-process state.

**Listener `/v1/secrets` endpoints**
- `GET /v1/secrets` (with `ETag`/`If-None-Match`)
- `PUT /v1/secrets/{name}` (body: `{"value":"..."}`)
- `DELETE /v1/secrets/{name}`
- All bearer-auth via the existing listen-token. Backend-agnostic.

**`cronicle secret {set,get,list,rm}` CLI**
Two transports behind one interface:
- Default: opens `.cronicle/state.db` on disk (sqlite only).
- `--remote URL --token T` (or env `CRONICLE_REMOTE` +
  `CRONICLE_LISTEN_TOKEN`): routes through `/v1/secrets`. Works
  against any backend the listener fronts.

`set` reads value from stdin by default. `get` refuses to print to
TTY without `--force`. `list` never shows values.

**Smart defaults** (no flags →)
- `cronicle worker --producer X --producer-token Y` → `http://X/v1/secrets`, bearer = Y
- `cronicle run --listen :PORT --listen-token T` → `state://`
- bare `cronicle run` → `env://`

Explicit `--secret-source` always wins.

### Security guardrails

- Audit on change logs **names only**, never values
  (guarded by `TestStore_diffAuditLogsNamesNotValues`).
- Bearer auth on all wire paths; tokens preferred via env so they
  don't appear in `ps`/shell history.
- Subprocess env scrubbing: bash/MCP children inherit a benign
  allowlist + explicit task `env` only — no leakage of
  `ANTHROPIC_API_KEY` or `CRONICLE_*` deployment metadata.
- `StaleTTL` refusal: revoked secrets stop flowing if refresh dies.
- 1 MiB read cap on the HTTP source; URL/credentials redaction in logs.
- File-mode 0600 on state.db (existing cronicle convention).

### Tests

22 new tests across `secretsource` (7), `secretstore` (6+5),
`state.SecretStore` (5), and `pkg/exec` scrubbed mode (3).
All 7 packages green: `state`, `secretsource`, `secretstore`,
`configsource`, `cronicle`, `pkg/agent`, `pkg/exec`.

## Test plan

- [x] Unit: `go test ./...`
- [x] Smoke 1 — passthrough: bare `cronicle run`, `ANTHROPIC_API_KEY` from shell, SDK fallback → `passthrough_AGENT_OK`, $0.00186
- [x] Smoke 2 — env://: `--secret-source env://`, env resolves `$secret.X` → `env_source_AGENT_OK`
- [x] Smoke 3 — distributed: producer + worker, env:// on worker → `distributed_AGENT_OK`
- [x] Smoke 4 — file://: JSON on disk → `file_source_AGENT_OK`
- [x] Smoke 5 — http://: bearer-auth'd Python stub → `http_source_AGENT_OK`
- [x] Smoke A — env:// writes into state.db; `cronicle secret list` against running cronicle sees ingested names
- [x] Smoke B — CLI-managed `state://`: `cronicle secret set ANTHROPIC_API_KEY < key`, then `--secret-source state://` → `unified_AGENT_OK`
- [x] Smoke C — distributed via listener: producer with `state://` default, PUT via curl, worker auto-derives `http://producer/v1/secrets` from `--producer-token` → `unified_AGENT_OK`
- [x] Smoke remote-CLI: `CRONICLE_REMOTE=http://producer:8766 cronicle secret set …` → producer's state.db updated → agent task uses new value (`remote_cli_AGENT_OK`, $0.001866)

## Follow-ups

- cronicle-infra side: `PostgresStore` adds `SecretStore` methods
  against the existing `secrets` table (AEAD already there).
- k8s/docker drivers: stop using `cronicled exec` for secret
  injection — workers just get `CRONICLE_LISTEN_TOKEN` and the smart
  default derives the rest.
- Optional follow-up: AEAD-at-rest on sqlite (mirror cronicle-infra's
  XChaCha20-Poly1305 + DEK pipeline). Interface stays the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)