### PR TITLE
refactor(git): cronicle-hosted clone uses bearer auth + stale-checkout fix

### DIFF
--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -263,6 +263,21 @@ type Repo struct {
 	// DeployKey is the path to the rsa private key that enables pull access to a
 	// private remote repository.
 	DeployKey string `hcl:"key,optional"`
+	// Username + Password together produce HTTP Basic auth for the
+	// remote. Password supports the standard HCL eval context, so the
+	// idiomatic shape is to interpolate from the process env:
+	//
+	//   repo {
+	//     url      = "https://api.cronicle.dev/git/<org>/<repo>"
+	//     password = "${env.CRONICLE_TOKEN}"
+	//   }
+	//
+	// Username is optional and defaults to "x" — the conventional
+	// placeholder for git's HTTP Basic challenge. Every modern host
+	// (GitHub, GitLab, Gitea, cronicle-git) ignores the username and
+	// authenticates on the token in the password slot.
+	Username string `hcl:"username,optional"`
+	Password string `hcl:"password,optional"`
 	// Branch and Commit are mutually exclusive. ErrBranchAndCommitGiven
 	// rejects HCL that sets both. Historical bug: these fields had their
 	// HCL tags crossed (`branch` populated Commit and vice versa) — fixed

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -527,10 +527,22 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 			return exec.Result{}, err
 		}
 		task.Git, err = Clone(task.CroniclePath, task.CronicleRepo.URL, &auth)
-		// var err error
-		// task.Git, err = Clone(task.CroniclePath, task.CronicleRepo.URL, task.CronicleRepo.DeployKey)
 		if err != nil {
 			slog.Error("clone failed", "error", err.Error())
+			return exec.Result{}, err
+		}
+		// Fetch + checkout on every task exec so the worker picks up
+		// new commits on the schedule's repo. Without this, Clone()
+		// short-circuits to "git open, skip clone" on second+ runs and
+		// the worker stays on whatever the initial clone captured —
+		// indefinitely, until the pod restarts. The producer keeps its
+		// /work fresh via its own config-refresh loop; the worker has
+		// no equivalent, so we do it here per-task.
+		//
+		// Symmetric with the task.Repo branch above. Branch/commit
+		// inherit from the schedule-level (CronicleRepo) block.
+		if err := task.Git.Checkout(task.CronicleRepo.Branch, task.CronicleRepo.Commit); err != nil {
+			slog.Error("checkout failed", "error", err.Error())
 			return exec.Result{}, err
 		}
 	}

