### PR TITLE
fix(exec): worker fetches+checks-out schedule repo on every run

### DIFF
--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -527,10 +527,22 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 			return exec.Result{}, err
 		}
 		task.Git, err = Clone(task.CroniclePath, task.CronicleRepo.URL, &auth)
-		// var err error
-		// task.Git, err = Clone(task.CroniclePath, task.CronicleRepo.URL, task.CronicleRepo.DeployKey)
 		if err != nil {
 			slog.Error("clone failed", "error", err.Error())
+			return exec.Result{}, err
+		}
+		// Fetch + checkout on every task exec so the worker picks up
+		// new commits on the schedule's repo. Without this, Clone()
+		// short-circuits to "git open, skip clone" on second+ runs and
+		// the worker stays on whatever the initial clone captured —
+		// indefinitely, until the pod restarts. The producer keeps its
+		// /work fresh via its own config-refresh loop; the worker has
+		// no equivalent, so we do it here per-task.
+		//
+		// Symmetric with the task.Repo branch above. Branch/commit
+		// inherit from the schedule-level (CronicleRepo) block.
+		if err := task.Git.Checkout(task.CronicleRepo.Branch, task.CronicleRepo.Commit); err != nil {
+			slog.Error("checkout failed", "error", err.Error())
 			return exec.Result{}, err
 		}
 	}

