### PR TITLE
fix(last_run): resolve ${last_run} on the producer at enqueue, not on workers

### DIFF
--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -118,7 +118,11 @@ type Task struct {
 	// Survives the run for transcript/audit access.
 	ScratchDir string
 	// LastRun is the start time of this schedule's previous SUCCESSFUL
-	// run, looked up from the state backend by ExecuteTasks. Substituted
+	// run. Resolved by the dispatcher (resolveLastRun) against the
+	// authoritative state store before ExecuteTasks runs — the producer
+	// at enqueue, or the in-process ConsumeSchedule / ExecTasks paths.
+	// ExecuteTasks never reads state for it (it also runs on distributed
+	// workers, whose store has no run history). Substituted
 	// into commands/prompts as `${last_run}` (RFC3339) and
 	// `${last_run_epoch}` (unix seconds) so a task can fetch only what's
 	// new "since the prior run" instead of guessing a lookback window.

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -348,6 +348,10 @@ func ConsumeSchedule(queue <-chan []byte, path string, wg *sync.WaitGroup) {
 				slog.Error("schedule unmarshal failed", "error", err.Error())
 			}
 			schedule.PropigateTaskProperties(p)
+			// In-process dispatch (non-queue, single-node): resolve
+			// ${last_run} here, where StateStore() is the authoritative
+			// store, before ExecuteTasks (which never reads state itself).
+			resolveLastRun(StateStore(), &schedule)
 			schedule.ExecuteTasks()
 		}(scheduleBytes)
 	}
@@ -486,8 +490,11 @@ func ExecTasks(cronicleFile string, taskName string, scheduleName string, now ti
 			}
 		} else {
 			schedule.Now = nowInLoc
-		schedule.RunID = newRunID()
-		schedule.Source = "exec"
+			schedule.RunID = newRunID()
+			schedule.Source = "exec"
+			// Foreground one-shot dispatch: resolve ${last_run} from the
+			// authoritative store before ExecuteTasks (which never reads it).
+			resolveLastRun(StateStore(), &schedule)
 			schedule.ExecuteTasks()
 		}
 	}

