### PR TITLE
[prototype/RFC] Route the in-process self-worker through the HTTP pathway

### DIFF
--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -102,7 +102,7 @@ func Run(ctx context.Context, cronicleFile string, runOptions RunOptions) {
 		go enqueueAdapter(enqueueChan, stateStore)
 		go StartCron(ctx, cronicleFileAbs, enqueueChan)
 		if runOptions.RunWorker {
-			go selfWorker(ctx, stateStore, croniclePath, &wg)
+			go selfWorker(ctx, loopbackURL(runOptions.ListenAddr), runOptions.ListenToken, croniclePath, &wg)
 		}
 		go reaperLoop(ctx, stateStore)
 	} else {

--- a/internal/cronicle/cron_source.go
+++ b/internal/cronicle/cron_source.go
@@ -113,7 +113,7 @@ func RunFromSource(ctx context.Context, spec, workdir string, runOptions RunOpti
 			return fmt.Errorf("scheduler start: %w", err)
 		}
 		if runOptions.RunWorker {
-			go selfWorker(ctx, stateStore, workdirAbs, &wg)
+			go selfWorker(ctx, loopbackURL(runOptions.ListenAddr), runOptions.ListenToken, workdirAbs, &wg)
 		}
 		go reaperLoop(ctx, stateStore)
 	} else {

--- a/internal/cronicle/queue_self.go
+++ b/internal/cronicle/queue_self.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -44,76 +45,45 @@ func enqueueAdapter(in <-chan []byte, store state.Backend) {
 	}
 }
 
-// selfWorker is the in-process consumer for --queue self mode. Claims
-// jobs from the SQLite store, hands the payload to the same DAG walker
-// the existing ConsumeSchedule path uses, then acks. Treats Apply
-// failures as "the run executed but recorded a schedule_complete with
-// success=false" — the job is acked DONE either way; the projection
-// has the failure detail.
+// selfWorker is the in-process worker for single-node mode. Rather than
+// claiming from the state store directly, it drives jobs through the SAME
+// HTTP pathway a remote worker uses — long-polling the producer's own
+// /v1/jobs over loopback, executing, and acking over HTTP. Net effect:
+// ONE worker code path (no in-process special case), and the worker never
+// holds a store handle, so the producer stays the sole owner of state.
 //
