### PR TITLE
refactor(worker): unify local + remote workers behind a queueClient interface (no socket)

### DIFF
--- a/internal/cronicle/queue_self.go
+++ b/internal/cronicle/queue_self.go
@@ -51,75 +51,27 @@ func enqueueAdapter(in <-chan []byte, store state.Backend) {
 	}
 }
 
-// selfWorker is the in-process consumer for --queue self mode. Claims
-// jobs from the SQLite store, hands the payload to the same DAG walker
-// the existing ConsumeSchedule path uses, then acks. Treats Apply
-// failures as "the run executed but recorded a schedule_complete with
-// success=false" — the job is acked DONE either way; the projection
-// has the failure detail.
+// selfWorker is the in-process worker for single-node mode (--worker). It
+// runs the SAME claim→execute→ack loop as a remote worker (see worker /
+// consume), but over a localQueueClient — a thin in-process adapter on the
+// state backend, with NO socket. The worker's only contact with state is
+// the three queue verbs (Claim/Ack/Heartbeat); it never reads run history
+// or projections, so the producer stays the single source of truth by
+// construction, not convention.
 //
-// Visibility timeout is 5 minutes. Long-running agent runs aren't
-// covered by that without explicit Heartbeat — single-node mode
-// rarely needs it because the worker IS the producer (no network
-// partition can preempt), but if a panic kills the goroutine the
-// reaper will recover the job.
+// Run events still reach the store through the producer's in-process slog
+// sink (same process), so unlike a remote worker there is nothing to ship.
+// Jobs run one at a time (consume is serial); the reaper recovers a job if
+// this worker dies mid-run.
 func selfWorker(ctx context.Context, store state.Backend, croniclePath string, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
 	workerID := SelfWorkerID()
+	lc := &localQueueClient{store: store, workerID: workerID, ctx: ctx}
+	w := newWorker(ctx, lc, workerID, 30*time.Second, 100*time.Second)
 	slog.Info("self-worker started", "worker_id", workerID)
-
-	for {
-		// Bail before each Claim attempt so a cancel signal observed
-		// between WaitForJob returning and the next Claim still ends
-		// the loop promptly.
-		if ctx.Err() != nil {
-			slog.Info("self-worker: shutting down", "worker_id", workerID)
-			return
-		}
-		job, err := store.Claim(workerID, 5*time.Minute)
-		if errors.Is(err, state.ErrNoJobs) {
-			// Park until a wakeup or 30s elapses, then re-Claim. Passing
-			// ctx here lets cancellation interrupt the park immediately
-			// instead of waiting for the 30s ceiling.
-			store.WaitForJob(ctx, 30*time.Second)
-			continue
-		}
-		if err != nil {
-			slog.Error("self-worker: claim failed", "error", err.Error())
-			// Sleep through cancel — return early on ctx.Done so shutdown
-			// isn't blocked by the back-off.
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-		wg.Add(1)
-		go func(j state.Job) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("self-worker: panic during execute",
-						"run_id", j.RunID, "panic", r)
-					_ = store.Ack(j.RunID, workerID, false, "panic during execute")
-				}
-			}()
-
-			var sch Schedule
-			if err := json.Unmarshal(j.Payload, &sch); err != nil {
-				slog.Error("self-worker: payload decode failed",
-					"run_id", j.RunID, "error", err.Error())
-				_ = store.Ack(j.RunID, workerID, false, err.Error())
-				return
-			}
-			sch.PropigateTaskProperties(croniclePath)
-			sch.ExecuteTasks()
-			// Per-task success rolls into the projection via the slog
-			// Sink; the queue Ack just records "this worker handled
-			// this job to completion." Run-level success is recorded
-			// separately on the projection's runs row.
-			_ = store.Ack(j.RunID, workerID, true, "")
-		}(job)
+	if err := w.consume(croniclePath); err != nil && !errors.Is(err, context.Canceled) {
+		slog.Error("self-worker stopped", "error", err.Error())
 	}
 }
 

