### PR TITLE
feat(worker): restore self-worker concurrency via a worker pool

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,6 +46,7 @@ The run command will log schedule information to stdout including git commit inf
 		workdir, _ := cmd.Flags().GetString("workdir")
 
 		runWorker, _ := cmd.Flags().GetBool("worker")
+		workerCount, _ := cmd.Flags().GetInt("worker-count")
 		cron, _ := cmd.Flags().GetString("cron")
 		command, _ := cmd.Flags().GetString("command")
 		logToFile, _ := cmd.Flags().GetBool("log-to-file")
@@ -61,6 +62,7 @@ The run command will log schedule information to stdout including git commit inf
 
 		runOptions := cronicle.RunOptions{
 			RunWorker:   runWorker,
+			WorkerCount: workerCount,
 			LogToFile:   logToFile,
 			ListenAddr:  listenAddr,
 			ListenToken: listenToken,
@@ -121,6 +123,7 @@ func init() {
 		"working directory for .cronicle/state.db, .cronicle/log/*.jsonl, scratch dirs. "+
 			"File-source mode derives this from --path; required for non-file sources")
 	runCmd.Flags().Bool("worker", true, "start a worker thread to consume tasks in distributed mode")
+	runCmd.Flags().Int("worker-count", 4, "number of in-process self-workers (queue mode); each runs one job at a time, so N = up to N concurrent jobs")
 	runCmd.Flags().String("cron", "", "crontab expression for running a command e.g. @every 1h")
 	runCmd.Flags().String("command", "", "command to run on the given cron [/bin/echo cronicle]")
 	runCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); stdout is unaffected and remains controlled by --log-format")

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -102,7 +102,7 @@ func Run(ctx context.Context, cronicleFile string, runOptions RunOptions) {
 		go enqueueAdapter(enqueueChan, stateStore)
 		go StartCron(ctx, cronicleFileAbs, enqueueChan)
 		if runOptions.RunWorker {
-			go selfWorker(ctx, stateStore, croniclePath, &wg)
+			selfWorkerPool(ctx, stateStore, croniclePath, runOptions.WorkerCount, &wg)
 		}
 		go reaperLoop(ctx, stateStore)
 	} else {
@@ -158,6 +158,11 @@ type RunOptions struct {
 	// listener it's the chan-based ConsumeSchedule. Set to false on
 	// dedicated producers so external workers do all execution.
 	RunWorker bool
+	// WorkerCount is how many in-process self-workers to run in queue
+	// mode. Each runs the shared (serial) consume loop, so N workers =
+	// up to N jobs executing concurrently. <=1 means one worker (serial).
+	// Ignored when RunWorker is false or in non-listener mode.
+	WorkerCount int
 	// LogToFile mirrors structured logs to .cronicle/log/cronicle.jsonl
 	// rotated by lumberjack. Independent of stdout.
 	LogToFile bool

--- a/internal/cronicle/cron_source.go
+++ b/internal/cronicle/cron_source.go
@@ -113,7 +113,7 @@ func RunFromSource(ctx context.Context, spec, workdir string, runOptions RunOpti
 			return fmt.Errorf("scheduler start: %w", err)
 		}
 		if runOptions.RunWorker {
-			go selfWorker(ctx, stateStore, workdirAbs, &wg)
+			selfWorkerPool(ctx, stateStore, workdirAbs, runOptions.WorkerCount, &wg)
 		}
 		go reaperLoop(ctx, stateStore)
 	} else {

--- a/internal/cronicle/queue_self.go
+++ b/internal/cronicle/queue_self.go
@@ -51,27 +51,43 @@ func enqueueAdapter(in <-chan []byte, store state.Backend) {
 	}
 }
 
-// selfWorker is the in-process worker for single-node mode (--worker). It
-// runs the SAME claim→execute→ack loop as a remote worker (see worker /
-// consume), but over a localQueueClient — a thin in-process adapter on the
-// state backend, with NO socket. The worker's only contact with state is
-// the three queue verbs (Claim/Ack/Heartbeat); it never reads run history
-// or projections, so the producer stays the single source of truth by
-// construction, not convention.
+// selfWorkerPool launches count in-process workers for single-node mode
+// (--worker). Each runs the SAME claim→execute→ack loop as a remote worker
+// (see worker / consume), over its own localQueueClient — a thin in-process
+// adapter on the state backend, with NO socket. A worker's only contact
+// with state is the three queue verbs (Claim/Ack/Heartbeat); it never reads
+// run history or projections, so the producer stays the single source of
+// truth by construction, not convention.
 //
-// Run events still reach the store through the producer's in-process slog
-// sink (same process), so unlike a remote worker there is nothing to ship.
-// Jobs run one at a time (consume is serial); the reaper recovers a job if
-// this worker dies mid-run.
-func selfWorker(ctx context.Context, store state.Backend, croniclePath string, wg *sync.WaitGroup) {
-	wg.Add(1)
-	defer wg.Done()
-	workerID := SelfWorkerID()
-	lc := &localQueueClient{store: store, workerID: workerID, ctx: ctx}
-	w := newWorker(ctx, lc, workerID, 30*time.Second, 100*time.Second)
-	slog.Info("self-worker started", "worker_id", workerID)
-	if err := w.consume(croniclePath); err != nil && !errors.Is(err, context.Canceled) {
-		slog.Error("self-worker stopped", "error", err.Error())
+// Each consume loop runs one job at a time, so count workers = up to count
+// jobs concurrently; the store's atomic Claim keeps two from grabbing the
+// same job. count<=1 runs a single (serial) worker. Run events reach the
+// store through the producer's in-process slog sink (same process), so
+// unlike a remote worker there is nothing to ship. The reaper recovers a
+// job if a worker dies mid-run.
+//
+// Non-blocking: spawns the workers (registering each on wg) and returns.
+func selfWorkerPool(ctx context.Context, store state.Backend, croniclePath string, count int, wg *sync.WaitGroup) {
+	if count < 1 {
+		count = 1
+	}
+	base := SelfWorkerID()
+	for i := 0; i < count; i++ {
+		workerID := base
+		if count > 1 {
+			// Distinct IDs so claims/heartbeats are attributable per worker.
+			workerID = base + "-" + strconv.Itoa(i)
+		}
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			lc := &localQueueClient{store: store, workerID: id, ctx: ctx}
+			w := newWorker(ctx, lc, id, 30*time.Second, 100*time.Second)
+			slog.Info("self-worker started", "worker_id", id)
+			if err := w.consume(croniclePath); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Error("self-worker stopped", "worker_id", id, "error", err.Error())
+			}
+		}(workerID)
 	}
 }
 

--- a/internal/cronicle/worker_concurrency_test.go
+++ b/internal/cronicle/worker_concurrency_test.go
@@ -1,0 +1,73 @@
+package cronicle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// TestSelfWorkerPool_RunsJobsConcurrently verifies the pool actually
+// parallelizes: N sleepy jobs across N workers finish in roughly one
+// sleep, not N sleeps. A single (serial) worker would take ~N× as long.
+func TestSelfWorkerPool_RunsJobsConcurrently(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	const n = 4
+	const sleep = 400 * time.Millisecond
+	dir := t.TempDir()
+	for i := 0; i < n; i++ {
+		out := filepath.Join(dir, fmt.Sprintf("job%d.done", i))
+		runID := fmt.Sprintf("R%d", i)
+		sch := Schedule{
+			Name:  "demo",
+			RunID: runID,
+			Tasks: []Task{{Name: "t", Command: []string{"bash", "-c", "sleep 0.4; printf ok > " + out}}},
+		}
+		payload, _ := json.Marshal(sch)
+		if err := store.Enqueue(runID, "demo", payload); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	start := time.Now()
+	selfWorkerPool(ctx, store, "", n, &wg)
+
+	// Wait for all jobs to finish (all marker files present).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		done := 0
+		for i := 0; i < n; i++ {
+			if _, err := os.Stat(filepath.Join(dir, fmt.Sprintf("job%d.done", i))); err == nil {
+				done++
+			}
+		}
+		if done == n {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d/%d jobs finished before timeout", done, n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	elapsed := time.Since(start)
+
+	// Serial would be ~n*sleep (1.6s). Concurrent is ~sleep + overhead.
+	// Assert comfortably below the serial floor.
+	if elapsed > time.Duration(n)*sleep-200*time.Millisecond {
+		t.Errorf("pool of %d ran in %v — looks serial (serial floor ~%v)", n, elapsed, time.Duration(n)*sleep)
+	}
+}


### PR DESCRIPTION
Follow-up to #131. Unifying the self-worker onto the shared `consume` loop made single-node execution serial (one job at a time). This restores concurrency the same way the distributed side scales — **by worker count**.

## What
- `selfWorker` → **`selfWorkerPool(count)`**: launches N in-process workers, each its own `localQueueClient` + `consume` loop with a distinct `worker_id`. The store's atomic `Claim` keeps two workers off the same job, so **N workers = up to N concurrent jobs**. `count<=1` is a single serial worker.
- New **`RunOptions.WorkerCount`** + **`--worker-count` flag (default 4)**. This bounds what used to be *unbounded* goroutine-per-job concurrency before #131 — a small improvement (no goroutine explosion when many schedules fire at once), still tunable.
- `cron.go` / `cron_source.go` call `selfWorkerPool` (non-blocking — it spawns and registers each worker on the WaitGroup).

## Why a pool (not goroutine-per-job)
Keeps the model identical to remote workers: one worker = one job at a time; concurrency = how many workers. Same `consume`/`execute` loop, same cancel/heartbeat semantics, no special concurrency path. Single-node with `--worker-count N` mirrors distributed with N worker pods.

## Default = 4
Restores practical concurrency for the common "several schedules fire together" case while bounding resource use. Tunable per deployment; raise it for agent-heavy (IO-bound) workloads. Easy to change if you'd prefer a different default (e.g. `runtime.NumCPU()`).

## Tests
- `worker_concurrency_test` — 4×400ms jobs through a pool of 4 finish in ~0.42s, well under the ~1.6s serial floor.
- Verified the binary honors `--worker-count` (N distinct `self-worker started` IDs). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)