-// Visibility timeout is 5 minutes. Long-running agent runs aren't
-// covered by that without explicit Heartbeat — single-node mode
-// rarely needs it because the worker IS the producer (no network
-// partition can preempt), but if a panic kills the goroutine the
-// reaper will recover the job.
-func selfWorker(ctx context.Context, store state.Backend, croniclePath string, wg *sync.WaitGroup) {
-	workerID := SelfWorkerID()
-	slog.Info("self-worker started", "worker_id", workerID)
-
-	for {
-		// Bail before each Claim attempt so a cancel signal observed
-		// between WaitForJob returning and the next Claim still ends
-		// the loop promptly.
-		if ctx.Err() != nil {
-			slog.Info("self-worker: shutting down", "worker_id", workerID)
-			return
-		}
-		job, err := store.Claim(workerID, 5*time.Minute)
-		if errors.Is(err, state.ErrNoJobs) {
-			// Park until a wakeup or 30s elapses, then re-Claim. Passing
-			// ctx here lets cancellation interrupt the park immediately
-			// instead of waiting for the 30s ceiling.
-			store.WaitForJob(ctx, 30*time.Second)
-			continue
-		}
-		if err != nil {
-			slog.Error("self-worker: claim failed", "error", err.Error())
-			// Sleep through cancel — return early on ctx.Done so shutdown
-			// isn't blocked by the back-off.
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-		wg.Add(1)
-		go func(j state.Job) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("self-worker: panic during execute",
-						"run_id", j.RunID, "panic", r)
-					_ = store.Ack(j.RunID, workerID, false, "panic during execute")
-				}
-			}()
-
-			var sch Schedule
-			if err := json.Unmarshal(j.Payload, &sch); err != nil {
-				slog.Error("self-worker: payload decode failed",
-					"run_id", j.RunID, "error", err.Error())
-				_ = store.Ack(j.RunID, workerID, false, err.Error())
-				return
-			}
-			sch.PropigateTaskProperties(croniclePath)
-			sch.ExecuteTasks()
-			// Per-task success rolls into the projection via the slog
-			// Sink; the queue Ack just records "this worker handled
-			// this job to completion." Run-level success is recorded
-			// separately on the projection's runs row.
-			_ = store.Ack(j.RunID, workerID, true, "")
-		}(job)
+// It is only started when the listener is configured (see Run), so the
+// loopback endpoint is always reachable; consume() backs off and retries
+// until it binds. Unlike a remote worker it does NOT ship run events over
+// HTTP — they already reach the store through the producer's own in-process
+// slog sink (same process); shipping too would double-apply them.
+//
+// One difference worth calling out: jobs run one at a time (consume is
+// serial), matching the remote worker. Single-node concurrency is now a
+// function of how many self-workers you run, not in-process goroutines.
+func selfWorker(ctx context.Context, producerURL, token, croniclePath string, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+	w := newHTTPWorker(HTTPWorkerOptions{
+		ProducerURL: producerURL,
+		Token:       token,
+		WorkerID:    SelfWorkerID(),
+		Path:        croniclePath,
+	}, ctx)
+	slog.Info("self-worker started (http loopback)",
+		"worker_id", w.opts.WorkerID, "producer", producerURL)
+	if err := w.consume(croniclePath); err != nil && !errors.Is(err, context.Canceled) {
+		slog.Error("self-worker stopped", "error", err.Error())
 	}
+}
+
+// loopbackURL turns the listener bind address (":8765", "0.0.0.0:8765")
+// into a URL the in-process self-worker can dial on loopback.
+func loopbackURL(listenAddr string) string {
+	if _, port, err := net.SplitHostPort(listenAddr); err == nil && port != "" {
+		return "http://127.0.0.1:" + port
+	}
+	return "http://" + listenAddr
 }
 
 // reaperLoop periodically walks the jobs table for claims past their

--- a/internal/cronicle/worker_http.go
+++ b/internal/cronicle/worker_http.go
@@ -111,32 +111,52 @@ func StartHTTPWorker(ctx context.Context, opts HTTPWorkerOptions) error {
 		defer shipper.stop()
 	}
 
-	client := &http.Client{
+	w := newHTTPWorker(opts, ctx)
+	slog.Info("HTTP worker started",
+		"worker_id", w.opts.WorkerID,
+		"producer", w.opts.ProducerURL,
+		"poll_block", w.opts.PollBlock.String(),
+	)
+	return w.consume(pathAbs)
+}
+
+// newHTTPWorker builds a worker with defaults applied. Shared by the
+// out-of-process entrypoint (StartHTTPWorker) and the in-process loopback
+// self-worker, so both drive the identical claim/execute/ack protocol.
+func newHTTPWorker(opts HTTPWorkerOptions, ctx context.Context) *httpWorker {
+	if opts.WorkerID == "" {
+		opts.WorkerID = defaultWorkerID()
+	}
+	if opts.PollBlock <= 0 {
+		opts.PollBlock = 30 * time.Second
+	}
+	if opts.HeartbeatEvery <= 0 {
+		opts.HeartbeatEvery = 100 * time.Second
+	}
+	return &httpWorker{
+		opts: opts,
 		// One full long-poll cycle plus margin. Don't set this too
 		// tight or transient retransmits look like timeouts.
-		Timeout: opts.PollBlock + 30*time.Second,
+		client:     &http.Client{Timeout: opts.PollBlock + 30*time.Second},
+		ctx:        ctx,
+		activeRuns: map[string]context.CancelFunc{},
 	}
-	w := &httpWorker{
-		opts:   opts,
-		client: client,
-		ctx:    ctx,
-	}
+}
 
