### PR TITLE
fix: bump anthropic-sdk-go fork to complete multi-turn ToParam fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,4 +104,4 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-replace github.com/anthropics/anthropic-sdk-go => github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260527151002-739a8b136dd1
+replace github.com/anthropics/anthropic-sdk-go => github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260529110403-ee8571291242

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260527151002-739a8b136dd1 h1:tJbse1yyIIt446n5BzCDeI3uM1IVxR6albQ7fmddzN0=
-github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260527151002-739a8b136dd1/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
+github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260529110403-ee8571291242 h1:T6wSLA5Vrl0gdvVVcsD14vLWBm9356Bs8OLhU6vnplM=
+github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260529110403-ee8571291242/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=


### PR DESCRIPTION
## Problem
Multi-turn agent steps were 400ing on the second API call:
- `messages.1.content.0.tool_use.citations: Extra inputs are not permitted`
- `messages.1.content.0.text.signature: Extra inputs are not permitted`

Root cause: `go.mod` pinned fork commit `151002`, whose `ContentBlockUnion.ToParam()` applied **blanket** raw-JSON passthrough to *every* content block. That re-emits response-only fields (`citations` on `tool_use`, `signature` on `text`/`thinking`) onto **input** params on turn 2+, which the API rejects. Single-turn agents (daily-haiku, job-scout) were unaffected because they never replay a turn.

This is the unfinished half of upstream [anthropics/anthropic-sdk-go#346](https://github.com/anthropics/anthropic-sdk-go/issues/346).

## Fix
Pin to fork commit [`ee857129`](https://github.com/jshiv/anthropic-sdk-go/commit/ee857129124259e8ab82445229b57e38d0e5f8ff) on `fix/toparam-web-tools`, which makes `ContentBlockUnion.ToParam` raw-pass **only**:
- `web_search_tool_result` / `web_fetch_tool_result` blocks, and
- `text` blocks that **cite** web_search results (typed conversion drops the citation `url`/`encrypted_index` → `web_search_result_location.url: ...not 0`).

Everything else uses typed conversion (no extra fields).

### Why not upstream v1.46.0?
v1.46.0 does **not** fix this — its `ContentBlockUnion.ToParam` is pure typed conversion (no raw passthrough), so #346's `web_search_tool_result` content drop is still present *and* the citation `url` is still dropped. The 1.46 changes are streaming-accumulator fixes, not `ToParam`. We still need the fork.

## Verification
`go test ./pkg/agent/ -run TestWebSearchMultiTurnRoundTrip` — **passes** against the pinned remote commit (real API, turn 2 succeeds). Previously failed with `text.signature`/`tool_use.citations` (151002) and `web_search_result_location.url` (intermediate 153458).

Note: an image rebuild + worker redeploy is required for this to take effect on running deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)