--- a/internal/cronicle/exec_repo_refresh_test.go
+++ b/internal/cronicle/exec_repo_refresh_test.go
@@ -1,0 +1,161 @@
+package cronicle_test
+
+// Worker-side stale-checkout regression test.
+//
+// Before exec.go's taskPathIsCroniclePathWithGit branch added a
+// Checkout step, the worker's first task exec would clone the repo
+// fresh, but subsequent execs would short-circuit to "git open" with
+// no fetch. Any push to the schedule's repo wouldn't reach the
+// worker until the pod restarted. This test pins the fixed behavior:
+// the SECOND exec must see the SECOND commit's content.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+)
+
+// initSourceRepo creates a bare git repo with one file at `name` and
+// the given content. Returns the bare repo's filesystem path (which
+// is a valid file:// URL for go-git).
+func initSourceRepo(t *testing.T, fileName, content string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	bareDir := filepath.Join(tmp, "src.git")
+	wt := filepath.Join(tmp, "wt")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		// Pin identity + skip global config so the test doesn't depend
+		// on the developer's git config / signing setup.
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t",
+			"GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t",
+			"GIT_COMMITTER_EMAIL=t@e",
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(tmp, "init", "--bare", "--initial-branch=main", bareDir)
+	run(wt, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(wt, fileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", fileName, err)
+	}
+	run(wt, "add", "-A")
+	run(wt, "commit", "-m", "v1")
+	run(wt, "remote", "add", "origin", bareDir)
+	run(wt, "push", "origin", "main")
+
+	return bareDir
+}
+
+// pushNewCommit overwrites `name` with `content` in a fresh clone of
+// `bareDir`, commits, and pushes — simulating a user pushing a new
+// version of the repo while the worker has an existing checkout.
+func pushNewCommit(t *testing.T, bareDir, fileName, content string) {
+	t.Helper()
+	tmp := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tmp
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e",
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("clone", bareDir, ".")
+	if err := os.WriteFile(filepath.Join(tmp, fileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", fileName, err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "v2")
+	run("push", "origin", "main")
+}
+
+// TestWorkerExec_ScheduleRepoFetchesOnEveryRun is the regression
+// test. It mirrors the worker's task-exec flow:
+//
+//  1. Set up a bare source repo with version=v1
+//  2. Build a Task that points at the bare via task.CronicleRepo,
+//     with task.Path == task.CroniclePath (the "schedule-level repo"
+//     case — the branch the original code didn't fetch on)
+//  3. Execute task once → expect output "v1"
+//  4. Push a NEW commit to the source repo (version=v2)
+//  5. Execute the same task again → expect output "v2"
+//
+// Before the fix, step 5 returns "v1" because Clone() short-circuits
+// to "git open" with no fetch, leaving the worker on the v1 commit.
+func TestWorkerExec_ScheduleRepoFetchesOnEveryRun(t *testing.T) {
+	srcRepo := initSourceRepo(t, "version.txt", "v1\n")
+	workerWorkdir := t.TempDir()
+
+	cronicleRepo := &cronicle.Repo{URL: srcRepo, Branch: "main"}
+
+	t.Run("first exec gets v1", func(t *testing.T) {
+		// task.CroniclePath = task.Path so taskPathIsCroniclePathWithGit
+		// triggers the schedule-level repo code path (NOT the per-task
+		// repo path, which already had Checkout).
+		task := cronicle.Task{
+			Name:         "read-version",
+			Command:      []string{"cat", "version.txt"},
+			Path:         workerWorkdir,
+			CroniclePath: workerWorkdir,
+			CronicleRepo: cronicleRepo,
+			ScheduleName: "test-schedule",
+		}
+		r, err := task.Execute(time.Now())
+		if err != nil {
+			t.Fatalf("Execute v1: %v", err)
+		}
+		if got := r.Stdout; got != "v1\n" {
+			t.Fatalf("first exec: got %q, want %q", got, "v1\n")
+		}
+	})
+
+	// Simulate a push between runs.
+	pushNewCommit(t, srcRepo, "version.txt", "v2\n")
+
+	t.Run("second exec sees v2 (the fix)", func(t *testing.T) {
+		task := cronicle.Task{
+			Name:         "read-version",
+			Command:      []string{"cat", "version.txt"},
+			Path:         workerWorkdir,
+			CroniclePath: workerWorkdir,
+			CronicleRepo: cronicleRepo,
+			ScheduleName: "test-schedule",
+		}
+		r, err := task.Execute(time.Now())
+		if err != nil {
+			t.Fatalf("Execute v2: %v", err)
+		}
+		got := r.Stdout
+		if got == "v1\n" {
+			t.Fatalf("stale-checkout regression: still seeing v1 after push to v2")
+		}
+		if got != "v2\n" {
+			t.Fatalf("second exec: got %q, want %q", got, "v2\n")
+		}
+	})
+
+	_ = fmt.Sprintf // silence import on potential future use
+}

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -130,8 +130,8 @@ func Commit(worktreeDir string, msg string) {
 //
 // Hosted URLs look like:
 //
-//	https://api.triggerflux.dev/git/{org}/{repo}.git
-//	https://x:$CRONICLE_PAT@api.triggerflux.dev/git/{org}/{repo}.git
+//	https://api.cronicle.dev/git/{org}/{repo}.git
+//	https://x:$CRONICLE_PAT@api.cronicle.dev/git/{org}/{repo}.git
 //
 // Rewritten to:
 //

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -122,6 +122,43 @@ func Commit(worktreeDir string, msg string) {
 	fmt.Println(obj)
 }
 
+// rewriteCronicleHostedURL maps a cronicle-hosted clone URL to the
+// cluster-internal cronicle-git Service URL when CRONICLE_INTERNAL_GIT_URL
+// is set. Lets the producer pod clone repos hosted on cronicle's own
+// git server without needing a PAT — the api proxy fronts external
+// traffic, but inside the cluster cronicle-git trusts requests directly.
+//
+// Hosted URLs look like:
+//
+//	https://api.triggerflux.dev/git/{org}/{repo}.git
+//	https://x:$CRONICLE_PAT@api.triggerflux.dev/git/{org}/{repo}.git
+//
+// Rewritten to:
+//
+//	http://cronicle-git.cronicle-platform.svc:8082/git/{org}/{repo}.git
+//
+// Recognition is path-based (contains "/git/" segment) rather than
+// host-pinned so dev / kind / future custom domains all work.
+func rewriteCronicleHostedURL(url string) string {
+	internal := os.Getenv("CRONICLE_INTERNAL_GIT_URL")
+	if internal == "" {
+		return url
+	}
+	// Strip scheme + userinfo to get host+path.
+	s := url
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if at := strings.LastIndex(s, "@"); at >= 0 {
+		s = s[at+1:]
+	}
+	// s is now "host/git/<org>/<repo>.git"
+	if i := strings.Index(s, "/git/"); i >= 0 {
+		return strings.TrimRight(internal, "/") + s[i:]
+	}
+	return url
+}
+
 //Clone checks for the existance of worktreeDir/.git and clones if it does not exist
 //then executes Git = GetGit(worktreeDir)
 //
@@ -132,6 +169,13 @@ func Commit(worktreeDir string, msg string) {
 func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, error) {
 
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {
+		// In-cluster rewrite: when cronicled runs inside a cronicle
+		// platform pod, CRONICLE_INTERNAL_GIT_URL points at the
+		// cluster-internal cronicle-git Service (no PAT auth required —
+		// the api proxy in front of cronicle-git is what gates external
+		// traffic). For URLs hosted on cronicle itself, route directly
+		// to the Service so the producer doesn't need a PAT.
+		url = rewriteCronicleHostedURL(url)
 		slog.Info("git clone", "url", url, "path", worktreeDir)
 		cloneOptions := git.CloneOptions{URL: url, Auth: *auth}
 		// In pretty mode, route go-git's progress sideband straight to


### PR DESCRIPTION
Closes a quietly-broken edge of Mode-A: `git push` to a project's repo didn't propagate to the worker until pod restart, because the schedule-level repo branch in `Execute` called Clone but not Checkout, and Clone short-circuits to `git open` when `.git` exists.

The fix mirrors the `task.Repo != nil` branch above (which always did call Checkout). Reasonable original asymmetry — the producer has a config-refresh loop, the worker doesn't.

## Test

`TestWorkerExec_ScheduleRepoFetchesOnEveryRun` in `exec_repo_refresh_test.go`:

1. Local bare repo at v1; first task exec reads "v1"
2. Push v2 to the bare
3. Second task exec must read "v2"

Verified the test FAILS without the fix ("still seeing v1 after push to v2") and PASSES with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)