--- a/internal/cronicle/worker_e2e_test.go
+++ b/internal/cronicle/worker_e2e_test.go
@@ -69,31 +69,27 @@ func TestDistributed_ProducerWorkerEndToEnd(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	w := &httpWorker{
-		opts: HTTPWorkerOptions{
-			ProducerURL:    ts.URL,
-			Token:          token,
-			WorkerID:       "W1",
-			PollBlock:      2 * time.Second,
-			HeartbeatEvery: time.Hour, // never fires during the test
-		},
-		client:     &http.Client{Timeout: 10 * time.Second},
-		ctx:        ctx,
-		activeRuns: map[string]context.CancelFunc{},
+	hc := &httpQueueClient{
+		producerURL: ts.URL,
+		token:       token,
+		workerID:    "W1",
+		client:      &http.Client{Timeout: 10 * time.Second},
+		ctx:         ctx,
 	}
+	w := newWorker(ctx, hc, "W1", 2*time.Second, time.Hour /* heartbeat never fires */)
 
 	// Claim the job over HTTP and run it.
-	job, ok, err := w.pollOnce()
+	job, ok, err := hc.Claim(w.pollBlock)
 	if err != nil {
-		t.Fatalf("pollOnce: %v", err)
+		t.Fatalf("Claim: %v", err)
 	}
 	if !ok {
-		t.Fatal("pollOnce returned no job, want R2")
+		t.Fatal("Claim returned no job, want R2")
 	}
 	if job.RunID != "R2" || job.Schedule != "daily" {
 		t.Fatalf("claimed job = (%q,%q), want (R2,daily)", job.RunID, job.Schedule)
 	}
-	w.execute(w.opts.Path, job)
+	w.execute("", job)
 
 	// Flush shipped events into the producer projection.
 	shipper.stop()

--- a/internal/cronicle/worker_http.go
+++ b/internal/cronicle/worker_http.go
@@ -1,19 +1,15 @@
 package cronicle
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -57,9 +53,10 @@ type HTTPWorkerOptions struct {
 	PostStateStoreHook func() error
 }
 
-// StartHTTPWorker runs the long-poll consumer loop. Blocks until ctx
-// is canceled or an unrecoverable transport failure occurs (none are
-// unrecoverable today — connection errors trigger backoff and retry).
+// StartHTTPWorker runs the long-poll consumer loop against a remote
+// producer. Blocks until ctx is canceled or an unrecoverable transport
+// failure occurs (none are unrecoverable today — connection errors trigger
+// backoff and retry).
 //
 // File logging is set up identically to StartWorker — workers running
 // distributed get the same on-disk audit trail as single-node.
@@ -111,16 +108,16 @@ func StartHTTPWorker(ctx context.Context, opts HTTPWorkerOptions) error {
 		defer shipper.stop()
 	}
 
-	client := &http.Client{
-		// One full long-poll cycle plus margin. Don't set this too
-		// tight or transient retransmits look like timeouts.
-		Timeout: opts.PollBlock + 30*time.Second,
-	}
-	w := &httpWorker{
-		opts:   opts,
-		client: client,
+	hc := &httpQueueClient{
+		producerURL: opts.ProducerURL,
+		token:       opts.Token,
+		workerID:    opts.WorkerID,
+		// One full long-poll cycle plus margin. Don't set this too tight
+		// or transient retransmits look like timeouts.
+		client: &http.Client{Timeout: opts.PollBlock + 30*time.Second},
 		ctx:    ctx,
 	}
+	w := newWorker(ctx, hc, opts.WorkerID, opts.PollBlock, opts.HeartbeatEvery)
 
 	slog.Info("HTTP worker started",
 		"worker_id", opts.WorkerID,
@@ -128,54 +125,78 @@ func StartHTTPWorker(ctx context.Context, opts HTTPWorkerOptions) error {
 		"poll_block", opts.PollBlock.String(),
 	)
 
-	// Control channel: a long-lived SSE connection to the producer
-	// for cancel signals. The goroutine reconnects on disconnects so
-	// transient producer restarts don't permanently disable cancel.
-	go w.controlLoop()
+	// Control channel: a long-lived SSE connection to the producer for
+	// cancel signals (remote-only — see httpQueueClient.controlLoop).
+	go hc.controlLoop(w.cancelRun)
 
+	return w.consume(pathAbs)
+}
+
+// worker drives one job at a time off a queueClient: claim → execute →
+// ack, heartbeating while a job runs. It is transport-agnostic — the same
+// loop serves a remote (HTTP) and the in-process (local) self-worker. The
+// worker never touches the state store directly; everything goes through
+// the queueClient.
+type worker struct {
+	queue     queueClient
+	workerID  string
+	pollBlock time.Duration
+	hbEvery   time.Duration
+	ctx       context.Context
+	// activeRuns maps run_id → cancel func of the per-run execute context.
+	// The control channel consults this (via cancelRun) when a cancel
+	// arrives for a run we hold. Guarded by mu because the cancel path and
+	// the execute path touch it concurrently.
+	mu         sync.Mutex
+	activeRuns map[string]context.CancelFunc
+}
+
+func newWorker(ctx context.Context, q queueClient, workerID string, pollBlock, hbEvery time.Duration) *worker {
+	if pollBlock <= 0 {
+		pollBlock = 30 * time.Second
+	}
+	if hbEvery <= 0 {
+		hbEvery = 100 * time.Second
+	}
+	return &worker{
+		queue:      q,
+		workerID:   workerID,
+		pollBlock:  pollBlock,
+		hbEvery:    hbEvery,
+		ctx:        ctx,
+		activeRuns: map[string]context.CancelFunc{},
+	}
+}
+
+// consume runs the claim → execute → ack loop until ctx is canceled. THE
+// single worker execution pathway; jobs run one at a time (concurrency is
+// a function of worker count, not in-process goroutines).
+func (w *worker) consume(pathAbs string) error {
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-w.ctx.Done():
+			return w.ctx.Err()
 		default:
 		}
-		job, gotJob, err := w.pollOnce()
+		job, gotJob, err := w.queue.Claim(w.pollBlock)
 		if err != nil {
-			slog.Error("worker poll failed", "error", err.Error())
-			// Backoff. With the producer down workers should not
-			// hot-loop on connection errors.
+			slog.Error("worker claim failed", "error", err.Error())
+			// Backoff so a sick queue doesn't hot-loop on errors.
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-w.ctx.Done():
+				return w.ctx.Err()
 			case <-time.After(2 * time.Second):
 			}
 			continue
 		}
 		if !gotJob {
-			// 204 No Content — the long-poll waited and got nothing.
-			// Just reconnect immediately.
 			continue
 		}
 		w.execute(pathAbs, job)
 	}
 }
 
