### PR TITLE
fix: fork anthropic-sdk-go to fix web tool ToParam() bugs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,3 +103,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/anthropics/anthropic-sdk-go => github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260527141030-38784e7cad48

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/anthropics/anthropic-sdk-go v1.45.0 h1:rWnpyBpm9OAm97jyH5bi6W4SRCwJeNY/RyhaJ7CHSUI=
-github.com/anthropics/anthropic-sdk-go v1.45.0/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -129,6 +127,8 @@ github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260527141030-38784e7cad48 h1:QXa+rnDc6Fu6M1rQKilhFj80pIbhOwi4SJ7STH8FYNg=
+github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260527141030-38784e7cad48/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=


### PR DESCRIPTION
## Summary
- Adds a `replace` directive in go.mod pointing to [jshiv/anthropic-sdk-go@fix/toparam-web-tools](https://github.com/jshiv/anthropic-sdk-go/tree/fix/toparam-web-tools)
- Fixes `WebFetchToolResultBlock.ToParam()` which was dropping `Content` and `Caller` fields
- Fixes `WebSearchToolResultBlock.ToParam()` which was dropping the `Caller` field
- Upstream issue: https://github.com/anthropics/anthropic-sdk-go/issues/346
- Companion PR: https://github.com/jshiv/cronicle-infra/pull/66

## Context
The morning briefing agent uses `web_search` and fails on multi-turn conversations. This is the `cronicle` binary that runs in the worker pod — it needs the same fork as cronicle-infra.

## Test plan
- [x] `go build ./...` compiles clean
- [ ] Deploy and verify morning briefing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)