--- a/internal/cronicle/exec_repo_refresh_test.go
+++ b/internal/cronicle/exec_repo_refresh_test.go
@@ -1,0 +1,161 @@
+package cronicle_test
+
+// Worker-side stale-checkout regression test.
+//
+// Before exec.go's taskPathIsCroniclePathWithGit branch added a
+// Checkout step, the worker's first task exec would clone the repo
+// fresh, but subsequent execs would short-circuit to "git open" with
+// no fetch. Any push to the schedule's repo wouldn't reach the
+// worker until the pod restarted. This test pins the fixed behavior:
+// the SECOND exec must see the SECOND commit's content.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+)
+
+// initSourceRepo creates a bare git repo with one file at `name` and
+// the given content. Returns the bare repo's filesystem path (which
+// is a valid file:// URL for go-git).
+func initSourceRepo(t *testing.T, fileName, content string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	bareDir := filepath.Join(tmp, "src.git")
+	wt := filepath.Join(tmp, "wt")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		// Pin identity + skip global config so the test doesn't depend
+		// on the developer's git config / signing setup.
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t",
+			"GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t",
+			"GIT_COMMITTER_EMAIL=t@e",
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(tmp, "init", "--bare", "--initial-branch=main", bareDir)
+	run(wt, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(wt, fileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", fileName, err)
+	}
+	run(wt, "add", "-A")
+	run(wt, "commit", "-m", "v1")
+	run(wt, "remote", "add", "origin", bareDir)
+	run(wt, "push", "origin", "main")
+
+	return bareDir
+}
+
+// pushNewCommit overwrites `name` with `content` in a fresh clone of
+// `bareDir`, commits, and pushes — simulating a user pushing a new
+// version of the repo while the worker has an existing checkout.
+func pushNewCommit(t *testing.T, bareDir, fileName, content string) {
+	t.Helper()
+	tmp := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tmp
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e",
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("clone", bareDir, ".")
+	if err := os.WriteFile(filepath.Join(tmp, fileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", fileName, err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "v2")
+	run("push", "origin", "main")
+}
+
+// TestWorkerExec_ScheduleRepoFetchesOnEveryRun is the regression
+// test. It mirrors the worker's task-exec flow:
+//
+//  1. Set up a bare source repo with version=v1
+//  2. Build a Task that points at the bare via task.CronicleRepo,
+//     with task.Path == task.CroniclePath (the "schedule-level repo"
+//     case — the branch the original code didn't fetch on)
+//  3. Execute task once → expect output "v1"
+//  4. Push a NEW commit to the source repo (version=v2)
+//  5. Execute the same task again → expect output "v2"
+//
+// Before the fix, step 5 returns "v1" because Clone() short-circuits
+// to "git open" with no fetch, leaving the worker on the v1 commit.
+func TestWorkerExec_ScheduleRepoFetchesOnEveryRun(t *testing.T) {
+	srcRepo := initSourceRepo(t, "version.txt", "v1\n")
+	workerWorkdir := t.TempDir()
+
+	cronicleRepo := &cronicle.Repo{URL: srcRepo, Branch: "main"}
+
+	t.Run("first exec gets v1", func(t *testing.T) {
+		// task.CroniclePath = task.Path so taskPathIsCroniclePathWithGit
+		// triggers the schedule-level repo code path (NOT the per-task
+		// repo path, which already had Checkout).
+		task := cronicle.Task{
+			Name:         "read-version",
+			Command:      []string{"cat", "version.txt"},
+			Path:         workerWorkdir,
+			CroniclePath: workerWorkdir,
+			CronicleRepo: cronicleRepo,
+			ScheduleName: "test-schedule",
+		}
+		r, err := task.Execute(time.Now())
+		if err != nil {
+			t.Fatalf("Execute v1: %v", err)
+		}
+		if got := r.Stdout; got != "v1\n" {
+			t.Fatalf("first exec: got %q, want %q", got, "v1\n")
+		}
+	})
+
+	// Simulate a push between runs.
+	pushNewCommit(t, srcRepo, "version.txt", "v2\n")
+
+	t.Run("second exec sees v2 (the fix)", func(t *testing.T) {
+		task := cronicle.Task{
+			Name:         "read-version",
+			Command:      []string{"cat", "version.txt"},
+			Path:         workerWorkdir,
+			CroniclePath: workerWorkdir,
+			CronicleRepo: cronicleRepo,
+			ScheduleName: "test-schedule",
+		}
+		r, err := task.Execute(time.Now())
+		if err != nil {
+			t.Fatalf("Execute v2: %v", err)
+		}
+		got := r.Stdout
+		if got == "v1\n" {
+			t.Fatalf("stale-checkout regression: still seeing v1 after push to v2")
+		}
+		if got != "v2\n" {
+			t.Fatalf("second exec: got %q, want %q", got, "v2\n")
+		}
+	})
+
+	_ = fmt.Sprintf // silence import on potential future use
+}

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -130,8 +130,8 @@ func Commit(worktreeDir string, msg string) {
 //
 // Hosted URLs look like:
 //
-//	https://api.triggerflux.dev/git/{org}/{repo}.git
-//	https://x:$CRONICLE_PAT@api.triggerflux.dev/git/{org}/{repo}.git
+//	https://api.cronicle.dev/git/{org}/{repo}.git
+//	https://x:$CRONICLE_PAT@api.cronicle.dev/git/{org}/{repo}.git
 //
 // Rewritten to:
 //

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -32,7 +32,24 @@ type Git struct {
 	authMethod    *transport.AuthMethod
 }
 
-// Auth authroizes a repository if from a local rsa key
+// Auth returns the transport.AuthMethod implied by the repo block.
+// Branches, in order:
+//
+//  1. URL empty → no auth (local-path clone or no remote).
+//  2. DeployKey set → SSH public-key auth from the file at DeployKey.
+//  3. Password non-empty → HTTP Basic auth. Username defaults to "x"
+//     (git's HTTP Basic challenge requires SOME username; modern hosts
+//     ignore the value). The Password field is a parsed HCL string,
+//     so HCL like `password = "${env.CRONICLE_TOKEN}"` has already
+//     resolved to the env-var value by the time this runs. An empty
+//     Password skips this branch (anonymous), letting laptops without
+//     the env var still clone public repos cleanly.
+//  4. Otherwise → nil (anonymous).
+//
+// The Basic-auth branch is host-agnostic: GitHub, GitLab, Gitea, the
+// cronicle-hosted git server all accept "any-username + token-in-
+// password-slot" over HTTPS, so one shape covers every common case
+// without hardcoding a hostname or env-var name.
 func (repo *Repo) Auth() (transport.AuthMethod, error) {
 
 	if repo.URL == "" {
@@ -56,7 +73,14 @@ func (repo *Repo) Auth() (transport.AuthMethod, error) {
 		return auth, nil
 	}
 
-	// auth := http.BasicAuth{Username: repo.user, Password: repo.password}
+	if repo.Password != "" {
+		user := repo.Username
+		if user == "" {
+			user = "x"
+		}
+		return &http.BasicAuth{Username: user, Password: repo.Password}, nil
+	}
+
 	return nil, nil
 
 }
@@ -123,32 +147,6 @@ func Commit(worktreeDir string, msg string) {
 	fmt.Println(obj)
 }
 
-// cronicleHostedAuth returns BasicAuth set up with the
-// CRONICLE_BEARER_TOKEN env (the platform-level service credential
-// producer + worker pods carry) when the URL is a cronicle-hosted
-// clone URL — recognized by containing "/git/" in the path. Returns
-// nil when the env isn't set or the URL isn't cronicle-hosted, which
-// is the dev/non-platform path.
-//
-// The cronicle-git server (via the cronicle-api proxy in front of it)
-// accepts the infra-bearer in the Basic password slot as a valid auth
-// source for cronicle-hosted repos. The username is conventional only;
-// any non-empty string works.
-//
-// This replaces the earlier URL-rewrite approach (rewriteCronicleHostedURL +
-// CRONICLE_INTERNAL_GIT_URL) with the simpler "auth like a normal git
-// remote" model — same shape as GitHub, just with a different token.
-func cronicleHostedAuth(rawURL string) *http.BasicAuth {
-	if !strings.Contains(rawURL, "/git/") {
-		return nil
-	}
-	token := os.Getenv("CRONICLE_BEARER_TOKEN")
-	if token == "" {
-		return nil
-	}
-	return &http.BasicAuth{Username: "cronicle", Password: token}
-}
-
 //Clone checks for the existance of worktreeDir/.git and clones if it does not exist
 //then executes Git = GetGit(worktreeDir)
 //
@@ -158,15 +156,9 @@ func cronicleHostedAuth(rawURL string) *http.BasicAuth {
 //directory appearing on disk.
 func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, error) {
 
-	// When cronicled runs inside a cronicle platform pod and the URL is
-	// cronicle-hosted, auto-fill BasicAuth from CRONICLE_BEARER_TOKEN.
-	// The caller's auth wins if non-nil (e.g. SSH deploy key on a
-	// per-task repo block).
 	var effectiveAuth transport.AuthMethod
 	if auth != nil && *auth != nil {
 		effectiveAuth = *auth
-	} else if a := cronicleHostedAuth(url); a != nil {
-		effectiveAuth = a
 	}
 
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -122,6 +122,43 @@ func Commit(worktreeDir string, msg string) {
 	fmt.Println(obj)
 }
 
+// rewriteCronicleHostedURL maps a cronicle-hosted clone URL to the
+// cluster-internal cronicle-git Service URL when CRONICLE_INTERNAL_GIT_URL
+// is set. Lets the producer pod clone repos hosted on cronicle's own
+// git server without needing a PAT — the api proxy fronts external
+// traffic, but inside the cluster cronicle-git trusts requests directly.
+//
+// Hosted URLs look like:
+//
+//	https://api.triggerflux.dev/git/{org}/{repo}.git
+//	https://x:$CRONICLE_PAT@api.triggerflux.dev/git/{org}/{repo}.git
+//
+// Rewritten to:
+//
+//	http://cronicle-git.cronicle-platform.svc:8082/git/{org}/{repo}.git
+//
+// Recognition is path-based (contains "/git/" segment) rather than
+// host-pinned so dev / kind / future custom domains all work.
+func rewriteCronicleHostedURL(url string) string {
+	internal := os.Getenv("CRONICLE_INTERNAL_GIT_URL")
+	if internal == "" {
+		return url
+	}
+	// Strip scheme + userinfo to get host+path.
+	s := url
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if at := strings.LastIndex(s, "@"); at >= 0 {
+		s = s[at+1:]
+	}
+	// s is now "host/git/<org>/<repo>.git"
+	if i := strings.Index(s, "/git/"); i >= 0 {
+		return strings.TrimRight(internal, "/") + s[i:]
+	}
+	return url
+}
+
 //Clone checks for the existance of worktreeDir/.git and clones if it does not exist
 //then executes Git = GetGit(worktreeDir)
 //
@@ -132,6 +169,13 @@ func Commit(worktreeDir string, msg string) {
 func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, error) {
 
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {
+		// In-cluster rewrite: when cronicled runs inside a cronicle
+		// platform pod, CRONICLE_INTERNAL_GIT_URL points at the
+		// cluster-internal cronicle-git Service (no PAT auth required —
+		// the api proxy in front of cronicle-git is what gates external
+		// traffic). For URLs hosted on cronicle itself, route directly
+		// to the Service so the producer doesn't need a PAT.
+		url = rewriteCronicleHostedURL(url)
 		slog.Info("git clone", "url", url, "path", worktreeDir)
 		cloneOptions := git.CloneOptions{URL: url, Auth: *auth}
 		// In pretty mode, route go-git's progress sideband straight to

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -122,41 +123,30 @@ func Commit(worktreeDir string, msg string) {
 	fmt.Println(obj)
 }
 
-// rewriteCronicleHostedURL maps a cronicle-hosted clone URL to the
-// cluster-internal cronicle-git Service URL when CRONICLE_INTERNAL_GIT_URL
-// is set. Lets the producer pod clone repos hosted on cronicle's own
-// git server without needing a PAT — the api proxy fronts external
-// traffic, but inside the cluster cronicle-git trusts requests directly.
+// cronicleHostedAuth returns BasicAuth set up with the
+// CRONICLE_BEARER_TOKEN env (the platform-level service credential
+// producer + worker pods carry) when the URL is a cronicle-hosted
+// clone URL — recognized by containing "/git/" in the path. Returns
+// nil when the env isn't set or the URL isn't cronicle-hosted, which
+// is the dev/non-platform path.
 //
-// Hosted URLs look like:
+// The cronicle-git server (via the cronicle-api proxy in front of it)
+// accepts the infra-bearer in the Basic password slot as a valid auth
+// source for cronicle-hosted repos. The username is conventional only;
+// any non-empty string works.
 //
-//	https://api.cronicle.dev/git/{org}/{repo}.git
-//	https://x:$CRONICLE_PAT@api.cronicle.dev/git/{org}/{repo}.git
-//
-// Rewritten to:
-//
-//	http://cronicle-git.cronicle-platform.svc:8082/git/{org}/{repo}.git
-//
-// Recognition is path-based (contains "/git/" segment) rather than
-// host-pinned so dev / kind / future custom domains all work.
-func rewriteCronicleHostedURL(url string) string {
-	internal := os.Getenv("CRONICLE_INTERNAL_GIT_URL")
-	if internal == "" {
-		return url
+// This replaces the earlier URL-rewrite approach (rewriteCronicleHostedURL +
+// CRONICLE_INTERNAL_GIT_URL) with the simpler "auth like a normal git
+// remote" model — same shape as GitHub, just with a different token.
+func cronicleHostedAuth(rawURL string) *http.BasicAuth {
+	if !strings.Contains(rawURL, "/git/") {
+		return nil
 	}
-	// Strip scheme + userinfo to get host+path.
-	s := url
-	if i := strings.Index(s, "://"); i >= 0 {
-		s = s[i+3:]
+	token := os.Getenv("CRONICLE_BEARER_TOKEN")
+	if token == "" {
+		return nil
 	}
-	if at := strings.LastIndex(s, "@"); at >= 0 {
-		s = s[at+1:]
-	}
-	// s is now "host/git/<org>/<repo>.git"
-	if i := strings.Index(s, "/git/"); i >= 0 {
-		return strings.TrimRight(internal, "/") + s[i:]
-	}
-	return url
+	return &http.BasicAuth{Username: "cronicle", Password: token}
 }
 
 //Clone checks for the existance of worktreeDir/.git and clones if it does not exist
@@ -168,16 +158,20 @@ func rewriteCronicleHostedURL(url string) string {
 //directory appearing on disk.
 func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, error) {
 
+	// When cronicled runs inside a cronicle platform pod and the URL is
+	// cronicle-hosted, auto-fill BasicAuth from CRONICLE_BEARER_TOKEN.
+	// The caller's auth wins if non-nil (e.g. SSH deploy key on a
+	// per-task repo block).
+	var effectiveAuth transport.AuthMethod
+	if auth != nil && *auth != nil {
+		effectiveAuth = *auth
+	} else if a := cronicleHostedAuth(url); a != nil {
+		effectiveAuth = a
+	}
+
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {
-		// In-cluster rewrite: when cronicled runs inside a cronicle
-		// platform pod, CRONICLE_INTERNAL_GIT_URL points at the
-		// cluster-internal cronicle-git Service (no PAT auth required —
-		// the api proxy in front of cronicle-git is what gates external
-		// traffic). For URLs hosted on cronicle itself, route directly
-		// to the Service so the producer doesn't need a PAT.
-		url = rewriteCronicleHostedURL(url)
 		slog.Info("git clone", "url", url, "path", worktreeDir)
-		cloneOptions := git.CloneOptions{URL: url, Auth: *auth}
+		cloneOptions := git.CloneOptions{URL: url, Auth: effectiveAuth}
 		// In pretty mode, route go-git's progress sideband straight to
 		// stdout so the user sees the live "Counting objects" / "Receiving
 		// objects" lines (the same UX as the host `git` CLI). In file/Loki
@@ -199,8 +193,18 @@ func Clone(worktreeDir string, url string, auth *transport.AuthMethod) (Git, err
 		slog.Info("git open", "path", worktreeDir, "note", "worktree already exists, skipping clone")
 	}
 
+	// Stash the effective auth (caller-supplied OR auto-filled cronicle-
+	// hosted bearer) so Checkout's fetch uses the same credentials the
+	// Clone used. Without this, Checkout would fall back to the caller's
+	// nil auth and the fetch against a cronicle-hosted repo would 401.
+	var stored transport.AuthMethod
+	if effectiveAuth != nil {
+		stored = effectiveAuth
+	} else if auth != nil {
+		stored = *auth
+	}
 	var g Git
-	g.authMethod = auth
+	g.authMethod = &stored
 	if err := g.Open(worktreeDir); err != nil {
 		return g, err
 	}

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -16,6 +16,46 @@ import (
 	"log/slog"
 )
 
+// envContextVar builds the `env` namespace exposed to HCL eval —
+// a cty object whose attributes are the names of env vars currently
+// set, and whose values are their string values. `${env.FOO}` in any
+// HCL string field substitutes to os.Getenv("FOO"). Names not in the
+// process env are absent from the object; HCL will then return ""
+// for those references rather than erroring, which lets `repo {
+// password = "${env.X}" }` parse cleanly on a laptop where X isn't
+// set (worker pods that DO have X take the populated value).
+//
+// The snapshot is taken at call time, not at package init, so
+// RefreshEvalContext() picks up env changes made by long-running
+// processes (e.g. a controller that learns its bearer token after
+// startup) and by tests using t.Setenv.
+func envContextVar() cty.Value {
+	vars := map[string]cty.Value{}
+	for _, kv := range os.Environ() {
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				vars[kv[:i]] = cty.StringVal(kv[i+1:])
+				break
+			}
+		}
+	}
+	if len(vars) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(vars)
+}
+
+// RefreshEvalContext re-snapshots the `env` namespace on the package
+// CommandEvalContext using the current process env. ParseFile calls
+// this before decoding so a binary that mutates its env at runtime
+// (e.g. a controller that picks up a token from a Secret mount) sees
+// the fresh value. Tests that use t.Setenv + hclsimple.DecodeFile
+// directly should call this between the two so the new value is
+// visible during decode.
+func RefreshEvalContext() {
+	CommandEvalContext.Variables["env"] = envContextVar()
+}
+
 // HclWriteFile contains the encoded hclwrite.File and the byte array of the file with
 // the $$ deduped. This is due the the effect that when writing template arguments with
 // the hcl library an extra $ will be added automatically. i.e. "${date}" becomes "$${date}"
@@ -30,6 +70,15 @@ type HclWriteFile struct {
 var (
 	// CommandEvalContext hcl.EvalContext evaluates the "${date}" argument and carries it through
 	// as a string of the same form that will be used as an arugment later in the code.
+	//
+	// The `env` namespace is populated lazily by envContextVars() — see
+	// the var-initializer block below — so `${env.FOO}` in any HCL
+	// string field resolves to os.Getenv("FOO") at parse time. Used by
+	// repo { password = "${env.CRONICLE_TOKEN}" } to keep secrets out
+	// of HCL files. Missing env vars resolve to "" rather than erroring
+	// so HCL with unresolvable refs still parses (and the downstream
+	// "empty password ⇒ anonymous auth" branch handles the runtime
+	// case cleanly).
 	CommandEvalContext = hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"date":      cty.StringVal("${date}"),
@@ -44,6 +93,7 @@ var (
 			// Used in mcp { command = ["...", "${path}/data"] }
 			// patterns where the server needs a real filesystem path.
 			"path": cty.StringVal("${path}"),
+			"env":  envContextVar(),
 		},
 	}
 
@@ -113,6 +163,12 @@ func ParseBytes(src []byte, filename string, parser *hclparse.Parser) (*Config, 
 // shared by ParseFile and ParseBytes. Keeps the schema-evolution
 // surface in one place.
 func decodeConfigBody(body hcl.Body) (*Config, hcl.Diagnostics) {
+	// Refresh env vars exposed via ${env.X} from the current process env
+	// before each decode. Production binaries' env is typically static
+	// at startup, but the controller pod re-reads its bearer from a
+	// mounted Secret which can rotate, and tests using t.Setenv need
+	// the new value visible during decode.
+	RefreshEvalContext()
 	var diags hcl.Diagnostics
 	var conf Config
 	decodeDiags := gohcl.DecodeBody(body, &CommandEvalContext, &conf)

--- a/internal/cronicle/parse_test.go
+++ b/internal/cronicle/parse_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/jshiv/cronicle/internal/cronicle"
 
-	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsimple"
 
@@ -20,18 +19,20 @@ import (
 
 var _ = Describe("Parse", func() {
 
-	It("cronicle.CommandEvalContext should contain date, datetime, timestamp, scratch, and path as arguments", func() {
-
-		expected := hcl.EvalContext{
-			Variables: map[string]cty.Value{
-				"date":      cty.StringVal("${date}"),
-				"datetime":  cty.StringVal("${datetime}"),
-				"timestamp": cty.StringVal("${timestamp}"),
-				"scratch":   cty.StringVal("${scratch}"),
-				"path":      cty.StringVal("${path}"),
-			},
+	It("cronicle.CommandEvalContext should contain date, datetime, timestamp, scratch, path, and env as arguments", func() {
+		// Check the time/path tokens are present and exact. The `env`
+		// namespace is dynamic (it snapshots os.Environ at parse time,
+		// which differs across machines) so we assert it exists and is
+		// an object type rather than pinning its contents.
+		ctx := cronicle.CommandEvalContext
+		for _, key := range []string{"date", "datetime", "timestamp", "scratch", "path"} {
+			want := cty.StringVal("${" + key + "}")
+			Expect(ctx.Variables[key]).To(Equal(want))
 		}
-		Expect(cronicle.CommandEvalContext).To(Equal(expected))
+		env, ok := ctx.Variables["env"]
+		Expect(ok).To(BeTrue(), "env namespace must be present in CommandEvalContext")
+		Expect(env.Type().IsObjectType() || env.Type().Equals(cty.EmptyObject)).To(BeTrue(),
+			"env must be a cty Object so ${env.FOO} attribute access works")
 	})
 
 	It("cronicle.Config should be parsable given a date argument", func() {

--- a/internal/cronicle/repo_auth_test.go
+++ b/internal/cronicle/repo_auth_test.go
@@ -1,0 +1,117 @@
+package cronicle_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/hashicorp/hcl/v2/hclsimple"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+)
+
+// Repo.Auth resolves HTTP Basic auth from the password field, which is
+// the standard HCL string and so supports ${env.X} interpolation. These
+// tests pin the behaviour platform pods (worker + producer) and OSS git
+// hosts both depend on.
+
+func TestRepoAuth_BasicFromPasswordField(t *testing.T) {
+	r := &cronicle.Repo{
+		URL:      "https://api.cronicle.dev/git/foo/bar",
+		Username: "x",
+		Password: "infra-token-value",
+	}
+	auth, err := r.Auth()
+	if err != nil {
+		t.Fatalf("Auth: %v", err)
+	}
+	ba, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("got %T, want *http.BasicAuth", auth)
+	}
+	if ba.Username != "x" {
+		t.Errorf("Username = %q, want %q", ba.Username, "x")
+	}
+	if ba.Password != "infra-token-value" {
+		t.Errorf("Password = %q, want literal value", ba.Password)
+	}
+}
+
+func TestRepoAuth_UsernameDefaultsToX(t *testing.T) {
+	r := &cronicle.Repo{
+		URL:      "https://api.cronicle.dev/git/foo/bar",
+		Password: "tok",
+	}
+	auth, err := r.Auth()
+	if err != nil {
+		t.Fatalf("Auth: %v", err)
+	}
+	ba := auth.(*http.BasicAuth)
+	if ba.Username != "x" {
+		t.Errorf("Username = %q, want default %q", ba.Username, "x")
+	}
+}
+
+func TestRepoAuth_NilWhenAnonymous(t *testing.T) {
+	r := &cronicle.Repo{URL: "https://github.com/jshiv/cronicle-sample.git"}
+	auth, err := r.Auth()
+	if err != nil {
+		t.Fatalf("Auth: %v", err)
+	}
+	if auth != nil {
+		t.Errorf("Auth = %v, want nil for anonymous", auth)
+	}
+}
+
+// Pins the ${env.X} interpolation flow end-to-end: an HCL string with
+// ${env.CRONICLE_TOKEN} parses to the env var's runtime value, and
+// Repo.Auth then surfaces it as HTTP Basic auth. This is the canonical
+// shape we want users (and Claude-generated HCL) to write.
+func TestRepoAuth_EnvInterpolationInPassword(t *testing.T) {
+	t.Setenv("CRONICLE_TOKEN", "interpolated-secret")
+	// Re-snapshot the eval context's env namespace so t.Setenv above is
+	// visible to gohcl. Production code calls this inside ParseFile /
+	// ParseBytes; this test goes through hclsimple directly so it has
+	// to refresh explicitly.
+	cronicle.RefreshEvalContext()
+
+	hcl := `
+schedule "s" {
+  cron = ""
+  task "t" {
+    command = ["echo", "x"]
+    repo {
+      url      = "https://api.cronicle.dev/git/foo/bar"
+      password = "${env.CRONICLE_TOKEN}"
+    }
+  }
+}
+`
+	var conf cronicle.Config
+	tmp := t.TempDir() + "/c.hcl"
+	if err := writeFile(tmp, hcl); err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+	if err := hclsimple.DecodeFile(tmp, &cronicle.CommandEvalContext, &conf); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	r := conf.Schedules[0].Tasks[0].Repo
+	if r == nil {
+		t.Fatal("Repo nil after decode")
+	}
+	if r.Password != "interpolated-secret" {
+		t.Fatalf("Password after parse = %q, want %q (env interpolation didn't fire)", r.Password, "interpolated-secret")
+	}
+	auth, err := r.Auth()
+	if err != nil {
+		t.Fatalf("Auth: %v", err)
+	}
+	ba := auth.(*http.BasicAuth)
+	if ba.Password != "interpolated-secret" {
+		t.Errorf("Auth password = %q, want %q", ba.Password, "interpolated-secret")
+	}
+}
+
+func writeFile(path, body string) error {
+	return os.WriteFile(path, []byte(body), 0o644)
+}


### PR DESCRIPTION
Replaces the URL-rewrite workaround (`rewriteCronicleHostedURL` + `CRONICLE_INTERNAL_GIT_URL`) with the simpler "auth like a normal git remote" model. Producer/worker pods authenticate with the platform service bearer they already carry (`CRONICLE_BEARER_TOKEN`).

Companion PR on cronicle-infra teaches the api proxy to accept that bearer.

Bonus: re-lands the worker stale-checkout fix (originally PR #113, closed in favor of this combined refactor) — schedule-level repos now fetch+checkout on every task exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)