-type httpWorker struct {
-	opts   HTTPWorkerOptions
-	client *http.Client
-	ctx    context.Context
-	// activeRuns maps run_id → cancel func of the per-run execute
-	// context. The control-channel goroutine consults this when a
-	// cancel SSE message arrives for a run we hold. Guarded by a
-	// mutex because the SSE goroutine and the execute goroutine touch
-	// it concurrently.
-	mu         sync.Mutex
-	activeRuns map[string]context.CancelFunc
-}
-
-// registerRun records that we've started executing run_id with the
-// given cancel func. Caller calls unregisterRun via defer.
-func (w *httpWorker) registerRun(runID string, cancel context.CancelFunc) {
+func (w *worker) registerRun(runID string, cancel context.CancelFunc) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.activeRuns == nil {
@@ -184,15 +205,15 @@ func (w *httpWorker) registerRun(runID string, cancel context.CancelFunc) {
 	w.activeRuns[runID] = cancel
 }
 
-func (w *httpWorker) unregisterRun(runID string) {
+func (w *worker) unregisterRun(runID string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	delete(w.activeRuns, runID)
 }
 
-// cancelRun preempts an in-flight run if we hold it. Idempotent —
-// calling cancel() on a context multiple times is safe.
-func (w *httpWorker) cancelRun(runID string) bool {
+// cancelRun preempts an in-flight run if we hold it. Idempotent. Passed as
+// the callback to the (HTTP) control channel.
+func (w *worker) cancelRun(runID string) bool {
 	w.mu.Lock()
 	cancel, ok := w.activeRuns[runID]
 	w.mu.Unlock()
@@ -203,49 +224,14 @@ func (w *httpWorker) cancelRun(runID string) bool {
 	return true
 }
 
-func (w *httpWorker) authHeader() string { return "Bearer " + w.opts.Token }
-
-// pollOnce issues one GET /v1/jobs roundtrip. Returns (job, true, nil)
-// on a 200 with a job, (zero, false, nil) on a 204, and (zero, false, err)
-// on transport / decode errors.
-func (w *httpWorker) pollOnce() (state.Job, bool, error) {
-	url := strings.TrimRight(w.opts.ProducerURL, "/") +
-		"/v1/jobs?worker=" + w.opts.WorkerID +
-		"&block=" + w.opts.PollBlock.String()
-	req, err := http.NewRequestWithContext(w.ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return state.Job{}, false, err
-	}
-	req.Header.Set("Authorization", w.authHeader())
-	resp, err := w.client.Do(req)
-	if err != nil {
-		return state.Job{}, false, err
-	}
-	defer resp.Body.Close()
-	switch resp.StatusCode {
-	case http.StatusNoContent:
-		return state.Job{}, false, nil
-	case http.StatusOK:
-		var j state.Job
-		if err := json.NewDecoder(resp.Body).Decode(&j); err != nil {
-			return state.Job{}, false, fmt.Errorf("decode job: %w", err)
-		}
-		return j, true, nil
-	default:
-		body, _ := io.ReadAll(resp.Body)
-		return state.Job{}, false, fmt.Errorf("claim http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-}
-
 // execute runs the job and acks it. Heartbeats while running.
 //
-// Phase 3: a per-run execute context carries the cancel signal from
-// the SSE control channel. Workers register their cancel func before
-// starting the DAG walk; an inbound cancel SSE message routes through
-// w.cancelRun(runID) which calls cancel() on the matching context.
-// Shell tasks die because exec.CommandContext is bound to runCtx;
-// agent tasks check ctx.Done() between turns (see pkg/agent).
-func (w *httpWorker) execute(croniclePath string, job state.Job) {
+// A per-run execute context carries the cancel signal from the control
+// channel: registerRun records the cancel func before the DAG walk; an
+// inbound cancel routes through cancelRun(runID). Shell tasks die because
+// exec.CommandContext is bound to runCtx; agent tasks check ctx.Done()
+// between turns (see pkg/agent).
+func (w *worker) execute(croniclePath string, job state.Job) {
 	slog.Info("worker claimed job",
 		"run_id", job.RunID,
 		"schedule", job.Schedule,
@@ -273,9 +259,8 @@ func (w *httpWorker) execute(croniclePath string, job state.Job) {
 		if sch.Source == "" {
 			sch.Source = "worker"
 		}
-		// Plumb the per-run ctx onto the schedule so its task
-		// dispatch path (shell exec.CommandContext, agent loop) can
-		// honor cancel.
+		// Plumb the per-run ctx onto the schedule so its task dispatch path
+		// (shell exec.CommandContext, agent loop) can honor cancel.
 		sch.RunCtx = runCtx
 		func() {
 			defer func() {
@@ -287,10 +272,9 @@ func (w *httpWorker) execute(croniclePath string, job state.Job) {
 			sch.PropigateTaskProperties(croniclePath)
 			sch.ExecuteTasks()
 		}()
-		// If our run ctx was canceled mid-execute, mark the ack as
-		// canceled rather than failed. The projection row already
-		// reflects "canceled" from the producer's POST /cancel; this
-		// is just the queue-side record.
+		// If our run ctx was canceled mid-execute, mark the ack as canceled
+		// rather than failed. The projection row already reflects "canceled"
+		// from the producer's POST /cancel; this is just the queue record.
 		if runCtx.Err() == context.Canceled {
 			success = false
 			errMsg = "canceled"
@@ -299,197 +283,33 @@ func (w *httpWorker) execute(croniclePath string, job state.Job) {
 	}
 
 	hbCancel()
-	// Don't ack a canceled run as failed — the producer already moved
-	// the job row to canceled when it called Cancel(); a subsequent
-	// Ack(failed) would be a no-op (UPDATE with WHERE status=claimed
-	// matches nothing) but it avoids spurious projection writes.
+	// Don't ack a canceled run as failed — the producer already moved the
+	// job row to canceled when it called Cancel(); a subsequent Ack(failed)
+	// would be a no-op but it avoids spurious projection writes.
 	if canceled {
 		return
 	}
-	if err := w.ack(job.RunID, success, errMsg); err != nil {
+	if err := w.queue.Ack(job.RunID, success, errMsg); err != nil {
 		slog.Error("worker: ack failed", "run_id", job.RunID, "error", err.Error())
 	}
 }
 
-// heartbeatLoop pings /heartbeat on opts.HeartbeatEvery cadence until
-// ctx is canceled. A 409 (lost ownership) terminates the loop early —
-// the worker has been preempted by the reaper.
-func (w *httpWorker) heartbeatLoop(ctx context.Context, runID string) {
-	t := time.NewTicker(w.opts.HeartbeatEvery)
+// heartbeatLoop pings the queue on hbEvery cadence until ctx is canceled.
+// A heartbeat failure (e.g. lost ownership) terminates the loop early.
+func (w *worker) heartbeatLoop(ctx context.Context, runID string) {
+	t := time.NewTicker(w.hbEvery)
 	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			if err := w.heartbeat(runID); err != nil {
+			if err := w.queue.Heartbeat(runID); err != nil {
 				slog.Warn("heartbeat failed; stopping heartbeat loop",
 					"run_id", runID, "error", err.Error())
 				return
 			}
 		}
-	}
-}
-
-func (w *httpWorker) heartbeat(runID string) error {
-	url := strings.TrimRight(w.opts.ProducerURL, "/") + "/v1/jobs/" + runID + "/heartbeat"
-	body, _ := json.Marshal(map[string]string{"worker": w.opts.WorkerID})
-	return w.post(url, body, http.StatusOK)
-}
-
-func (w *httpWorker) ack(runID string, success bool, errMsg string) error {
-	url := strings.TrimRight(w.opts.ProducerURL, "/") + "/v1/jobs/" + runID + "/ack"
-	body, _ := json.Marshal(map[string]any{
-		"worker":  w.opts.WorkerID,
-		"success": success,
-		"error":   errMsg,
-	})
-	return w.post(url, body, http.StatusOK)
-}
-
-func (w *httpWorker) post(url string, body []byte, expectCode int) error {
-	req, err := http.NewRequestWithContext(w.ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", w.authHeader())
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := w.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != expectCode {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
-	}
-	return nil
-}
-
-// controlLoop maintains an SSE subscription to /v1/workers/{id}/control
-// for cancel signals. Reconnects on transient errors with backoff so a
-// brief producer restart doesn't permanently disable cancel.
-//
-// The loop respects w.ctx — when the worker is shutting down, the
-// SSE connection closes and we exit. Per-message handling routes to
-// the run's cancel func via w.cancelRun.
-func (w *httpWorker) controlLoop() {
-	url := strings.TrimRight(w.opts.ProducerURL, "/") +
-		"/v1/workers/" + w.opts.WorkerID + "/control"
-
-	host, _ := os.Hostname()
-	backoff := time.Second
-
-	for {
-		select {
-		case <-w.ctx.Done():
-			return
-		default:
-		}
-
-		req, err := http.NewRequestWithContext(w.ctx, http.MethodGet, url, nil)
-		if err != nil {
-			// non-recoverable construction error; just exit
-			return
-		}
-		req.Header.Set("Authorization", w.authHeader())
-		req.Header.Set("Accept", "text/event-stream")
-		req.Header.Set("X-Cronicle-Host", host)
-
-		// SSE connection has no overall timeout — long-lived by design.
-		// We use a separate client to avoid the long-poll client's
-		// 60s+30s budget bleeding into here.
-		sseClient := &http.Client{}
-		resp, err := sseClient.Do(req)
-		if err != nil {
-			if w.ctx.Err() != nil {
-				return
-			}
-			slog.Warn("control channel: connect failed; backing off",
-				"error", err.Error(), "backoff", backoff)
-			select {
-			case <-w.ctx.Done():
-				return
-			case <-time.After(backoff):
-			}
-			if backoff < 30*time.Second {
-				backoff *= 2
-			}
-			continue
-		}
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			slog.Warn("control channel: non-200; backing off",
-				"status", resp.StatusCode,
-				"body", strings.TrimSpace(string(body)),
-				"backoff", backoff)
-			select {
-			case <-w.ctx.Done():
-				return
-			case <-time.After(backoff):
-			}
-			continue
-		}
-		backoff = time.Second // reset on successful connect
-		slog.Info("control channel: subscribed", "worker_id", w.opts.WorkerID)
-		w.consumeSSE(resp.Body)
-		// Connection closed (server hangup, network issue). Reconnect.
-	}
-}
-
-// consumeSSE parses the SSE stream until the body closes. Lines we
-// care about: `event: control` followed by `data: {...}` whose JSON
-// has type=cancel + run_id. Pings are noted at debug level only.
-func (w *httpWorker) consumeSSE(body io.ReadCloser) {
-	defer body.Close()
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
-
-	var event string
-	for scanner.Scan() {
-		select {
-		case <-w.ctx.Done():
-			return
-		default:
-		}
-		line := scanner.Text()
-		switch {
-		case strings.HasPrefix(line, "event:"):
-			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-		case strings.HasPrefix(line, "data:"):
-			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-			if event == "control" {
-				var msg state.ControlMsg
-				if err := json.Unmarshal([]byte(data), &msg); err != nil {
-					slog.Warn("control channel: bad data", "data", data)
-					continue
-				}
-				w.handleControl(msg)
-			}
-		case line == "":
-			event = "" // SSE message boundary
-		}
-	}
-}
-
-// handleControl dispatches an inbound control message to the matching
-// in-flight run. Unknown types are logged-and-dropped — forward-compat
-// with future verbs (drain, pause).
-func (w *httpWorker) handleControl(msg state.ControlMsg) {
-	switch msg.Type {
-	case "cancel":
-		if w.cancelRun(msg.RunID) {
-			slog.Info("control: canceling run", "run_id", msg.RunID)
-		} else {
-			// Cancel arrived for a run we don't hold (already finished
-			// locally, or the producer signaled the wrong worker). Benign.
-			slog.Debug("control: cancel for unknown run", "run_id", msg.RunID)
-		}
-	case "ping":
-		// no-op
-	default:
-		slog.Debug("control: unknown msg type", "type", msg.Type)
 	}
 }
 
@@ -502,17 +322,3 @@ func defaultWorkerID() string {
 	}
 	return host + "-" + strconv.Itoa(os.Getpid())
 }
-
-// hashOnly stays around as a placeholder for a future: if we ever
-// want to anonymize hostnames in worker IDs (compliance scenarios),
-// hashing host with a process-stable salt is the move.
-//
-//nolint:unused
-func hashOnly(s string) string {
-	return strings.ToLower(s)
-}
-
-// silence the unused import for sync — the worker uses sync.Once /
-// sync.Mutex paths only on the producer side. Keep the import here
-// reserved for follow-up work without re-shuffling each PR.
-var _ sync.Mutex

--- a/internal/cronicle/worker_local_test.go
+++ b/internal/cronicle/worker_local_test.go
@@ -1,0 +1,54 @@
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// TestLocalQueueClient_WorkerClaimsAndExecutes drives the SAME worker loop
+// the remote path uses, but over a localQueueClient — proving single-node
+// execution goes through the unified pathway with no socket. The worker
+// claims an enqueued job straight from the store, executes it, and acks.
+func TestLocalQueueClient_WorkerClaimsAndExecutes(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	out := filepath.Join(t.TempDir(), "ran.txt")
+	sch := Schedule{
+		Name:  "demo",
+		RunID: "R1",
+		Tasks: []Task{{Name: "t1", Command: []string{"bash", "-c", "printf ok > " + out}}},
+	}
+	payload, _ := json.Marshal(sch)
+	if err := store.Enqueue("R1", "demo", payload); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lc := &localQueueClient{store: store, workerID: "self", ctx: ctx}
+	w := newWorker(ctx, lc, "self", 100*time.Millisecond, time.Hour)
+	go w.consume("")
+
+	// The task writes the file when it executes — proof the local client
+	// claimed and ran the job through the shared worker loop.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(out); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("task never ran — local queue client did not claim/execute")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/cronicle/worker_queue.go
+++ b/internal/cronicle/worker_queue.go
@@ -1,0 +1,269 @@
+package cronicle
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// queueClient is how a worker pulls jobs from the producer's queue and
+// settles them. There are two implementations and ONE worker loop:
+//
+//   - httpQueueClient — remote workers, over the producer's /v1/jobs HTTP
+//     API (the distributed deployment).
+//   - localQueueClient — the in-process self-worker, straight over the
+//     state backend. No socket: single-node talks to its own queue with a
+//     function call, not a loopback request.
+//
+// The self-worker holding a localQueueClient (rather than a raw
+// state.Backend) is the point: its only contact with state is these three
+// queue verbs — it cannot read run history or projections, so the producer
+// stays the single source of truth without relying on convention.
+type queueClient interface {
+	// Claim returns the next job, blocking up to block for one to appear.
+	// (job, false, nil) means "nothing within block" — the caller loops.
+	Claim(block time.Duration) (state.Job, bool, error)
+	Ack(runID string, success bool, errMsg string) error
+	Heartbeat(runID string) error
+}
+
+// localVisibility is how long a claimed job is invisible to other workers
+// before the reaper may reclaim it. Matches the producer-side default.
+const localVisibility = 5 * time.Minute
+
+// localQueueClient drives the queue in-process for the single-node
+// self-worker. It is the ONLY place the worker side touches the store, and
+// only through Claim/Ack/Heartbeat.
+type localQueueClient struct {
+	store    state.Backend
+	workerID string
+	ctx      context.Context
+}
+
+func (c *localQueueClient) Claim(block time.Duration) (state.Job, bool, error) {
+	job, err := c.store.Claim(c.workerID, localVisibility)
+	if errors.Is(err, state.ErrNoJobs) {
+		// Park until a wakeup or block elapses, then report "no job" so the
+		// worker loops and re-claims. ctx lets shutdown interrupt the park.
+		c.store.WaitForJob(c.ctx, block)
+		return state.Job{}, false, nil
+	}
+	if err != nil {
+		return state.Job{}, false, err
+	}
+	return job, true, nil
+}
+
+func (c *localQueueClient) Ack(runID string, success bool, errMsg string) error {
+	return c.store.Ack(runID, c.workerID, success, errMsg)
+}
+
+func (c *localQueueClient) Heartbeat(runID string) error {
+	return c.store.Heartbeat(runID, c.workerID, localVisibility)
+}
+
+// httpQueueClient drives the queue over the producer's HTTP API. It also
+// owns the SSE control channel (cancel signals), which is inherently a
+// remote concern — the local worker has no equivalent.
+type httpQueueClient struct {
+	producerURL string
+	token       string
+	workerID    string
+	client      *http.Client
+	ctx         context.Context
+}
+
+func (c *httpQueueClient) authHeader() string { return "Bearer " + c.token }
+
+func (c *httpQueueClient) Claim(block time.Duration) (state.Job, bool, error) {
+	url := strings.TrimRight(c.producerURL, "/") +
+		"/v1/jobs?worker=" + c.workerID +
+		"&block=" + block.String()
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return state.Job{}, false, err
+	}
+	req.Header.Set("Authorization", c.authHeader())
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return state.Job{}, false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return state.Job{}, false, nil
+	case http.StatusOK:
+		var j state.Job
+		if err := json.NewDecoder(resp.Body).Decode(&j); err != nil {
+			return state.Job{}, false, fmt.Errorf("decode job: %w", err)
+		}
+		return j, true, nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return state.Job{}, false, fmt.Errorf("claim http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func (c *httpQueueClient) Heartbeat(runID string) error {
+	url := strings.TrimRight(c.producerURL, "/") + "/v1/jobs/" + runID + "/heartbeat"
+	body, _ := json.Marshal(map[string]string{"worker": c.workerID})
+	return c.post(url, body, http.StatusOK)
+}
+
+func (c *httpQueueClient) Ack(runID string, success bool, errMsg string) error {
+	url := strings.TrimRight(c.producerURL, "/") + "/v1/jobs/" + runID + "/ack"
+	body, _ := json.Marshal(map[string]any{
+		"worker":  c.workerID,
+		"success": success,
+		"error":   errMsg,
+	})
+	return c.post(url, body, http.StatusOK)
+}
+
+func (c *httpQueueClient) post(url string, body []byte, expectCode int) error {
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", c.authHeader())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != expectCode {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// controlLoop maintains an SSE subscription to /v1/workers/{id}/control
+// for cancel signals, dispatching each to cancel(runID). Reconnects on
+// transient errors with backoff so a brief producer restart doesn't
+// permanently disable cancel. Respects ctx for shutdown. Remote-only —
+// the in-process self-worker has no control channel.
+func (c *httpQueueClient) controlLoop(cancel func(runID string) bool) {
+	url := strings.TrimRight(c.producerURL, "/") +
+		"/v1/workers/" + c.workerID + "/control"
+
+	host, _ := os.Hostname()
+	backoff := time.Second
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(c.ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return
+		}
+		req.Header.Set("Authorization", c.authHeader())
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("X-Cronicle-Host", host)
+
+		// SSE connection has no overall timeout — long-lived by design.
+		sseClient := &http.Client{}
+		resp, err := sseClient.Do(req)
+		if err != nil {
+			if c.ctx.Err() != nil {
+				return
+			}
+			slog.Warn("control channel: connect failed; backing off",
+				"error", err.Error(), "backoff", backoff)
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			if backoff < 30*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			slog.Warn("control channel: non-200; backing off",
+				"status", resp.StatusCode,
+				"body", strings.TrimSpace(string(body)),
+				"backoff", backoff)
+			select {
+			case <-c.ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			continue
+		}
+		backoff = time.Second // reset on successful connect
+		slog.Info("control channel: subscribed", "worker_id", c.workerID)
+		c.consumeSSE(resp.Body, cancel)
+		// Connection closed (server hangup, network issue). Reconnect.
+	}
+}
+
+// consumeSSE parses the SSE stream until the body closes, routing each
+// control message to cancel(runID).
+func (c *httpQueueClient) consumeSSE(body io.ReadCloser, cancel func(runID string) bool) {
+	defer body.Close()
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+
+	var event string
+	for scanner.Scan() {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if event == "control" {
+				var msg state.ControlMsg
+				if err := json.Unmarshal([]byte(data), &msg); err != nil {
+					slog.Warn("control channel: bad data", "data", data)
+					continue
+				}
+				handleControl(msg, cancel)
+			}
+		case line == "":
+			event = "" // SSE message boundary
+		}
+	}
+}
+
+// handleControl dispatches an inbound control message via cancel. Unknown
+// types are logged-and-dropped — forward-compat with future verbs.
+func handleControl(msg state.ControlMsg, cancel func(runID string) bool) {
+	switch msg.Type {
+	case "cancel":
+		if cancel(msg.RunID) {
+			slog.Info("control: canceling run", "run_id", msg.RunID)
+		} else {
+			slog.Debug("control: cancel for unknown run", "run_id", msg.RunID)
+		}
+	case "ping":
+		// no-op
+	default:
+		slog.Debug("control: unknown msg type", "type", msg.Type)
+	}
+}


### PR DESCRIPTION
The interface alternative to the socket prototype (#129, closed). Same architectural win — one worker loop, the worker no longer holds a raw `state.Backend` — with **no socket** for single-node.

## What
One execution loop (`worker.consume`/`execute`) for both worker kinds. Transport is a `queueClient` interface:

```go
type queueClient interface {
    Claim(block time.Duration) (state.Job, bool, error)
    Ack(runID string, success bool, errMsg string) error
    Heartbeat(runID string) error
}
```

- **`httpQueueClient`** — remote workers, over the producer's `/v1/jobs` HTTP API (+ the SSE control/cancel channel). Mostly relocated from `worker_http.go`.
- **`localQueueClient`** — the in-process self-worker, a thin adapter straight over the state backend. **No socket** — single-node talks to its own queue with a function call.

## Why this over the socket version (#129)
Both give one worker loop and "the worker doesn't freely hold the store." The socket version added a loopback TCP self-dependency to single-node — a new failure mode (bind race, port conflicts) for the simplest deployment, against the simplicity goal. This keeps single-node in-process while still narrowing the self-worker's contact with state to the three queue verbs (it can't read run history/projections) — so the producer stays the single source of truth **by construction**.

## Surface
- `worker` (was `httpWorker`) is transport-agnostic.
- `selfWorker` keeps its `(ctx, store, path, wg)` signature → `cron.go` / `cron_source.go` unchanged.
- Net +77 LOC, but `worker_queue.go` (269) is mostly **relocated** HTTP code — `worker_http.go` shed ~280. Genuinely new logic ≈ the interface + `localQueueClient` (~25 lines).

## Behavior notes
- The self-worker now runs jobs **serially** (matching the remote worker); single-node concurrency scales by worker count, not in-process goroutines. (Was concurrent.)
- Events still reach the store via the in-process slog sink (no shipping → no double-apply).
- The no-listener `ConsumeSchedule` mode is untouched.

## Verified
- `worker_local_test` — local client claims + executes through the shared loop.
- Existing distributed e2e test rewired onto `httpQueueClient` (remote path) — still green.
- Ran single-node (`run --listen … --worker`): `self-worker started` → `worker claimed job` → `schedule complete success=true` each tick, no socket, no errors. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)