### PR TITLE
chore(ci): point push trigger at main after default-branch rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 # PR-time validation: go vet + go test ./...
-# Runs on every PR and on push to master (catches direct merges).
+# Runs on every PR and on push to main (catches direct merges).
 #
 # gofmt is intentionally not enforced here — Go 1.26 reflows godoc lists
 # differently than earlier versions, so re-enabling it requires a one-time
@@ -10,7 +10,7 @@ name: ci
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "**/*.md"
       - "docs/**"


### PR DESCRIPTION
Default branch was renamed master→main; update the ci.yml push trigger + comment to match. PR CI is unaffected (the `pull_request` trigger has no branch filter).