### PR TITLE
fix(git): handle non-empty workdir on clone (go-git v6)

### DIFF
--- a/internal/cronicle/clone_integration_test.go
+++ b/internal/cronicle/clone_integration_test.go
@@ -1,0 +1,136 @@
+package cronicle_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+)
+
+// TestClone_NonEmptyDir verifies Clone succeeds when the target
+// directory already has files (e.g. cronicled writes cronicle.hcl
+// before cronicle run starts). go-git v6 rejects PlainClone into
+// non-empty dirs; Clone handles this via init + fetch.
+func TestClone_NonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-populate with a file (simulates cronicled writing HCL)
+	if err := os.WriteFile(filepath.Join(dir, "cronicle.hcl"), []byte("# placeholder"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := (&cronicle.Repo{URL: "https://github.com/jshiv/cronicle-sample.git"}).Auth()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := cronicle.Clone(dir, "https://github.com/jshiv/cronicle-sample.git", opts)
+	if err != nil {
+		t.Fatalf("Clone into non-empty dir failed: %v", err)
+	}
+
+	// Verify repo is functional
+	if g.Head == nil {
+		t.Fatal("Head is nil after clone")
+	}
+	if !cronicle.DirExists(filepath.Join(dir, ".git")) {
+		t.Fatal(".git directory not created")
+	}
+
+	// Verify original file still exists (not clobbered)
+	if _, err := os.Stat(filepath.Join(dir, "cronicle.hcl")); err != nil {
+		t.Fatalf("pre-existing file was removed: %v", err)
+	}
+}
+
+// TestClone_EmptyDir verifies Clone still works with an empty dir
+// (the normal PlainClone path).
+func TestClone_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	opts, err := (&cronicle.Repo{URL: "https://github.com/jshiv/cronicle-sample.git"}).Auth()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := cronicle.Clone(dir, "https://github.com/jshiv/cronicle-sample.git", opts)
+	if err != nil {
+		t.Fatalf("Clone into empty dir failed: %v", err)
+	}
+
+	if g.Head == nil {
+		t.Fatal("Head is nil after clone")
+	}
+}
+
+// TestScratch_SurvivesCheckout verifies that files written to
+// .cronicle/ persist across a Force:true checkout. This is the
+// inter-task artifact passing mechanism — upstream tasks write to
+// ${scratch}, downstream tasks read from it.
+func TestScratch_SurvivesCheckout(t *testing.T) {
+	dir := t.TempDir()
+
+	opts, err := (&cronicle.Repo{URL: "https://github.com/jshiv/cronicle-sample.git"}).Auth()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := cronicle.Clone(dir, "https://github.com/jshiv/cronicle-sample.git", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a file to .cronicle/scratch (simulates task output)
+	scratchDir := filepath.Join(dir, ".cronicle", "scratch")
+	if err := os.MkdirAll(scratchDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(scratchDir, "data.txt")
+	if err := os.WriteFile(sentinel, []byte("task-output"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force checkout (same branch — simulates the per-task checkout)
+	if err := g.Checkout("master", ""); err != nil {
+		t.Fatalf("Checkout failed: %v", err)
+	}
+
+	// Verify sentinel survived
+	data, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf(".cronicle/scratch/data.txt was wiped by checkout: %v", err)
+	}
+	if string(data) != "task-output" {
+		t.Fatalf("got %q, want %q", string(data), "task-output")
+	}
+}
+
+// TestClone_NonEmptyDir_WithSSH verifies Clone into a non-empty
+// directory works with SSH auth (deploy key).
+func TestClone_NonEmptyDir_WithSSH(t *testing.T) {
+	if testSSHAddr == "" {
+		t.Skip("SSH test server not available")
+	}
+
+	dir := t.TempDir()
+	// Pre-populate
+	if err := os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sshURL := "ssh://git@" + testSSHAddr + "/test_repo"
+	repo := cronicle.Repo{URL: sshURL, DeployKey: "./test/test_deploy_key"}
+	opts, err := repo.Auth()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := cronicle.Clone(dir, sshURL, opts)
+	if err != nil {
+		t.Fatalf("SSH Clone into non-empty dir failed: %v", err)
+	}
+	if g.Head == nil {
+		t.Fatal("Head is nil after SSH clone")
+	}
+}

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -172,10 +172,56 @@ func Clone(worktreeDir string, url string, opts []client.Option) (Git, error) {
 			cloneOptions.Progress = os.Stdout
 		}
 
-		_, err := git.PlainClone(worktreeDir, &cloneOptions)
-		if err != nil {
-			slog.Error("git clone failed", "url", url, "path", worktreeDir, "error", err.Error())
-			return Git{}, err
+		// go-git v6 rejects PlainClone into non-empty dirs. When the
+		// workdir has files (e.g. cronicled writes cronicle.hcl before
+		// exec), init + add remote + fetch instead.
+		empty, _ := isDirEmpty(worktreeDir)
+		if !empty {
+			if _, err := git.PlainInit(worktreeDir, false); err != nil {
+				slog.Error("git init failed", "path", worktreeDir, "error", err.Error())
+				return Git{}, err
+			}
+			r, err := git.PlainOpen(worktreeDir)
+			if err != nil {
+				return Git{}, err
+			}
+			if _, err := r.CreateRemote(&c.RemoteConfig{
+				Name: "origin",
+				URLs: []string{url},
+			}); err != nil {
+				return Git{}, err
+			}
+			if err := r.Fetch(&git.FetchOptions{
+				RemoteName:    "origin",
+				ClientOptions: opts,
+			}); err != nil {
+				slog.Error("git fetch failed", "url", url, "path", worktreeDir, "error", err.Error())
+				return Git{}, err
+			}
+			// After init+fetch, HEAD is unborn. Point it at the remote's
+			// default branch and checkout so the worktree is populated.
+			wt, err := r.Worktree()
+			if err != nil {
+				return Git{}, err
+			}
+			if err := wt.Checkout(&git.CheckoutOptions{
+				Branch: plumbing.NewRemoteReferenceName("origin", "master"),
+				Force:  true,
+			}); err != nil {
+				// Try "main" if "master" doesn't exist
+				if err2 := wt.Checkout(&git.CheckoutOptions{
+					Branch: plumbing.NewRemoteReferenceName("origin", "main"),
+					Force:  true,
+				}); err2 != nil {
+					return Git{}, fmt.Errorf("checkout after init+fetch: %w (also tried main: %v)", err, err2)
+				}
+			}
+		} else {
+			_, err := git.PlainClone(worktreeDir, &cloneOptions)
+			if err != nil {
+				slog.Error("git clone failed", "url", url, "path", worktreeDir, "error", err.Error())
+				return Git{}, err
+			}
 		}
 		slog.Info("git clone complete", "url", url, "path", worktreeDir)
 	} else {

--- a/internal/cronicle/init.go
+++ b/internal/cronicle/init.go
@@ -247,6 +247,18 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
+// isDirEmpty returns true if the directory is empty or doesn't exist.
+func isDirEmpty(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
 // DirExists checks that a directory exists.
 func DirExists(dirname string) bool {
 	info, err := os.Stat(dirname)


### PR DESCRIPTION
## Summary
go-git v6 `PlainClone` rejects non-empty directories (v5 allowed it). When `cronicled` writes `cronicle.hcl` to `/work` before `cronicle run`, the clone fails with `ErrTargetDirNotEmpty`.

Fix: detect non-empty dir → `PlainInit` + `CreateRemote` + `Fetch` + `Checkout` instead of `PlainClone`.

## Integration tests added
- `TestClone_NonEmptyDir` — HTTPS clone into dir with pre-existing files
- `TestClone_EmptyDir` — normal PlainClone path still works
- `TestScratch_SurvivesCheckout` — `.cronicle/scratch` persists through Force:true checkout
- `TestClone_NonEmptyDir_WithSSH` — non-empty clone with deploy key auth

## Test results
```
ok  github.com/jshiv/cronicle/internal/cronicle          6.656s
ok  github.com/jshiv/cronicle/internal/cronicle/configsource   0.412s
ok  github.com/jshiv/cronicle/internal/cronicle/secretsource   0.605s
ok  github.com/jshiv/cronicle/internal/cronicle/secretstore    0.780s
ok  github.com/jshiv/cronicle/internal/cronicle/state          1.111s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)