### PR TITLE
color: --color flag + NO_COLOR; collapse pretty-color into pretty

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,9 +31,19 @@ var logFormat string
 // frontend renders as a faithful TTY mirror.
 var liveFormat string
 
+// colorMode is bound to the --color persistent flag. auto (the default)
+// defers to context: stdout pretty honors TTY+NO_COLOR; live SSE pretty
+// defaults to color (consumers are terminal renderers). always/never are
+// explicit overrides that beat both TTY detection and NO_COLOR.
+var colorMode string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Color policy must be applied BEFORE SetupLogging because the
+		// pretty stdout handler captures color.NoColor at construction
+		// time via fatih/color's SprintFunc closures.
+		cronicle.SetColorMode(cronicle.ColorMode(colorMode))
 		cronicle.SetupLogging(cronicle.LogFormat(logFormat))
 		cronicle.SetLiveFormat(cronicle.LiveFormat(liveFormat))
 	},
@@ -79,5 +89,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "auto",
 		"stdout log format: auto (pretty if TTY, text if piped), pretty, text, or json")
 	rootCmd.PersistentFlags().StringVar(&liveFormat, "live-format", "pretty",
-		"wire format for the live SSE event stream (GET /v1/runs/{id}/events): pretty (ANSI, default), pretty-color (force ANSI even when cronicled's stdout isn't a TTY), json, or text")
+		"wire format for the live SSE event stream (GET /v1/runs/{id}/events): pretty (ANSI; the default), json, or text. pretty-color is a deprecated alias for pretty (the live wire defaults to color regardless of TTY because consumers are xterm-class renderers).")
+	rootCmd.PersistentFlags().StringVar(&colorMode, "color", "auto",
+		"when to emit ANSI color in pretty output: auto (TTY+NO_COLOR for stdout; always-on for SSE wire), always (force on), never (force off). Honors the NO_COLOR convention from https://no-color.org in auto mode.")
 }

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -38,16 +38,19 @@ const (
 // emits ANSI-colored multi-line text identical to what a TTY would
 // show. Frontends consume via xterm.js. JSON / text are alternatives
 // for non-terminal clients.
+//
+// Color decision is independent of LiveFormat — controlled by the
+// --color flag and the NO_COLOR env var via the ColorMode/shouldColor
+// helpers below. The live wire defaults to color-on (xterm.js renders);
+// flip with --color=never or NO_COLOR=1.
 type LiveFormat string
 
 const (
 	LiveFormatPretty LiveFormat = "pretty"
-	// LiveFormatPrettyColor is `pretty` but with ANSI color codes ALWAYS
-	// emitted, regardless of whether cronicled's own stdout is a TTY.
-	// Necessary for headless service deployments (systemd, docker, k8s)
-	// where fatih/color's global NoColor=true would otherwise strip the
-	// color codes before they reach the SSE wire — leaving the xterm.js
-	// frontend with monochrome text even though it can render ANSI fine.
+	// LiveFormatPrettyColor is a deprecated alias for LiveFormatPretty
+	// kept for one release. The live wire's pretty format now emits
+	// color by default (no longer gated on TTY), so the distinction is
+	// gone. SetLiveFormat normalises it. Remove in v0.7+.
 	LiveFormatPrettyColor LiveFormat = "pretty-color"
 	LiveFormatJSON        LiveFormat = "json"
 	LiveFormatText        LiveFormat = "text"
@@ -60,10 +63,79 @@ var currentLiveFormat LiveFormat = LiveFormatPretty
 
 // SetLiveFormat changes the wire format the SSE live-stream will use.
 // Call before EnableStateStore. Empty string keeps the default (pretty).
+// pretty-color is normalised to pretty (the distinction is gone).
 func SetLiveFormat(format LiveFormat) {
-	if format != "" {
-		currentLiveFormat = format
+	if format == "" {
+		return
 	}
+	if format == LiveFormatPrettyColor {
+		format = LiveFormatPretty
+	}
+	currentLiveFormat = format
+}
+
+// ColorMode is the --color flag value: auto (default), always, or never.
+// auto defers to context — TTY+NO_COLOR for stdout, always-on for the SSE
+// wire. always/never are explicit overrides that beat both TTY and NO_COLOR.
+type ColorMode string
+
+const (
+	ColorModeAuto   ColorMode = "auto"
+	ColorModeAlways ColorMode = "always"
+	ColorModeNever  ColorMode = "never"
+)
+
+// currentColorMode is the effective --color setting. Initialised to auto;
+// SetColorMode replaces it before SetupLogging runs so the stdout pretty
+// handler's SprintFunc closures capture the right color.NoColor value.
+var currentColorMode ColorMode = ColorModeAuto
+
+// SetColorMode applies the --color flag value. Beyond storing the mode it
+// flips fatih/color's global NoColor and (for always/never) unsets the
+// env vars fatih/color re-checks at every color.New() call — without that
+// step, NO_COLOR=1 leaks through and stamps c.noColor=true on every
+// instance before our global flip can take effect.
+//
+// Precedence chosen: explicit --color flag beats env, matching git/grep.
+// Pure no-color.org behaviour (env always wins) lives at ColorModeAuto.
+func SetColorMode(mode ColorMode) {
+	if mode == "" {
+		mode = ColorModeAuto
+	}
+	currentColorMode = mode
+	switch mode {
+	case ColorModeAlways:
+		// fatih/color.New() does `if noColorIsSet() { c.noColor=true }`
+		// every call, reading the env directly. Unset it so the
+		// per-instance override can't trip.
+		_ = os.Unsetenv("NO_COLOR")
+		if os.Getenv("TERM") == "dumb" {
+			_ = os.Unsetenv("TERM")
+		}
+		color.NoColor = false
+	case ColorModeNever:
+		color.NoColor = true
+	}
+	// auto: leave color.NoColor at fatih/color's init-time default
+	// (TTY+NO_COLOR detection), which is exactly what we want for the
+	// stdout context.
+}
+
+// shouldColorLive reports whether the live SSE encoder should emit color.
+// The wire's default is color-on (consumers are terminal renderers); the
+// --color flag and NO_COLOR override that.
+func shouldColorLive() bool {
+	switch currentColorMode {
+	case ColorModeNever:
+		return false
+	case ColorModeAlways:
+		return true
+	}
+	// auto: honor NO_COLOR + TERM=dumb, then default to on for the wire.
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return true
 }
 
 // resolvedLogFormat tracks what format SetupLogging settled on after auto-
@@ -287,13 +359,8 @@ func newLiveEncoder(format LiveFormat) state.Encoder {
 			h = slog.NewJSONHandler(&buf, nil)
 		case LiveFormatText:
 			h = slog.NewTextHandler(&buf, nil)
-		case LiveFormatPrettyColor:
-			h = &liveSinkPrettyHandler{
-				fallback:   newTintHandler(&buf),
-				out:        &buf,
-				forceColor: true,
-			}
-		default: // pretty (also the empty-string fallback)
+		default: // pretty (also the empty-string fallback and the
+			// pretty-color alias, which SetLiveFormat normalises).
 			h = &liveSinkPrettyHandler{
 				fallback: newTintHandler(&buf),
 				out:      &buf,
@@ -603,23 +670,23 @@ func (p *stdoutPrettyHandler) WithGroup(name string) slog.Handler {
 // No pre-emption path exists for the SSE consumer, so every record gets
 // turned into visible bytes — header / footer / per-line / per-token.
 //
-// forceColor=true (set by LiveFormatPrettyColor) toggles fatih/color's
-// global NoColor=false for the duration of Handle. This is gated by a
-// process-wide mutex so concurrent stdout pretty renders aren't affected
-// mid-record. The mutex held window is one Handle call (typically a few
-// microseconds); LiveSink fanout is already serialized per subscriber so
-// contention is bounded by the number of subscribers, not by traffic.
+// The SSE wire defaults to color-on regardless of TTY (consumers are
+// xterm.js — they always render). Each Handle call temporarily flips
+// fatih/color's global NoColor=false under a process-wide mutex, then
+// restores it. The mutex window is one Handle call (microseconds), and
+// LiveSink fanout already serializes per subscriber so contention is
+// bounded by subscriber count, not by traffic. --color=never (set by
+// the operator on the cronicle subprocess) opts out via shouldColorLive.
 type liveSinkPrettyHandler struct {
-	fallback   slog.Handler
-	out        io.Writer // the LiveSink encoder's per-Handle bytes.Buffer
-	forceColor bool
+	fallback slog.Handler
+	out      io.Writer // the LiveSink encoder's per-Handle bytes.Buffer
 }
 
-// liveColorMu serializes color.NoColor flips for force-color live renders.
+// liveColorMu serializes color.NoColor flips for the live-wire encoder.
 // Without it, two concurrent live encoder calls could race-toggle the flag
 // while a stdout pretty handler is rendering, producing mid-record color
-// flipping. The cost is whole-process serialization of force-color renders,
-// which is fine: SSE volume isn't bounded by render throughput here.
+// flipping. The cost is whole-process serialization of live renders, which
+// is fine: SSE volume isn't bounded by render throughput here.
 var liveColorMu sync.Mutex
 
 func (p *liveSinkPrettyHandler) Enabled(ctx context.Context, l slog.Level) bool {
@@ -627,7 +694,7 @@ func (p *liveSinkPrettyHandler) Enabled(ctx context.Context, l slog.Level) bool 
 }
 
 func (p *liveSinkPrettyHandler) Handle(_ context.Context, r slog.Record) error {
-	if p.forceColor {
+	if shouldColorLive() {
 		liveColorMu.Lock()
 		prev := color.NoColor
 		color.NoColor = false
@@ -679,17 +746,15 @@ func (p *liveSinkPrettyHandler) handle(r slog.Record) error {
 
 func (p *liveSinkPrettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &liveSinkPrettyHandler{
-		fallback:   p.fallback.WithAttrs(attrs),
-		out:        p.out,
-		forceColor: p.forceColor,
+		fallback: p.fallback.WithAttrs(attrs),
+		out:      p.out,
 	}
 }
 
 func (p *liveSinkPrettyHandler) WithGroup(name string) slog.Handler {
 	return &liveSinkPrettyHandler{
-		fallback:   p.fallback.WithGroup(name),
-		out:        p.out,
-		forceColor: p.forceColor,
+		fallback: p.fallback.WithGroup(name),
+		out:      p.out,
 	}
 }
 

--- a/internal/cronicle/log_header_test.go
+++ b/internal/cronicle/log_header_test.go
@@ -73,15 +73,21 @@ func TestWriteAgentRunHeader_OmitsEmpty(t *testing.T) {
 	}
 }
 
-// TestLiveSinkPrettyHandler_ForceColor: with the global color.NoColor=true
-// (the case when cronicled runs as a headless service — no TTY on stdout),
-// the default pretty handler emits monochrome bytes. PrettyColor mode must
-// emit ANSI escapes anyway so the xterm.js consumer can render them.
-func TestLiveSinkPrettyHandler_ForceColor(t *testing.T) {
+// TestLiveSinkPrettyHandler_ColorByDefault: the SSE wire emits ANSI for
+// pretty mode regardless of the producer's TTY state — the consumer is
+// xterm.js, which can always render color. This is the entire reason
+// the live wire's color decision is decoupled from stdout's. Used to
+// require the separate LiveFormatPrettyColor; now baked in.
+func TestLiveSinkPrettyHandler_ColorByDefault(t *testing.T) {
 	// Simulate headless (non-TTY) producer state.
 	prev := color.NoColor
 	color.NoColor = true
 	defer func() { color.NoColor = prev }()
+	// Default ColorMode is auto; shouldColorLive returns true unless
+	// NO_COLOR is in env. Tests don't set NO_COLOR so auto → color on.
+	prevMode := currentColorMode
+	currentColorMode = ColorModeAuto
+	defer func() { currentColorMode = prevMode }()
 
 	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "shell run start", 0)
 	rec.AddAttrs(
@@ -92,39 +98,58 @@ func TestLiveSinkPrettyHandler_ForceColor(t *testing.T) {
 		slog.String("command", "echo hello && rm -rf /tmp/cache"),
 	)
 
-	plainEnc := newLiveEncoder(LiveFormatPretty)
-	colorEnc := newLiveEncoder(LiveFormatPrettyColor)
+	pretty := newLiveEncoder(LiveFormatPretty)(rec)
+	// pretty-color is the deprecated alias — SetLiveFormat normalises it,
+	// but newLiveEncoder is called directly here; both should color.
+	alias := newLiveEncoder(LiveFormatPrettyColor)(rec)
 
-	plain := plainEnc(rec)
-	colored := colorEnc(rec)
-
-	if bytes.Contains(plain, []byte("\x1b[")) {
-		t.Fatalf("LiveFormatPretty should not emit ANSI when color.NoColor=true; got:\n%q", plain)
-	}
-	if !bytes.Contains(colored, []byte("\x1b[")) {
-		t.Fatalf("LiveFormatPrettyColor must emit ANSI even when color.NoColor=true; got:\n%q", colored)
-	}
-	// Both encodings should contain the resolved command — color choice
-	// changes the bytes around it, not the content.
-	if !bytes.Contains(plain, []byte("echo hello && rm -rf /tmp/cache")) ||
-		!bytes.Contains(colored, []byte("echo hello && rm -rf /tmp/cache")) {
-		t.Fatalf("resolved command missing from one of the encodings\nplain:\n%s\ncolored:\n%s", plain, colored)
+	for name, b := range map[string][]byte{"pretty": pretty, "pretty-color alias": alias} {
+		if !bytes.Contains(b, []byte("\x1b[")) {
+			t.Fatalf("%s: expected ANSI on the live wire; got:\n%q", name, b)
+		}
+		if !bytes.Contains(b, []byte("echo hello && rm -rf /tmp/cache")) {
+			t.Fatalf("%s: missing resolved command in output\n%s", name, b)
+		}
 	}
 }
 
-// TestLiveSinkPrettyHandler_ForceColor_RestoresGlobal: after a forced-
-// color render, the global color.NoColor must return to its prior value
-// so a stdout pretty handler that ran concurrently isn't permanently
-// flipped into color mode.
-func TestLiveSinkPrettyHandler_ForceColor_RestoresGlobal(t *testing.T) {
+// TestLiveSinkPrettyHandler_NoColorEnv: with NO_COLOR set, the live wire
+// emits monochrome — even though the wire-default is color-on. Matches
+// the no-color.org convention in auto mode.
+func TestLiveSinkPrettyHandler_NoColorEnv(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	prevMode := currentColorMode
+	currentColorMode = ColorModeAuto
+	defer func() { currentColorMode = prevMode }()
+
+	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "shell run start", 0)
+	rec.AddAttrs(
+		slog.String("entry_type", "shell_run_start"),
+		slog.String("run_id", "R1"),
+		slog.String("schedule", "daily"),
+		slog.String("task", "cleanup"),
+		slog.String("command", "echo hello"),
+	)
+	got := newLiveEncoder(LiveFormatPretty)(rec)
+	if bytes.Contains(got, []byte("\x1b[")) {
+		t.Fatalf("NO_COLOR set: expected monochrome on the live wire; got:\n%q", got)
+	}
+}
+
+// TestLiveSinkPrettyHandler_RestoresGlobal: after the handler returns,
+// the global color.NoColor must be restored so a concurrent stdout pretty
+// handler isn't permanently flipped into color mode.
+func TestLiveSinkPrettyHandler_RestoresGlobal(t *testing.T) {
 	prev := color.NoColor
 	color.NoColor = true
 	defer func() { color.NoColor = prev }()
+	prevMode := currentColorMode
+	currentColorMode = ColorModeAuto
+	defer func() { currentColorMode = prevMode }()
 
 	h := &liveSinkPrettyHandler{
-		fallback:   newTintHandler(&bytes.Buffer{}),
-		out:        &bytes.Buffer{},
-		forceColor: true,
+		fallback: newTintHandler(&bytes.Buffer{}),
+		out:      &bytes.Buffer{},
 	}
 	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "dim line", 0)
 	rec.AddAttrs(


### PR DESCRIPTION
## Summary

The split between `LiveFormatPretty` and `LiveFormatPrettyColor` conflated two questions: "what's the layout shape?" and "is the consumer color-capable?". cronicled had to pass `--live-format=pretty-color` explicitly because the live wire's pretty default stripped color when the producer wasn't on a TTY — but the consumer (xterm.js) always renders ANSI, regardless of cronicled's stdout state.

This PR consolidates the color decision:

### What changes

| concern | before | after |
|---|---|---|
| pretty-on-stdout color | TTY check (fatih/color default) | TTY + `NO_COLOR` + `--color` |
| pretty-on-SSE color | gated on `LiveFormatPrettyColor` (explicit value) | **on by default**; `NO_COLOR` + `--color=never` disable |
| `pretty-color` value | distinct LiveFormat | deprecated alias for `pretty` |
| operator override | none — had to pick the right format value | `--color={auto,always,never}` |

### `--color` precedence

```
1. --color=never                    → off
2. --color=always                   → on (also unsets NO_COLOR — see note)
3. NO_COLOR env set                 → off (no-color.org)
4. wire context = SSE               → on (consumer is xterm-class)
5. wire context = stdout            → TTY check
```

Matches git/grep — explicit `--color=always` beats env.

### Gotcha resolved

`fatih/color.New()` reads `NO_COLOR` on **every call** and stamps `c.noColor=true` on the new instance. Flipping the package-level `color.NoColor=false` after the fact does nothing, because each instance already cached the env. `SetColorMode(always)` therefore also unsets `NO_COLOR` from the process env so future `color.New()` calls see no env override.

### Backwards compatibility

- `--live-format=pretty-color` still parses (normalised to `pretty`).
- cronicled (in cronicle-infra) still passes `--live-format=pretty-color` — that path remains valid via the alias.
- The explicit flag in cronicled becomes redundant once this ships and can be dropped in a follow-up cronicle-infra PR.

## Test plan

- [x] `go test ./internal/cronicle/ -short` green (incl. 3 new color tests)
- [x] Matrix verified end-to-end:
  - `--color=always` → ANSI
  - `--color=never` → no ANSI
  - `--color=auto` (piped) → no ANSI (TTY check)
  - `NO_COLOR=1 --color=auto` → no ANSI (env honoured)
  - `NO_COLOR=1 --color=always` → ANSI (flag wins)
  - `--live-format=pretty-color` → accepted, normalised to pretty

🤖 Generated with [Claude Code](https://claude.com/claude-code)