### PR TITLE
fix(git): restore 'clean untracked' behavior dropped in v5→v6 migration

### DIFF
--- a/internal/cronicle/clone_integration_test.go
+++ b/internal/cronicle/clone_integration_test.go
@@ -106,6 +106,61 @@ func TestScratch_SurvivesCheckout(t *testing.T) {
 	}
 }
 
+// TestCheckout_CleansUntrackedFiles verifies that Checkout removes
+// untracked files outside the .cronicle/ exclusion. This is the
+// `git reset --hard && git clean -fd` semantic the v5 fork used to
+// provide via a patched HardReset; the v6 native Checkout doesn't
+// do the clean step, so we restore it explicitly in (g *Git).Checkout.
+//
+// Regression caught in the wild: after the v5→v6 migration, untracked
+// files inside the worktree (e.g. files written by a previous task
+// that didn't land in .cronicle/scratch) were accumulating across
+// runs and drifting the worktree from the repo state.
+func TestCheckout_CleansUntrackedFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	opts, err := (&cronicle.Repo{URL: "https://github.com/jshiv/cronicle-sample.git"}).Auth()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := cronicle.Clone(dir, "https://github.com/jshiv/cronicle-sample.git", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop an untracked file in the repo root (NOT in .cronicle/).
+	stray := filepath.Join(dir, "stray.txt")
+	if err := os.WriteFile(stray, []byte("untracked"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force checkout — should clean stray.txt
+	if err := g.Checkout("master", ""); err != nil {
+		t.Fatalf("Checkout failed: %v", err)
+	}
+
+	if _, err := os.Stat(stray); !os.IsNotExist(err) {
+		t.Fatalf("stray.txt should have been cleaned by Checkout; err=%v", err)
+	}
+
+	// Sanity: also verify .cronicle/ still survives in the same call
+	scratchDir := filepath.Join(dir, ".cronicle", "scratch")
+	if err := os.MkdirAll(scratchDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(scratchDir, "data.txt")
+	if err := os.WriteFile(sentinel, []byte("task-output"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Checkout("master", ""); err != nil {
+		t.Fatalf("second Checkout failed: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf(".cronicle/scratch should survive clean; err=%v", err)
+	}
+}
+
 // TestClone_NonEmptyDir_WithSSH verifies Clone into a non-empty
 // directory works with SSH auth (deploy key).
 func TestClone_NonEmptyDir_WithSSH(t *testing.T) {

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -300,6 +300,21 @@ func (g *Git) Checkout(branch string, commit string) error {
 		return err
 	}
 
+	// Checkout(Force:true) does a HardReset which restores tracked
+	// files but leaves untracked ones behind. Real `git reset --hard`
+	// doesn't clean either — you need `git clean -fd` for that. The
+	// v5 fork patched HardReset to also clean; v6 native doesn't, so
+	// we restore the behavior explicitly here.
+	//
+	// Clean honors Worktree.Excludes (set in Open() to include
+	// .cronicle), so per-run scratch dirs and the worker's local
+	// state survive checkout. Without this call, untracked files in
+	// a sub-repo accumulate across runs and the worktree drifts from
+	// the repo state.
+	if err := g.Worktree.Clean(&git.CleanOptions{Dir: true}); err != nil {
+		slog.Warn("git clean failed", "error", err.Error())
+	}
+
 	//Set head and commit state after checkout branch/commit
 	g.Head, err = g.Repository.Head()
 	if err != nil {


### PR DESCRIPTION
## Bug
After the go-git v5→v6 migration (#117), untracked files in a sub-repo were no longer being cleaned up on Checkout. The v5 fork patched HardReset to clean (respecting Worktree.Excludes); v6's native Checkout only does the reset half.

## Fix
Add an explicit \`Worktree.Clean(Dir: true)\` after Checkout. It honors the same Excludes that Open() sets (\`.cronicle\`), so per-run scratch dirs survive while untracked files in the repo root get cleaned.

This matches real git semantics: \`git reset --hard\` doesn't remove untracked files — you need \`git clean -fd\` for that. The combo is what most \"clean checkout\" workflows do.

## Test
New \`TestCheckout_CleansUntrackedFiles\` verifies:
- A stray file in the repo root IS cleaned by Checkout
- \`.cronicle/scratch\` IS preserved across the same Checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)