--- a/internal/cronicle/dag.go
+++ b/internal/cronicle/dag.go
@@ -16,8 +16,12 @@ import (
 // SUCCEEDED run of the named schedule, excluding the in-flight run.
 // Best-effort: ok=false when there's no state backend, no prior success,
 // or the query errors — callers treat that as "no prior run".
-func lastSuccessfulRunStart(schedule, currentRunID string) (time.Time, bool) {
-	st := StateStore()
+//
+// The store is passed in explicitly so the producer resolves ${last_run}
+// against its authoritative state backend at enqueue time (enqueueAdapter)
+// — never the worker, whose local store is a non-authoritative in-memory
+// projection. See Schedule.LastRunResolved.
+func lastSuccessfulRunStart(st state.Backend, schedule, currentRunID string) (time.Time, bool) {
 	if st == nil {
 		return time.Time{}, false
 	}
@@ -34,6 +38,26 @@ func lastSuccessfulRunStart(schedule, currentRunID string) (time.Time, bool) {
 		return r.StartedAt, true
 	}
 	return time.Time{}, false
+}
+
+// resolveLastRun stamps every task's LastRun with the schedule's previous
+// successful run start, read from the authoritative state store st.
+//
+// Call this at DISPATCH time — the producer's enqueueAdapter, or the
+// in-process ConsumeSchedule / ExecTasks paths — so the value is baked
+// before ExecuteTasks runs. ExecuteTasks must NOT resolve ${last_run}
+// itself: it also runs on distributed workers, where StateStore() is a
+// non-authoritative in-memory projection with no run history. Resolving
+// only at dispatch keeps the producer the single source of truth.
+//
+// Best-effort: a miss (no prior run, no/again-unavailable store) leaves
+// LastRun zero → ${last_run} empty → "full backfill".
+func resolveLastRun(st state.Backend, sch *Schedule) {
+	if lastRun, ok := lastSuccessfulRunStart(st, sch.Name, sch.RunID); ok {
+		for i := range sch.Tasks {
+			sch.Tasks[i].LastRun = lastRun
+		}
+	}
 }
 
 // ExecuteTasks executes all tasks in dependency order, running independent tasks concurrently.
@@ -84,16 +108,13 @@ func (schedule Schedule) ExecuteTasks() {
 		}
 	}
 
-	// Last successful run start, surfaced to tasks as ${last_run} /
-	// ${last_run_epoch} so "incremental since last run" jobs read the
-	// real boundary instead of guessing a lookback window. Best-effort:
-	// zero (→ empty token) on the first run or when state is unavailable.
-	if lastRun, ok := lastSuccessfulRunStart(schedule.Name, schedule.RunID); ok {
-		for name, t := range taskMap {
-			t.LastRun = lastRun
-			taskMap[name] = t
-		}
-	}
+	// ${last_run} / ${last_run_epoch} come straight from task.LastRun,
+	// which the DISPATCHER already resolved (resolveLastRun) — the producer
+	// at enqueue, or the in-process ConsumeSchedule / ExecTasks paths.
+	// ExecuteTasks itself never reads state for this: it also runs on
+	// distributed workers, whose StateStore() is a non-authoritative
+	// in-memory projection with no run history. Empty → ${last_run} empty
+	// → "no prior run / full backfill".
 
 	startedAt := time.Now()
 	startAttrs := []any{

--- a/internal/cronicle/dag_lastrun_test.go
+++ b/internal/cronicle/dag_lastrun_test.go
@@ -1,0 +1,100 @@
+package cronicle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// writeLastRunTask returns a task that records the substituted ${last_run}
+// token to outFile, so a test can assert what value ExecuteTasks fed the
+// task without scraping logs.
+func writeLastRunTask(outFile string) Task {
+	return Task{
+		Name:    "t1",
+		Command: []string{"bash", "-c", `printf '%s' "${last_run}" > ` + outFile},
+	}
+}
+
+// withStaleStore points the process-wide StateStore at store for the
+// duration of the test, restoring the prior store afterward. Simulates a
+// worker whose local store is NOT the authoritative one the dispatcher used.
+func withStaleStore(t *testing.T, store state.Backend) {
+	t.Helper()
+	prev := StateStore()
+	SetStateStore(store)
+	t.Cleanup(func() { SetStateStore(prev) })
+}
+
+// TestExecuteTasks_NeverReadsStateForLastRun is the worker-side half of the
+// ${last_run} contract: ExecuteTasks must use the baked Task.LastRun as-is
+// and NEVER read StateStore() itself. This is the exact regression that
+// shipped in #126 — on a distributed worker StateStore() is a
+// non-authoritative in-memory projection with no run history, so reading it
+// would clobber the dispatcher-resolved value with an empty/wrong one.
+func TestExecuteTasks_NeverReadsStateForLastRun(t *testing.T) {
+	// A store holding a DIFFERENT "succeeded" run that ExecuteTasks must
+	// ignore: the value was already resolved upstream and baked into the
+	// task. (Stands in for a worker's non-authoritative local store.)
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	staleStoreTime := time.Now().Add(-99 * time.Hour).Truncate(time.Second)
+	seedRun(t, store, "RX", "daily", "succeeded", staleStoreTime)
+	withStaleStore(t, store)
+
+	out := filepath.Join(t.TempDir(), "last_run.txt")
+	baked := time.Now().Add(-26 * time.Hour).Truncate(time.Second)
+
+	task := writeLastRunTask(out)
+	task.LastRun = baked // already resolved by the dispatcher
+	sch := Schedule{Name: "daily", RunID: "R2", Tasks: []Task{task}}
+	sch.ExecuteTasks()
+
+	got := readFile(t, out)
+	want := baked.UTC().Format(time.RFC3339)
+	if got != want {
+		t.Errorf("${last_run} = %q, want the baked %q (ExecuteTasks read the store: %q)",
+			got, want, staleStoreTime.UTC().Format(time.RFC3339))
+	}
+}
+
+// TestResolveLastRun_FeedsExecuteTasks covers the dispatch side for the
+// in-process paths (legacy ConsumeSchedule, foreground exec): resolveLastRun
+// reads the authoritative store and stamps Task.LastRun before ExecuteTasks,
+// which then substitutes it into ${last_run}.
+func TestResolveLastRun_FeedsExecuteTasks(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	prior := time.Now().Add(-26 * time.Hour).Truncate(time.Second)
+	seedRun(t, store, "R1", "daily", "succeeded", prior)
+
+	out := filepath.Join(t.TempDir(), "last_run.txt")
+	sch := Schedule{Name: "daily", RunID: "R2", Tasks: []Task{writeLastRunTask(out)}}
+
+	resolveLastRun(store, &sch) // dispatch-time resolution
+	sch.ExecuteTasks()
+
+	got := readFile(t, out)
+	want := prior.UTC().Format(time.RFC3339)
+	if got != want {
+		t.Errorf("${last_run} = %q, want %q resolved from the authoritative store", got, want)
+	}
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(b)
+}

--- a/internal/cronicle/queue_lastrun_test.go
+++ b/internal/cronicle/queue_lastrun_test.go
@@ -1,0 +1,90 @@
+package cronicle
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// drainEnqueue pushes one payload through enqueueAdapter synchronously:
+// send, close, then run the adapter (which ranges until the channel is
+// closed and returns). The resolved job is then claimable from store.
+func drainEnqueue(store state.Backend, payload []byte) {
+	in := make(chan []byte, 1)
+	in <- payload
+	close(in)
+	enqueueAdapter(in, store)
+}
+
+// TestEnqueueAdapter_ResolvesLastRunOnProducer locks in the producer-side
+// resolution of ${last_run}: enqueueAdapter must read the authoritative
+// store and bake the prior successful run's start into each Task.LastRun
+// in the payload, so the worker executes from a fully-resolved job.
+func TestEnqueueAdapter_ResolvesLastRunOnProducer(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	// A prior successful run of "daily" — the boundary ${last_run} should
+	// resolve to.
+	prior := time.Now().Add(-26 * time.Hour).Truncate(time.Second)
+	seedRun(t, store, "R1", "daily", "succeeded", prior)
+
+	sch := Schedule{
+		Name:  "daily",
+		RunID: "R2",
+		Tasks: []Task{{Name: "t1", Command: []string{"/bin/echo", "${last_run}"}}},
+	}
+	drainEnqueue(store, sch.JSON())
+
+	job, err := store.Claim("W1", time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	var got Schedule
+	if err := json.Unmarshal(job.Payload, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+
+	if len(got.Tasks) != 1 {
+		t.Fatalf("tasks = %d, want 1", len(got.Tasks))
+	}
+	if !got.Tasks[0].LastRun.Equal(prior) {
+		t.Errorf("Task.LastRun = %v, want %v", got.Tasks[0].LastRun, prior)
+	}
+}
+
+// TestEnqueueAdapter_NoPriorRunLeavesLastRunZero: with no prior success,
+// LastRun stays zero (→ ${last_run} empty → "full backfill"). The worker
+// consumes that value as-is and never reads its own store.
+func TestEnqueueAdapter_NoPriorRunLeavesLastRunZero(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	sch := Schedule{
+		Name:  "fresh",
+		RunID: "R1",
+		Tasks: []Task{{Name: "t1", Command: []string{"/bin/echo", "${last_run}"}}},
+	}
+	drainEnqueue(store, sch.JSON())
+
+	job, err := store.Claim("W1", time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	var got Schedule
+	if err := json.Unmarshal(job.Payload, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+
+	if !got.Tasks[0].LastRun.IsZero() {
+		t.Errorf("Task.LastRun = %v, want zero on first run", got.Tasks[0].LastRun)
+	}
+}

--- a/internal/cronicle/queue_self.go
+++ b/internal/cronicle/queue_self.go
@@ -36,8 +36,15 @@ func enqueueAdapter(in <-chan []byte, store state.Backend) {
 			// stamp RunID before queueing. Defensive: synthesize one
 			// rather than dropping the run.
 			sch.RunID = newRunID()
-			payload, _ = json.Marshal(sch)
 		}
+		// Resolve ${last_run} HERE, on the producer, against the
+		// authoritative state store, and bake it into the payload. The
+		// worker that later claims this job (single-node self-worker or a
+		// distributed HTTP worker) executes from the fully-resolved payload
+		// and never reads state itself — its local store is a
+		// non-authoritative in-memory projection with no run history.
+		resolveLastRun(store, &sch)
+		payload, _ = json.Marshal(sch)
 		if err := store.Enqueue(sch.RunID, sch.Name, payload); err != nil {
 			slog.Error("self-queue: enqueue failed", "run_id", sch.RunID, "error", err.Error())
 		}


### PR DESCRIPTION
## Problem
`${last_run}` / `${last_run_epoch}` (#126) resolved the prior successful run **inside `ExecuteTasks`** via the process-wide `StateStore()`. That's correct in single-node mode, but `ExecuteTasks` also runs on the **distributed HTTP worker**, whose `StateStore()` is a non-authoritative in-memory projection:

```go
// worker_http.go — StartHTTPWorker
EnableStateStore(":memory:")  // local projection, no run history
```

So `lastSuccessfulRunStart` queried an empty store, always missed, and `${last_run}` silently resolved to empty on every run in prod — the feature never engaged; jobs just fell back to a hardcoded lookback window.

## Fix — resolve at dispatch, keep `ExecuteTasks` pure
Resolution is now a **dispatch-time** concern, and `ExecuteTasks` is a pure function of the payload: it substitutes `Task.LastRun` and **never reads state** for this token.

- `resolveLastRun(store, *Schedule)` stamps `Task.LastRun` from the authoritative store. Called by whoever dispatches a schedule:
  - **producer** at enqueue (`enqueueAdapter`) for the queue path → the value rides in the job payload to the worker
  - the **in-process** `ConsumeSchedule` (legacy single-node) and `ExecTasks` (foreground `exec`) paths, where `StateStore()` *is* authoritative
- The worker simply reads the baked `Task.LastRun`; empty → `${last_run}` empty → full backfill.
- `lastSuccessfulRunStart` takes an explicit `state.Backend` (no reliance on the global on the worker side).

No `LastRunResolved` flag, no ambiguity — a zero `LastRun` unambiguously means "no prior run" because it's always resolved before `ExecuteTasks`. This matches how secrets, pause/drain, and the queue already treat the producer as the single source of truth: the worker is a pure executor that never reads shared state.

## Tests
- `queue_lastrun_test.go` — `enqueueAdapter` bakes the prior-run boundary into the payload (incl. the no-prior-run case).
- `dag_lastrun_test.go` — `ExecuteTasks` never reads state for `${last_run}` (baked value wins even with a stale store set — the exact regression); `resolveLastRun` feeds the in-process dispatch paths.
- Full `internal/cronicle` suite green. Verified both the producer-side and e2e (#128) tests fail when `resolveLastRun` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)