### PR TITLE
CI: go vet + go test on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+# PR-time validation: go vet + go test ./...
+# Runs on every PR and on push to master (catches direct merges).
+#
+# gofmt is intentionally not enforced here — Go 1.26 reflows godoc lists
+# differently than earlier versions, so re-enabling it requires a one-time
+# `gofmt -w .` sweep first.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test -race -count=1 -timeout=5m ./...

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -31,7 +31,6 @@ var _ = Describe("exec", func() {
 		command := []string{""}
 		res := Execute(command, "./", []string{})
 		err := res.Error
-		err.Error()
 		// expected := Result{Command: command, Stdout: "", Stderr: "", ExitStatus: 0, Error: nil}
 		Expect(err.Error()).To(Equal("exec: no command"))
 	})
@@ -40,7 +39,6 @@ var _ = Describe("exec", func() {
 		command := []string{"/bin/bash", "not_a_script"}
 		res := Execute(command, "./", []string{})
 		err := res.Error
-		err.Error()
 
 		exitError := errors.New("exit status 127")
 		expected := Result{Command: command, Stdout: "", Stderr: "/bin/bash: not_a_script: No such file or directory\n", ExitStatus: 127, Error: exitError}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: runs `go vet ./...` and `go test -race -count=1 ./...` on every pull request and on push to master.
- `pkg/exec/exec_test.go`: drops two orphan `err.Error()` lines that vet flags — the very next line uses `err` properly, so these calls were dead.

## Test plan
- [ ] Workflow runs green on this PR
- [ ] PRs that introduce a vet error or failing test go red

🤖 Generated with [Claude Code](https://claude.com/claude-code)