### PR TITLE
Encrypt the state.db secrets table at rest

### DIFF
--- a/cmd/secret_client.go
+++ b/cmd/secret_client.go
@@ -109,6 +109,19 @@ func openLocalClient(cmd *cobra.Command) (secretClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Mirror EnableStateStore's opt-in: when CRONICLE_DEK_HEX is set
+	// the CLI must bind the same AEAD so reads decrypt and writes
+	// seal. Without this, `cronicle secret get` on an encrypted
+	// state.db would error and `cronicle secret set` would write a
+	// fresh plaintext row that future reads couldn't trust.
+	if dek := strings.TrimSpace(os.Getenv("CRONICLE_DEK_HEX")); dek != "" {
+		aead, err := state.NewAEAD(dek)
+		if err != nil {
+			_ = s.Close()
+			return nil, fmt.Errorf("CRONICLE_DEK_HEX: %w", err)
+		}
+		s.WithAEAD(aead)
+	}
 	return &localClient{s: s}, nil
 }
 

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -230,6 +230,24 @@ func EnableStateStore(dsn string) error {
 	if err != nil {
 		return err
 	}
+	// At-rest secrets encryption is opt-in via CRONICLE_DEK_HEX. When
+	// the env is set, bind the AEAD and run a backfill of any pre-v10
+	// plaintext rows once. The DEK is held in process memory; an
+	// attacker with read-only access to state.db sees only ct/nonce.
+	if dek := strings.TrimSpace(os.Getenv("CRONICLE_DEK_HEX")); dek != "" {
+		aead, err := state.NewAEAD(dek)
+		if err != nil {
+			_ = s.Close()
+			return fmt.Errorf("CRONICLE_DEK_HEX: %w", err)
+		}
+		s.WithAEAD(aead)
+		if n, err := s.BackfillSecrets(); err != nil {
+			_ = s.Close()
+			return fmt.Errorf("secrets backfill: %w", err)
+		} else if n > 0 {
+			slog.Info("secrets: at-rest backfill complete", "rows", n)
+		}
+	}
 	stateStore = s
 	liveSink = state.NewLiveSink(newLiveEncoder(currentLiveFormat))
 

--- a/internal/cronicle/state/aead.go
+++ b/internal/cronicle/state/aead.go
@@ -1,0 +1,73 @@
+package state
+
+// At-rest envelope encryption for the secrets table.
+//
+// Cipher: XChaCha20-Poly1305 AEAD.
+//
+//	key      32 bytes — Data Encryption Key, supplied by the caller
+//	         (typically CRONICLE_DEK_HEX env on the cronicle binary).
+//	         Local dev runs without it: state.db stays plaintext, same
+//	         posture as today. Production deployments set it once and
+//	         the secrets table is opaque outside the running process.
+//	nonce    24 bytes — random per ciphertext, stored alongside.
+//	overhead 16 bytes — Poly1305 tag.
+//
+// The cipher choice and AAD-binding pattern mirror cronicle-infra's
+// `internal/secrets.AEAD`. We re-implement here rather than importing
+// because the cronicle binary is the OSS distribution — it must build
+// without the cronicle-infra sibling repo on disk.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// AEAD wraps a 32-byte DEK.
+type AEAD struct {
+	key []byte
+}
+
+// NewAEAD parses a hex-encoded 32-byte key. Returns error if length is wrong.
+func NewAEAD(hexKey string) (*AEAD, error) {
+	k, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode hex key: %w", err)
+	}
+	if len(k) != chacha20poly1305.KeySize {
+		return nil, fmt.Errorf("dek must be %d bytes (got %d)",
+			chacha20poly1305.KeySize, len(k))
+	}
+	return &AEAD{key: k}, nil
+}
+
+// Seal returns (ciphertext, nonce). Plaintext is bound to the secret's
+// name as additional data so a ciphertext row moved to a different
+// name (in-place row swap) fails to decrypt.
+func (a *AEAD) Seal(plaintext []byte, name string) ([]byte, []byte, error) {
+	aead, err := chacha20poly1305.NewX(a.key)
+	if err != nil {
+		return nil, nil, err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, nil, err
+	}
+	ct := aead.Seal(nil, nonce, plaintext, []byte(name))
+	return ct, nonce, nil
+}
+
+// Open returns the plaintext.
+func (a *AEAD) Open(ciphertext, nonce []byte, name string) ([]byte, error) {
+	aead, err := chacha20poly1305.NewX(a.key)
+	if err != nil {
+		return nil, err
+	}
+	if len(nonce) != aead.NonceSize() {
+		return nil, errors.New("bad nonce size")
+	}
+	return aead.Open(nil, nonce, ciphertext, []byte(name))
+}

