### PR TITLE
fix(last_run): register ${last_run}/${last_run_epoch} in the HCL eval context

### DIFF
--- a/internal/cronicle/last_run_integration_test.go
+++ b/internal/cronicle/last_run_integration_test.go
@@ -1,0 +1,63 @@
+package cronicle
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+
+	"github.com/jshiv/cronicle/internal/cronicle/state"
+)
+
+// TestLastRun_HCLToExec_Integration is the full-stack guard for ${last_run}:
+// parse it from a real HCL command, resolve it at dispatch from the state
+// store (the producer's job), execute, and check the value the task
+// actually received. It ties together every layer that has had a bug:
+//
+//   - HCL eval context registration (#133 — without it, parse fails here)
+//   - dispatch-time resolution from the authoritative store (#127)
+//   - exec-time substitution of task.LastRun (#126)
+//
+// First run (no prior success) -> empty (full backfill). After a prior
+// successful run exists -> that run's start time.
+func TestLastRun_HCLToExec_Integration(t *testing.T) {
+	store, err := state.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	out := filepath.Join(t.TempDir(), "lr.txt")
+	hcl := fmt.Sprintf(`schedule "lr" {
+  cron = "@once"
+  task "show" {
+    command = ["bash", "-c", "printf %%s ${last_run} > %s"]
+  }
+}`, out)
+
+	conf, diags := ParseBytes([]byte(hcl), "cronicle.hcl", hclparse.NewParser())
+	if diags.HasErrors() {
+		t.Fatalf("HCL parse failed (is ${last_run} registered in the eval context?): %s", diags.Error())
+	}
+	sch := conf.Schedules[0]
+
+	// First fire: no prior successful run -> ${last_run} empty.
+	sch.RunID = "R-first"
+	resolveLastRun(store, &sch)
+	sch.ExecuteTasks()
+	if got := readFile(t, out); got != "" {
+		t.Errorf("first run: ${last_run} = %q, want empty (full backfill)", got)
+	}
+
+	// Record a prior successful run, fire again: ${last_run} == its start.
+	prior := time.Now().Add(-26 * time.Hour).Truncate(time.Second)
+	seedRun(t, store, "R-prior", "lr", "succeeded", prior)
+	sch.RunID = "R-second"
+	resolveLastRun(store, &sch)
+	sch.ExecuteTasks()
+	if got := readFile(t, out); got != prior.UTC().Format(time.RFC3339) {
+		t.Errorf("second run: ${last_run} = %q, want prior run start %q", got, prior.UTC().Format(time.RFC3339))
+	}
+}

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -93,7 +93,15 @@ var (
 			// Used in mcp { command = ["...", "${path}/data"] }
 			// patterns where the server needs a real filesystem path.
 			"path": cty.StringVal("${path}"),
-			"env":  envContextVar(),
+			// last_run / last_run_epoch survive HCL parse as their literal
+			// tokens, then exec.go substitutes the prior successful run's
+			// start (resolved at dispatch — see resolveLastRun). Without
+			// these entries HCL rejects "${last_run}" as an unknown
+			// variable, so the token is unusable from a .hcl file even
+			// though the exec-time replacer knows it.
+			"last_run":       cty.StringVal("${last_run}"),
+			"last_run_epoch": cty.StringVal("${last_run_epoch}"),
+			"env":            envContextVar(),
 		},
 	}
 

--- a/internal/cronicle/parse_lastrun_test.go
+++ b/internal/cronicle/parse_lastrun_test.go
@@ -8,33 +8,58 @@ import (
 	"github.com/jshiv/cronicle/internal/cronicle"
 )
 