-	slog.Info("HTTP worker started",
-		"worker_id", opts.WorkerID,
-		"producer", opts.ProducerURL,
-		"poll_block", opts.PollBlock.String(),
-	)
-
-	// Control channel: a long-lived SSE connection to the producer
-	// for cancel signals. The goroutine reconnects on disconnects so
-	// transient producer restarts don't permanently disable cancel.
+// consume runs the long-poll claim → execute → ack loop until ctx is
+// canceled. This is THE worker execution pathway — there is no separate
+// in-process route. Jobs are processed one at a time (concurrency is a
+// function of worker count, local or remote, not in-process goroutines).
+func (w *httpWorker) consume(pathAbs string) error {
+	// Control channel: a long-lived SSE connection to the producer for
+	// cancel signals. The goroutine reconnects on disconnects so transient
+	// producer restarts don't permanently disable cancel.
 	go w.controlLoop()
 
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-w.ctx.Done():
+			return w.ctx.Err()
 		default:
 		}
 		job, gotJob, err := w.pollOnce()
@@ -145,8 +165,8 @@ func StartHTTPWorker(ctx context.Context, opts HTTPWorkerOptions) error {
 			// Backoff. With the producer down workers should not
 			// hot-loop on connection errors.
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-w.ctx.Done():
+				return w.ctx.Err()
 			case <-time.After(2 * time.Second):
 			}
 			continue


### PR DESCRIPTION
**Draft / RFC — not for merge.** Prototype to see what unifying all workers onto one execution pathway looks like (per the architecture discussion). Net **−10 LOC**.

## Idea
The in-process self-worker stops claiming from the state store directly. Instead it long-polls the producer's own `/v1/jobs` over **loopback** and acks over HTTP — i.e. it *is* an `httpWorker` pointed at its own producer. One worker code path; single-node becomes a degenerate case of multi-node.

## Changes
- `worker_http.go` — extract `newHTTPWorker()` + `(*httpWorker).consume()` from `StartHTTPWorker`; both entrypoints share the claim→execute→ack loop.
- `queue_self.go` — `selfWorker` becomes a loopback `httpWorker` (no store handle, no direct `Claim`/`Ack`); `loopbackURL()` derives the dial URL from the listener bind addr. The bespoke claim/goroutine/ack body is deleted.
- `cron.go` / `cron_source.go` — pass loopback URL + token instead of the store.

## Why it's nice
The worker **never touches the store** → the producer is *structurally* the sole owner of state. That kills the whole "worker read state it shouldn't" bug class (e.g. `${last_run}`) by construction, not by convention — and retires the worker-side `:memory:` projection hack. Run events still reach the store via the producer's in-process slog sink (same process), so no shipping and no double-apply.

## Verified
Ran single-node (`cronicle run --listen 127.0.0.1:8799 --listen-token … --worker`): logs show `self-worker started (http loopback)` → `worker claimed job` (over HTTP) → task executes → `schedule complete success=true`, every tick.

## Open questions / not done
1. **Concurrency change**: `consume` is serial (one job at a time), matching the remote worker. Single-node concurrency is now a function of worker count, not in-process goroutines — previously the self-worker ran jobs concurrently. Acceptable? Or run N self-workers / spawn per-job?
2. **No-listener direct mode** (`ConsumeSchedule`) is untouched. Full unification there means always standing up a queue + (loopback) server — removes the zero-dependency single-process mode. Separate product call.
3. **Transport**: uses the real loopback TCP listener (already running). A socketless in-memory streaming transport is possible but more work (long-poll + SSE need streaming); not attempted here.
4. **Ordering**: the worker starts before the listener binds; `consume` backs off and retries until it's up (works, but could reorder for cleanliness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)