--- a/internal/cronicle/state/aead_test.go
+++ b/internal/cronicle/state/aead_test.go
@@ -1,0 +1,175 @@
+package state
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// Store tests for the at-rest secrets path: they pin the seal/open
+// round-trip through PutSecret/GetSecret, the AAD-binding guard
+// (renaming a row breaks decryption), the backfill of legacy rows,
+// and the loud failure when an encrypted row is read without an AEAD.
+
+func newTestAEAD(t *testing.T) *AEAD {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	a, err := NewAEAD(hex.EncodeToString(key))
+	if err != nil {
+		t.Fatalf("NewAEAD: %v", err)
+	}
+	return a
+}
+
+func TestAEAD_sealOpenRoundtrip(t *testing.T) {
+	a := newTestAEAD(t)
+	pt := []byte("sk-ant-shhh")
+	ct, nonce, err := a.Seal(pt, "ANTHROPIC_API_KEY")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	out, err := a.Open(ct, nonce, "ANTHROPIC_API_KEY")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if string(out) != string(pt) {
+		t.Errorf("roundtrip mismatch: want %q, got %q", pt, out)
+	}
+}
+
+func TestAEAD_rejectsAADSwap(t *testing.T) {
+	// AAD = secret name. A ciphertext copied from row A to row B must
+	// fail to decrypt — without this, a Postgres-replica compromise
+	// that lets an attacker overwrite secret names could redirect
+	// known-plaintext rows ("PUBLIC_FOO") into sensitive slots
+	// ("ANTHROPIC_API_KEY").
+	a := newTestAEAD(t)
+	ct, nonce, err := a.Seal([]byte("payload"), "A_NAME")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := a.Open(ct, nonce, "B_NAME"); err == nil {
+		t.Errorf("Open with mismatched name should fail (AAD binding); got nil error")
+	}
+}
+
+func TestStore_putGetWithAEAD_doesNotStorePlaintext(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+	s.WithAEAD(newTestAEAD(t))
+
+	if err := s.PutSecret("ANTHROPIC_API_KEY", "sk-ant-real", "test"); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+
+	// pg_dump simulation: read the underlying columns directly.
+	var (
+		value     string
+		ct, nonce []byte
+	)
+	row := s.db.QueryRow(`SELECT value, value_ct, value_nonce FROM secrets WHERE name = 'ANTHROPIC_API_KEY'`)
+	if err := row.Scan(&value, &ct, &nonce); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if value != "" {
+		t.Errorf("plaintext column should be empty under AEAD; got %q", value)
+	}
+	if len(ct) == 0 || len(nonce) == 0 {
+		t.Errorf("ct/nonce should be populated; got ct=%d nonce=%d", len(ct), len(nonce))
+	}
+
+	v, ok, err := s.GetSecret("ANTHROPIC_API_KEY")
+	if err != nil || !ok || v != "sk-ant-real" {
+		t.Errorf("roundtrip: ok=%v v=%q err=%v", ok, v, err)
+	}
+}
+
+func TestStore_getEncryptedWithoutAEAD_errors(t *testing.T) {
+	// Seal a row, then drop the AEAD on a fresh handle — the second
+	// reader has no key, must fail loud rather than hand back ''.
+	s, _ := Open(":memory:")
+	defer s.Close()
+	s.WithAEAD(newTestAEAD(t))
+	if err := s.PutSecret("SECRET", "value", ""); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+	// Drop key without resetting rows.
+	s.aead = nil
+
+	_, _, err := s.GetSecret("SECRET")
+	if err == nil {
+		t.Errorf("reading encrypted row with no AEAD should error")
+	}
+}
+
+func TestStore_legacyPlaintextRowReadableUnderAEAD(t *testing.T) {
+	// Pre-v10 rows have ct=NULL, value=<plaintext>. After binding an
+	// AEAD, those rows must remain readable through the plaintext
+	// column until BackfillSecrets re-seals them.
+	s, _ := Open(":memory:")
+	defer s.Close()
+	if err := s.PutSecret("LEGACY", "legacy-plaintext", ""); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+	s.WithAEAD(newTestAEAD(t))
+
+	v, ok, err := s.GetSecret("LEGACY")
+	if err != nil || !ok || v != "legacy-plaintext" {
+		t.Errorf("legacy fallback: ok=%v v=%q err=%v", ok, v, err)
+	}
+}
+
+func TestStore_backfillEncryptsLegacyRows(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	_ = s.PutSecret("A", "a-pt", "")
+	_ = s.PutSecret("B", "b-pt", "")
+	s.WithAEAD(newTestAEAD(t))
+
+	n, err := s.BackfillSecrets()
+	if err != nil {
+		t.Fatalf("BackfillSecrets: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("backfill count: want 2, got %d", n)
+	}
+
+	for _, name := range []string{"A", "B"} {
+		var (
+			value     string
+			ct, nonce []byte
+		)
+		row := s.db.QueryRow(`SELECT value, value_ct, value_nonce FROM secrets WHERE name = ?`, name)
+		if err := row.Scan(&value, &ct, &nonce); err != nil {
+			t.Fatalf("scan %s: %v", name, err)
+		}
+		if value != "" || len(ct) == 0 || len(nonce) == 0 {
+			t.Errorf("%s not encrypted: value=%q ct=%d nonce=%d", name, value, len(ct), len(nonce))
+		}
+	}
+
+	// Second call is a no-op (no plaintext rows remaining).
+	n2, err := s.BackfillSecrets()
+	if err != nil {
+		t.Fatalf("BackfillSecrets second pass: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second backfill should be no-op; touched %d", n2)
+	}
+}
+
+func TestStore_backfillWithoutAEADIsNoop(t *testing.T) {
+	s, _ := Open(":memory:")
+	defer s.Close()
+	_ = s.PutSecret("X", "x-pt", "")
+
+	n, err := s.BackfillSecrets()
+	if err != nil || n != 0 {
+		t.Errorf("backfill no-AEAD: want (0, nil); got (%d, %v)", n, err)
+	}
+}

--- a/internal/cronicle/state/schema.go
+++ b/internal/cronicle/state/schema.go
@@ -295,4 +295,20 @@ CREATE TABLE IF NOT EXISTS secrets_meta (
 INSERT OR IGNORE INTO secrets_meta(id) VALUES (1);
 `
 
-const targetSchemaVersion = 9
+// schemaSQL_v10 adds at-rest envelope encryption to the secrets table.
+// Two new columns hold the ciphertext and per-row nonce; the existing
+// `value` column is kept (and written as the empty string for new rows)
+// for one release as a rollback path — a prior cronicle binary that
+// hasn't learned about ct/nonce will read empty plaintexts rather than
+// crash. A follow-up migration will DROP COLUMN once rollout settles.
+//
+// The seal/open round-trip is performed in Go by the Store when an
+// AEAD has been bound via WithAEAD; without it the table works exactly
+// as before (plaintext column only). This keeps local-dev runs free of
+// any DEK ceremony.
+const schemaSQL_v10 = `
+ALTER TABLE secrets ADD COLUMN value_ct    BLOB;
+ALTER TABLE secrets ADD COLUMN value_nonce BLOB;
+`
+
+const targetSchemaVersion = 10

--- a/internal/cronicle/state/secrets.go
+++ b/internal/cronicle/state/secrets.go
@@ -12,6 +12,18 @@ import (
 // tables. Reads are cheap PK lookups; writes touch two rows (the
 // secret row + the monotonic etag counter) in a single transaction so
 // SecretsEtag() always reflects the latest mutation.
+//
+// At-rest encryption is opt-in via Store.WithAEAD. When bound:
+//   - PutSecret seals into value_ct/value_nonce and writes value=''.
+//   - GetSecret/ListSecrets open ct/nonce when present, otherwise fall
+//     back to the plaintext `value` column. That fallback path matters
+//     for two transitions: legacy rows written before v10 ran, and
+//     a controlled rollback to a prior cronicle binary that doesn't
+//     know about ct/nonce.
+//
+// When AEAD is nil the table behaves exactly as it did in v9: writes
+// land in `value`, reads come from `value`. ct/nonce columns are NULL
+// and unused. This keeps the local-dev path zero-ceremony.
 
 // PutSecret upserts (name, value) and bumps the global etag. version
 // on the row increments via ON CONFLICT, so the column tracks per-row
@@ -25,17 +37,46 @@ func (s *Store) PutSecret(name, value, actor string) error {
 		return fmt.Errorf("state.PutSecret: begin: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.Exec(`
-		INSERT INTO secrets (name, value, version, updated_at, updated_by)
-		VALUES (?, ?, 1, datetime('now'), ?)
-		ON CONFLICT(name) DO UPDATE SET
-		    value      = excluded.value,
-		    version    = secrets.version + 1,
-		    updated_at = datetime('now'),
-		    updated_by = excluded.updated_by`,
-		name, value, actor,
-	); err != nil {
-		return fmt.Errorf("state.PutSecret: upsert: %w", err)
+	if s.aead != nil {
+		ct, nonce, err := s.aead.Seal([]byte(value), name)
+		if err != nil {
+			return fmt.Errorf("state.PutSecret: seal: %w", err)
+		}
+		// Plaintext column intentionally written empty: the row's
+		// authoritative value lives in value_ct/value_nonce. Keeping
+		// the column rather than dropping it preserves one-release
+		// rollback safety (a prior binary that hasn't learned about
+		// ct/nonce reads '' and treats the secret as cleared, vs.
+		// crashing on a missing column).
+		if _, err := tx.Exec(`
+			INSERT INTO secrets (name, value, value_ct, value_nonce, version, updated_at, updated_by)
+			VALUES (?, '', ?, ?, 1, datetime('now'), ?)
+			ON CONFLICT(name) DO UPDATE SET
+			    value       = '',
+			    value_ct    = excluded.value_ct,
+			    value_nonce = excluded.value_nonce,
+			    version     = secrets.version + 1,
+			    updated_at  = datetime('now'),
+			    updated_by  = excluded.updated_by`,
+			name, ct, nonce, actor,
+		); err != nil {
+			return fmt.Errorf("state.PutSecret: upsert: %w", err)
+		}
+	} else {
+		if _, err := tx.Exec(`
+			INSERT INTO secrets (name, value, version, updated_at, updated_by)
+			VALUES (?, ?, 1, datetime('now'), ?)
+			ON CONFLICT(name) DO UPDATE SET
+			    value      = excluded.value,
+			    value_ct   = NULL,
+			    value_nonce = NULL,
+			    version    = secrets.version + 1,
+			    updated_at = datetime('now'),
+			    updated_by = excluded.updated_by`,
+			name, value, actor,
+		); err != nil {
+			return fmt.Errorf("state.PutSecret: upsert: %w", err)
+		}
 	}
 	if err := bumpSecretsEtag(tx); err != nil {
 		return err
@@ -46,14 +87,41 @@ func (s *Store) PutSecret(name, value, actor string) error {
 	return nil
 }
 
+// resolveSecretValue picks the plaintext: ct/nonce when present (and
+// AEAD bound), otherwise the plaintext column. Returns an error if
+// the row is encrypted but no AEAD is bound — better to fail loud
+// than to silently hand back an empty string for what the caller
+// asked for as a real secret.
+func (s *Store) resolveSecretValue(name string, value string, ct, nonce []byte) (string, error) {
+	if len(ct) > 0 {
+		if s.aead == nil {
+			return "", fmt.Errorf("state: secret %q is encrypted but no DEK is configured", name)
+		}
+		pt, err := s.aead.Open(ct, nonce, name)
+		if err != nil {
+			return "", fmt.Errorf("state: open secret %q: %w", name, err)
+		}
+		return string(pt), nil
+	}
+	return value, nil
+}
+
 // GetSecret returns the value for name. (name not found) → (empty, false, nil).
-// Errors are reserved for real I/O / scan failures.
+// Errors are reserved for real I/O / scan / decrypt failures.
 func (s *Store) GetSecret(name string) (string, bool, error) {
-	var value string
-	row := s.db.QueryRow(`SELECT value FROM secrets WHERE name = ?`, name)
-	switch err := row.Scan(&value); {
+	var (
+		value string
+		ct    []byte
+		nonce []byte
+	)
+	row := s.db.QueryRow(`SELECT value, value_ct, value_nonce FROM secrets WHERE name = ?`, name)
+	switch err := row.Scan(&value, &ct, &nonce); {
 	case err == nil:
-		return value, true, nil
+		pt, err := s.resolveSecretValue(name, value, ct, nonce)
+		if err != nil {
+			return "", false, err
+		}
+		return pt, true, nil
 	case errors.Is(err, sql.ErrNoRows):
 		return "", false, nil
 	default:
@@ -64,18 +132,25 @@ func (s *Store) GetSecret(name string) (string, bool, error) {
 // ListSecrets returns the full name → value map. The map is freshly
 // allocated; callers may mutate it without affecting the store.
 func (s *Store) ListSecrets() (map[string]string, error) {
-	rows, err := s.db.Query(`SELECT name, value FROM secrets`)
+	rows, err := s.db.Query(`SELECT name, value, value_ct, value_nonce FROM secrets`)
 	if err != nil {
 		return nil, fmt.Errorf("state.ListSecrets: query: %w", err)
 	}
 	defer rows.Close()
 	out := map[string]string{}
 	for rows.Next() {
-		var name, value string
-		if err := rows.Scan(&name, &value); err != nil {
+		var (
+			name, value string
+			ct, nonce   []byte
+		)
+		if err := rows.Scan(&name, &value, &ct, &nonce); err != nil {
 			return nil, fmt.Errorf("state.ListSecrets: scan: %w", err)
 		}
-		out[name] = value
+		pt, err := s.resolveSecretValue(name, value, ct, nonce)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = pt
 	}
 	return out, rows.Err()
 }

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -60,6 +60,87 @@ type Store struct {
 	wait        *jobWaiters
 	controlOnce sync.Once
 	controlReg2 *controlRegistry
+
+	// aead is the at-rest cipher for the secrets table. nil keeps the
+	// historical plaintext-column behavior; setting it via WithAEAD
+	// flips PutSecret/GetSecret/ListSecrets to seal/open through
+	// value_ct/value_nonce instead. The transition is forward-only —
+	// once any row is encrypted, the store must keep its AEAD bound
+	// or those rows become unreadable.
+	aead *AEAD
+}
+
+// WithAEAD binds the at-rest cipher and returns the receiver so
+// callers can chain immediately after Open:
+//
+//	s, _ := state.Open(dsn)
+//	s.WithAEAD(aead)
+//	_, _ = s.BackfillSecrets()
+//
+// Idempotent — a second call replaces the prior key, which is the
+// intended path for a controlled DEK rotation (operator does a
+// re-encrypt pass via PutSecret of every name after swapping).
+func (s *Store) WithAEAD(a *AEAD) *Store {
+	s.aead = a
+	return s
+}
+
+// BackfillSecrets re-seals any plaintext rows under the bound AEAD,
+// in a single transaction. Returns the number of rows it touched.
+//
+// Run this once at api startup after WithAEAD. Idempotent: rows that
+// already have a non-empty value_ct are skipped, so a redeploy that
+// re-invokes the helper is free. With no AEAD bound the call is a
+// no-op (returns 0, nil) — operators who haven't opted in keep the
+// historical plaintext column behavior with no surprise.
+func (s *Store) BackfillSecrets() (int, error) {
+	if s == nil || s.aead == nil {
+		return 0, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("state.BackfillSecrets: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.Query(`
+		SELECT name, value FROM secrets
+		WHERE value_ct IS NULL AND value != ''`)
+	if err != nil {
+		return 0, fmt.Errorf("state.BackfillSecrets: scan: %w", err)
+	}
+	type pair struct{ name, value string }
+	var todo []pair
+	for rows.Next() {
+		var p pair
+		if err := rows.Scan(&p.name, &p.value); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("state.BackfillSecrets: row: %w", err)
+		}
+		todo = append(todo, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("state.BackfillSecrets: rows: %w", err)
+	}
+	n := 0
+	for _, p := range todo {
+		ct, nonce, err := s.aead.Seal([]byte(p.value), p.name)
+		if err != nil {
+			return n, fmt.Errorf("state.BackfillSecrets: seal %s: %w", p.name, err)
+		}
+		if _, err := tx.Exec(`
+			UPDATE secrets SET value_ct = ?, value_nonce = ?, value = ''
+			WHERE name = ?`, ct, nonce, p.name); err != nil {
+			return n, fmt.Errorf("state.BackfillSecrets: update %s: %w", p.name, err)
+		}
+		n++
+	}
+	if err := tx.Commit(); err != nil {
+		return n, fmt.Errorf("state.BackfillSecrets: commit: %w", err)
+	}
+	return n, nil
 }
 
 // Open returns a Store backed by the given DSN. Use ":memory:" for an
@@ -175,6 +256,15 @@ func (s *Store) migrate() error {
 	if current < 9 {
 		if _, err := s.db.Exec(schemaSQL_v9); err != nil {
 			return fmt.Errorf("state.migrate v9: %w", err)
+		}
+	}
+	// v10: at-rest envelope encryption columns on the secrets table.
+	// Backfill of pre-existing plaintext rows happens in Go via
+	// BackfillSecrets after WithAEAD — schema-level migration just
+	// adds the columns.
+	if current < 10 {
+		if _, err := s.db.Exec(schemaSQL_v10); err != nil {
+			return fmt.Errorf("state.migrate v10: %w", err)
 		}
 	}
 	if current >= targetSchemaVersion {


### PR DESCRIPTION
## Summary
- Add an `AEAD` (XChaCha20-Poly1305) helper to the `state` package and bind it on the `Store` via `WithAEAD`.
- Migration v10 adds `value_ct` / `value_nonce` BLOB columns to the `secrets` table; the existing plaintext `value` column stays for one release as a rollback path.
- `PutSecret` seals into ct/nonce when an AEAD is bound and writes the plaintext column as `''`. `GetSecret` / `ListSecrets` prefer the encrypted columns and fall back to the plaintext column for legacy rows. Reading an encrypted row without an AEAD bound returns a loud error.
- `BackfillSecrets` re-seals any pre-v10 plaintext rows once, called from `EnableStateStore` after `WithAEAD`.
- `EnableStateStore` and the local `cronicle secret` CLI both pick up `CRONICLE_DEK_HEX` from the env so the opt-in is one variable away.
- AEAD seal/open round-trip, AAD-binding (name swap rejection), plaintext-fallback, encrypted-without-DEK error, and backfill (including the idempotent no-op second pass) are pinned by tests.

## Why
The `state.db` secrets table is what `cronicle exec` resolves `$secret.NAME` references against at task-dispatch time. After PR #105 it's the single canonical store ingest funnels into. A reader with access to the file (laptop loss, backup leak, container-volume escape) could lift every API key the runtime resolves. Encrypting at rest with name-as-AAD means a stolen file is opaque, and a row copy across rows fails to decrypt.

The DEK lives in the cronicle process env (`CRONICLE_DEK_HEX`). Local-dev and CI runs without it keep the historical plaintext path, so this change is zero-ceremony to ignore and one env var to opt in.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (pre-existing unrelated warnings only)
- [x] `go test ./internal/cronicle/state/...` — 7 new tests pass, no regressions
- [x] `go test ./...` — full suite green
- [ ] On deploy: set `CRONICLE_DEK_HEX`, run a producer with an existing plaintext state.db, confirm the startup log shows `secrets: at-rest backfill complete rows=N` once
- [ ] On deploy: open state.db with sqlite3, confirm `SELECT value FROM secrets` returns empty strings while `SELECT length(value_ct) FROM secrets` is non-zero
- [ ] On deploy: confirm a worker still resolves `$secret.ANTHROPIC_API_KEY` correctly post-backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)