-// TestParse_LastRunTokenSurvivesHCL guards that ${last_run} /
-// ${last_run_epoch} are usable from an actual .hcl file. They must be
-// registered in the HCL eval context so they survive parse as their
-// literal tokens (for the exec-time replacer to substitute at dispatch).
-// Without that registration HCL rejects "${last_run}" as an unknown
-// variable and the whole config fails to parse — even though the
-// exec-time replacer knows the token. (Regression: shipped that way in
-// the original ${last_run} feature; no test parsed it from HCL.)
-func TestParse_LastRunTokenSurvivesHCL(t *testing.T) {
-	src := []byte(`
-schedule "lr" {
-  cron = "@every 3s"
-  task "show" {
-    command = ["bash", "-c", "echo since=${last_run} epoch=${last_run_epoch}"]
-  }
+// commandTokens is every template token the exec-time replacer (exec.go)
+// substitutes into a task command. Each MUST also be registered in the HCL
+// eval context (parse.go CommandEvalContext) or it can't be used from a
+// .hcl file at all — HCL rejects the unknown variable and the whole config
+// fails to parse.
+//
+// >> When you add a token to exec.go's strings.NewReplacer, add it here. <<
+var commandTokens = []string{
+	"date", "datetime", "timestamp",
+	"path", "scratch",
+	"last_run", "last_run_epoch",
 }
-`)
-	conf, diags := cronicle.ParseBytes(src, "cronicle.hcl", hclparse.NewParser())
-	if diags.HasErrors() {
-		t.Fatalf("HCL parse errored on ${last_run}: %s", diags.Error())
+
+// TestParse_CommandTokensSurviveHCL is the regression guard for the class
+// of bug shipped in the original ${last_run} feature: a token wired into
+// the exec replacer but NOT the HCL eval context, so it worked from
+// Go-built commands (every existing test) yet failed to parse from a real
+// .hcl file. For each token, parse an HCL command using it and assert the
+// config parses and the token survives literally for the exec replacer.
+func TestParse_CommandTokensSurviveHCL(t *testing.T) {
+	for _, name := range commandTokens {
+		tok := "${" + name + "}"
+		t.Run(name, func(t *testing.T) {
+			src := []byte(`schedule "s" {
+  cron = "@once"
+  task "t" {
+    command = ["echo", "X=` + tok + `"]
+  }
+}`)
+			conf, diags := cronicle.ParseBytes(src, "cronicle.hcl", hclparse.NewParser())
+			if diags.HasErrors() {
+				t.Fatalf("HCL parse failed for %s: %s", tok, diags.Error())
+			}
+			if conf == nil || len(conf.Schedules) != 1 || len(conf.Schedules[0].Tasks) != 1 {
+				t.Fatalf("unexpected parse result for %s: %+v", tok, conf)
+			}
+			got := conf.Schedules[0].Tasks[0].Command
+			if len(got) != 2 || got[1] != "X="+tok {
+				t.Errorf("%s not preserved through HCL: command = %v, want [echo X=%s]", tok, got, tok)
+			}
+		})
 	}
-	if conf == nil || len(conf.Schedules) != 1 || len(conf.Schedules[0].Tasks) != 1 {
-		t.Fatalf("unexpected parse result: %+v", conf)
-	}
-	got := conf.Schedules[0].Tasks[0].Command
-	want := "echo since=${last_run} epoch=${last_run_epoch}"
-	if len(got) != 3 || got[2] != want {
-		t.Errorf("command = %v\n want token preserved literally: %q", got, want)
+}
+
+// TestCommandEvalContext_HasEveryCommandToken is the cheap structural twin
+// of the round-trip test: every command token must be a variable in the
+// HCL eval context. Catches a token removed/renamed/missed (the #133 bug)
+// without needing to parse anything.
+func TestCommandEvalContext_HasEveryCommandToken(t *testing.T) {
+	for _, name := range commandTokens {
+		if _, ok := cronicle.CommandEvalContext.Variables[name]; !ok {
+			t.Errorf("HCL eval context missing %q — ${%s} would fail to parse from a .hcl file", name, name)
+		}
 	}
 }

--- a/internal/cronicle/parse_lastrun_test.go
+++ b/internal/cronicle/parse_lastrun_test.go
@@ -1,0 +1,40 @@
+package cronicle_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+
+	"github.com/jshiv/cronicle/internal/cronicle"
+)
+
+// TestParse_LastRunTokenSurvivesHCL guards that ${last_run} /
+// ${last_run_epoch} are usable from an actual .hcl file. They must be
+// registered in the HCL eval context so they survive parse as their
+// literal tokens (for the exec-time replacer to substitute at dispatch).
+// Without that registration HCL rejects "${last_run}" as an unknown
+// variable and the whole config fails to parse — even though the
+// exec-time replacer knows the token. (Regression: shipped that way in
+// the original ${last_run} feature; no test parsed it from HCL.)
+func TestParse_LastRunTokenSurvivesHCL(t *testing.T) {
+	src := []byte(`
+schedule "lr" {
+  cron = "@every 3s"
+  task "show" {
+    command = ["bash", "-c", "echo since=${last_run} epoch=${last_run_epoch}"]
+  }
+}
+`)
+	conf, diags := cronicle.ParseBytes(src, "cronicle.hcl", hclparse.NewParser())
+	if diags.HasErrors() {
+		t.Fatalf("HCL parse errored on ${last_run}: %s", diags.Error())
+	}
+	if conf == nil || len(conf.Schedules) != 1 || len(conf.Schedules[0].Tasks) != 1 {
+		t.Fatalf("unexpected parse result: %+v", conf)
+	}
+	got := conf.Schedules[0].Tasks[0].Command
+	want := "echo since=${last_run} epoch=${last_run_epoch}"
+	if len(got) != 3 || got[2] != want {
+		t.Errorf("command = %v\n want token preserved literally: %q", got, want)
+	}
+}


### PR DESCRIPTION
## Bug
`${last_run}` / `${last_run_epoch}` (#126) were added to the **exec-time replacer** (`exec.go`) but never to **`parse.go`'s `CommandEvalContext`** — the map of tokens that survive HCL parse as their literal form (alongside `${date}`, `${scratch}`, `${path}`). So HCL evaluation rejected the token and the **entire config failed to parse**:

```
Error: Unknown variable; There is no variable named "last_run".
  command = ["bash","-c","echo LASTRUN=[${last_run}]"]
```

The token worked only when a command was constructed in Go — which every existing unit/e2e test does — but was **unusable from an actual `.hcl` file**, the whole point of the feature. No test parsed it from HCL, so it shipped broken in #126.

## Fix
Register `last_run` / `last_run_epoch` as self-echoing literals in the eval context, exactly like the other tokens. They survive parse to the exec-time replacer, which substitutes the dispatch-resolved value (#127).

## Verified end-to-end (real binary, both modes)
Smoke-tested `echo LASTRUN=[${last_run}]` on `@every 3s`:
- **single-node**: `LASTRUN=[]` (first run, backfill) → `[…56Z]` → `[…59Z]` (later runs carry the prior run's start)
- **distributed** (producer + remote worker): `[]` → `[…19Z]` → `[…22Z]` → `[…25Z]` — the producer-resolved value crosses the wire to the remote worker

New `TestParse_LastRunTokenSurvivesHCL` guards the HCL parse path that was missing. Full suite green.

## Note
This unblocks the MCP-prompt docs (cronicle-infra #83) and the podcast-alpha `${last_run}` wiring, both of which use the token from HCL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)