### PR TITLE
feat(state): Postgres backend for state.Backend (DSN dispatch)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,6 +55,10 @@ The run command will log schedule information to stdout including git commit inf
 		if listenToken == "" {
 			listenToken = os.Getenv("CRONICLE_LISTEN_TOKEN")
 		}
+		stateSource, _ := cmd.Flags().GetString("state-source")
+		if stateSource == "" {
+			stateSource = os.Getenv("CRONICLE_STATE_SOURCE")
+		}
 
 		ctx, stop := signal.NotifyContext(context.Background(),
 			syscall.SIGINT, syscall.SIGTERM)
@@ -66,6 +70,7 @@ The run command will log schedule information to stdout including git commit inf
 			LogToFile:   logToFile,
 			ListenAddr:  listenAddr,
 			ListenToken: listenToken,
+			StateSource: stateSource,
 			// Defer secret-source startup until AFTER cronicle has opened
 			// state.db — the secretstore binds to that backend, so it has
 			// to land in the right order. The hook closes over `cmd` so
@@ -129,6 +134,7 @@ func init() {
 	runCmd.Flags().Bool("log-to-file", false, "mirror structured JSON logs to path/.cronicle/log/cronicle.jsonl (rotated by lumberjack); stdout is unaffected and remains controlled by --log-format")
 	runCmd.Flags().String("listen", "", "host:port to expose the remote-trigger HTTP API (e.g. :8765). Empty disables. Requires --listen-token.")
 	runCmd.Flags().String("listen-token", "", "bearer token for the remote-trigger HTTP API (or env CRONICLE_LISTEN_TOKEN). Required when --listen is set.")
+	runCmd.Flags().String("state-source", "", "state plane DSN (or env CRONICLE_STATE_SOURCE). Empty → local .cronicle/state.db (SQLite); postgres://… → durable Postgres so run history / ${last_run} survive restarts.")
 	addSecretSourceFlags(runCmd)
 
 	// Here you will define your flags and configuration settings.

--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,19 @@ import (
 
 	cron "github.com/robfig/cron/v3"
 )
+
+// redactDSN masks the password in a postgres:// DSN for safe logging.
+func redactDSN(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil || u.User == nil {
+		return dsn
+	}
+	if _, hasPw := u.User.Password(); hasPw {
+		u.User = url.UserPassword(u.User.Username(), "***")
+		return u.String()
+	}
+	return dsn
+}
 
 // Run is the main function of the cron package.
 //
@@ -57,15 +71,27 @@ func Run(ctx context.Context, cronicleFile string, runOptions RunOptions) {
 		}
 	}
 
-	// State plane: SQLite-backed projection of slog events. Lives at
-	// .cronicle/state.db so the lifetime matches the schedule directory.
-	// Currently the store is built into the producer; once Phase 2 lands
-	// the listener and the API will share this same handle.
-	stateDir := filepath.Join(croniclePath, ".cronicle")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		slog.Warn("state dir mkdir failed; projection disabled", "error", err.Error())
-	} else if err := EnableStateStore(filepath.Join(stateDir, "state.db")); err != nil {
-		slog.Warn("state store open failed; projection disabled", "error", err.Error())
+	// State plane: projection of slog events + the durable job queue.
+	// Default is a local SQLite at .cronicle/state.db (ephemeral in managed
+	// pods). When --state-source / CRONICLE_STATE_SOURCE points at a
+	// postgres:// DSN, the producer uses a durable, restart-surviving store
+	// instead — so run history (and ${last_run}) persists across pod
+	// recreation. The worker is unaffected: it still reaches all state
+	// through the producer over HTTP.
+	if runOptions.StateSource != "" {
+		if err := EnableStateStore(runOptions.StateSource); err != nil {
+			slog.Warn("state store open failed; projection disabled",
+				"source", redactDSN(runOptions.StateSource), "error", err.Error())
+		} else {
+			slog.Info("state store: external", "source", redactDSN(runOptions.StateSource))
+		}
+	} else {
+		stateDir := filepath.Join(croniclePath, ".cronicle")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			slog.Warn("state dir mkdir failed; projection disabled", "error", err.Error())
+		} else if err := EnableStateStore(filepath.Join(stateDir, "state.db")); err != nil {
+			slog.Warn("state store open failed; projection disabled", "error", err.Error())
+		}
 	}
 
 	if runOptions.PostStateStoreHook != nil {
@@ -163,6 +189,12 @@ type RunOptions struct {
 	// up to N jobs executing concurrently. <=1 means one worker (serial).
 	// Ignored when RunWorker is false or in non-listener mode.
 	WorkerCount int
+	// StateSource overrides where the state plane lives. Empty → local
+	// .cronicle/state.db (SQLite). A postgres:// DSN → durable Postgres,
+	// so run history / ${last_run} survive pod recreation. Set via
+	// --state-source or CRONICLE_STATE_SOURCE; in managed deployments the
+	// control plane injects a per-deployment DSN for the PRODUCER pod.
+	StateSource string
 	// LogToFile mirrors structured logs to .cronicle/log/cronicle.jsonl
 	// rotated by lumberjack. Independent of stdout.
 	LogToFile bool

--- a/internal/cronicle/state/control.go
+++ b/internal/cronicle/state/control.go
@@ -177,8 +177,9 @@ func (s *Store) Retry(runID, newRunID string) (RetryResult, error) {
 	// re-acquires s.mu, so re-implement the INSERT here.
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err := s.db.Exec(`
-		INSERT OR IGNORE INTO jobs(run_id, schedule, payload, status, enqueued_at)
-		VALUES (?, ?, ?, ?, ?)`,
+		INSERT INTO jobs(run_id, schedule, payload, status, enqueued_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (run_id) DO NOTHING`,
 		newRunID, schedule, string(newPayload), JobPending, now,
 	); err != nil {
 		return RetryResult{}, fmt.Errorf("Retry: enqueue: %w", err)
@@ -281,8 +282,9 @@ func (s *Store) RetryFailed(runID, newRunID string) (RetryResult, error) {
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err := s.db.Exec(`
-		INSERT OR IGNORE INTO jobs(run_id, schedule, payload, status, enqueued_at)
-		VALUES (?, ?, ?, ?, ?)`,
+		INSERT INTO jobs(run_id, schedule, payload, status, enqueued_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (run_id) DO NOTHING`,
 		newRunID, schedule, string(newPayload), JobPending, now,
 	); err != nil {
 		return RetryResult{}, fmt.Errorf("RetryFailed: enqueue: %w", err)
@@ -379,8 +381,9 @@ func (s *Store) RetryTask(runID, taskName string, keep map[string]bool, newRunID
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err := s.db.Exec(`
-		INSERT OR IGNORE INTO jobs(run_id, schedule, payload, status, enqueued_at)
-		VALUES (?, ?, ?, ?, ?)`,
+		INSERT INTO jobs(run_id, schedule, payload, status, enqueued_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (run_id) DO NOTHING`,
 		newRunID, schedule, string(newPayload), JobPending, now,
 	); err != nil {
 		return RetryResult{}, fmt.Errorf("RetryTask: enqueue: %w", err)

--- a/internal/cronicle/state/pg.go
+++ b/internal/cronicle/state/pg.go
@@ -1,0 +1,174 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+// dialect selects SQL flavor. The state store was written for SQLite; the
+// Postgres path reuses the same queries with a thin placeholder-rebind
+// driver + a DDL transform, so there's one schema/query source of truth.
+type dialect int
+
+const (
+	dialectSQLite dialect = iota
+	dialectPostgres
+)
+
+func isPostgresDSN(dsn string) bool {
+	return strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://")
+}
+
+// ---- placeholder-rebind driver ---------------------------------------------
+//
+// All Store queries use `?` placeholders (SQLite). Postgres wants `$1,$2,…`.
+// Rather than rewrite ~70 query sites, we register a tiny driver that wraps
+// pgx's stdlib driver and rebinds `?`→`$N` at Prepare time. Every query in
+// database/sql funnels through Prepare, so this covers exec/query/tx alike.
+
+const pgxRebindDriverName = "cronicle-pgx-rebind"
+
+var registerPGOnce sync.Once
+
+func registerPGDriver() {
+	registerPGOnce.Do(func() {
+		sql.Register(pgxRebindDriverName, rebindDriver{base: stdlib.GetDefaultDriver()})
+	})
+}
+
+type rebindDriver struct{ base driver.Driver }
+
+func (d rebindDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &rebindConn{Conn: c}, nil
+}
+
+// rebindConn overrides only Prepare; Close/Begin are promoted from the
+// embedded driver.Conn. database/sql falls back to prepared statements for
+// Exec/Query when QueryerContext/ExecerContext aren't implemented, so every
+// statement gets rebound. (We trade the direct-exec fast path for not having
+// to touch every call site — fine at cronicle's load.)
+type rebindConn struct{ driver.Conn }
+
+func (c *rebindConn) Prepare(query string) (driver.Stmt, error) {
+	return c.Conn.Prepare(rebindQuery(query))
+}
+
+// PrepareContext preserves the context (statement cancellation) while
+// rebinding. database/sql routes Query/ExecContext through this when the
+// conn doesn't implement Queryer/ExecerContext (we don't), so every
+// statement is both context-aware and rebound.
+func (c *rebindConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if cp, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		return cp.PrepareContext(ctx, rebindQuery(query))
+	}
+	return c.Conn.Prepare(rebindQuery(query))
+}
+
+// BeginTx forwards to pgx's tx (which honors isolation levels) — the
+// queue's atomic claim uses a non-default isolation level, which the
+// deprecated driver.Conn.Begin can't express.
+func (c *rebindConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if ct, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return ct.BeginTx(ctx, opts)
+	}
+	return c.Conn.Begin()
+}
+
+// rebindQuery converts `?` placeholders to `$1,$2,…`, skipping any `?`
+// inside single-quoted string literals.
+func rebindQuery(q string) string {
+	if !strings.ContainsRune(q, '?') {
+		return q
+	}
+	var b strings.Builder
+	b.Grow(len(q) + 8)
+	n := 0
+	inQuote := false
+	for i := 0; i < len(q); i++ {
+		ch := q[i]
+		switch {
+		case ch == '\'':
+			inQuote = !inQuote
+			b.WriteByte(ch)
+		case ch == '?' && !inQuote:
+			n++
+			b.WriteByte('$')
+			b.WriteString(strconv.Itoa(n))
+		default:
+			b.WriteByte(ch)
+		}
+	}
+	return b.String()
+}
+
+// ---- DDL dialect transform -------------------------------------------------
+
+// dialectizePG rewrites the SQLite DDL constants into Postgres-compatible
+// form. The differences are systematic and the DDL is fully controlled (no
+// user input), so targeted string replacement is safe.
+func dialectizePG(ddl string) string {
+	r := strings.NewReplacer(
+		// AUTOINCREMENT integer PK → identity column.
+		"INTEGER PRIMARY KEY AUTOINCREMENT", "BIGSERIAL PRIMARY KEY",
+		// CURRENT_TIMESTAMP is timestamptz in PG; the columns are TEXT, so
+		// cast on default.
+		"DEFAULT (CURRENT_TIMESTAMP)", "DEFAULT (CURRENT_TIMESTAMP::text)",
+		// SQLite BLOB → PG BYTEA (secrets value_ct/value_nonce).
+		" BLOB", " BYTEA",
+	)
+	return r.Replace(ddl)
+}
+
+// splitStatements breaks a multi-statement DDL block into individual
+// statements. pgx's extended protocol rejects multi-statement Exec, and
+// splitting is harmless for SQLite too — so migrate runs every statement
+// individually regardless of dialect. The state DDL has no `;` inside
+// string literals, so a naive split is correct here.
+func splitStatements(block string) []string {
+	var out []string
+	var cur strings.Builder
+	inLineComment := false // inside `-- … \n`
+	inQuote := false       // inside '…'
+	for i := 0; i < len(block); i++ {
+		ch := block[i]
+		switch {
+		case inLineComment:
+			cur.WriteByte(ch)
+			if ch == '\n' {
+				inLineComment = false
+			}
+		case inQuote:
+			cur.WriteByte(ch)
+			if ch == '\'' {
+				inQuote = false
+			}
+		case ch == '-' && i+1 < len(block) && block[i+1] == '-':
+			inLineComment = true
+			cur.WriteByte(ch)
+		case ch == '\'':
+			inQuote = true
+			cur.WriteByte(ch)
+		case ch == ';':
+			if strings.TrimSpace(cur.String()) != "" {
+				out = append(out, cur.String())
+			}
+			cur.Reset()
+		default:
+			cur.WriteByte(ch)
+		}
+	}
+	if strings.TrimSpace(cur.String()) != "" {
+		out = append(out, cur.String())
+	}
+	return out
+}

--- a/internal/cronicle/state/pg.go
+++ b/internal/cronicle/state/pg.go
@@ -4,12 +4,34 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/jackc/pgx/v5/stdlib"
 )
+
+// schemaFromDSN returns the per-deployment schema pinned via the DSN's
+// search_path (first entry if a list), or "" for none. The producer
+// self-creates this schema on connect so the control plane doesn't need
+// DB access — it just hands over a DSN scoped to the deployment.
+func schemaFromDSN(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return ""
+	}
+	sp := u.Query().Get("search_path")
+	if i := strings.IndexByte(sp, ','); i >= 0 {
+		sp = sp[:i]
+	}
+	return strings.TrimSpace(sp)
+}
+
+// quoteIdent double-quotes a Postgres identifier (schema name from the DSN).
+func quoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
 
 // dialect selects SQL flavor. The state store was written for SQLite; the
 // Postgres path reuses the same queries with a thin placeholder-rebind

--- a/internal/cronicle/state/pg_integration_test.go
+++ b/internal/cronicle/state/pg_integration_test.go
@@ -1,0 +1,146 @@
+package state
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// TestPostgres_Backend_Integration exercises the Postgres state.Backend
+// against a real Postgres (set TEST_PG_DSN, e.g.
+// postgres://postgres:pw@127.0.0.1:5433/cronicle?sslmode=disable).
+// Skipped otherwise so CI (no Postgres) stays green. Covers the
+// dialect-heavy surface: event→run projection (the ${last_run} read),
+// the durable job queue, and secrets.
+func TestPostgres_Backend_Integration(t *testing.T) {
+	dsn := os.Getenv("TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set TEST_PG_DSN to run the Postgres state.Backend integration test")
+	}
+	resetPublicSchema(t, dsn)
+
+	s, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("Open(postgres): %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if s.dialect != dialectPostgres {
+		t.Fatalf("dialect = %v, want postgres", s.dialect)
+	}
+
+	apply := func(line string) {
+		ev, ok := DecodeEvent([]byte(line))
+		if !ok {
+			t.Fatalf("decode: %s", line)
+		}
+		if err := s.Apply(ev); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	}
+
+	// --- run projection / the ${last_run} read path ---
+	apply(`{"time":"2026-06-01T10:00:00Z","entry_type":"schedule_start","run_id":"R1","schedule":"daily","tasks":["t"]}`)
+	apply(`{"time":"2026-06-01T10:00:05Z","entry_type":"schedule_complete","run_id":"R1","schedule":"daily","task_count":1,"duration_ms":5000,"success":true}`)
+	apply(`{"time":"2026-06-01T11:00:00Z","entry_type":"schedule_start","run_id":"R2","schedule":"daily","tasks":["t"]}`)
+	apply(`{"time":"2026-06-01T11:00:05Z","entry_type":"schedule_complete","run_id":"R2","schedule":"daily","task_count":1,"duration_ms":5000,"success":true}`)
+
+	got, err := s.ListRuns(ListFilter{Schedule: "daily", Status: StatusSucceeded, Limit: 1})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(got) != 1 || got[0].RunID != "R2" {
+		t.Fatalf("ListRuns last-success = %+v, want R2", got)
+	}
+	if got[0].StartedAt.IsZero() {
+		t.Errorf("R2 started_at is zero — ${last_run} would be empty")
+	}
+
+	// --- durable job queue: enqueue → claim → ack ---
+	if err := s.Enqueue("J1", "daily", []byte(`{"name":"daily"}`)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	job, err := s.Claim("W1", time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if job.RunID != "J1" {
+		t.Fatalf("claimed %q, want J1", job.RunID)
+	}
+	if err := s.Ack("J1", "W1", true, ""); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+
+	// --- workers registry (upserted on claim; explicit upsert too) ---
+	if err := s.UpsertWorker("W1", "host-a"); err != nil {
+		t.Fatalf("UpsertWorker: %v", err)
+	}
+	if ws, err := s.ListWorkers(); err != nil || len(ws) == 0 {
+		t.Fatalf("ListWorkers: %v (n=%d)", err, len(ws))
+	}
+
+	// --- secrets ---
+	if err := s.PutSecret("FOO", "bar", "tester"); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+	v, ok, err := s.GetSecret("FOO")
+	if err != nil || !ok || v != "bar" {
+		t.Fatalf("GetSecret = (%q,%v,%v), want (bar,true,nil)", v, ok, err)
+	}
+
+	// --- runtime control state tables (CURRENT_TIMESTAMP defaults, upserts) ---
+	if err := s.SetDrained("tester", "maintenance"); err != nil {
+		t.Fatalf("SetDrained: %v", err)
+	}
+	if drained, err := s.IsDrained(); err != nil || !drained {
+		t.Fatalf("IsDrained = (%v,%v), want true", drained, err)
+	}
+	if err := s.SetSchedulePaused("daily", "tester", "hold"); err != nil {
+		t.Fatalf("SetSchedulePaused: %v", err)
+	}
+	if paused, err := s.IsSchedulePaused("daily"); err != nil || !paused {
+		t.Fatalf("IsSchedulePaused = (%v,%v), want true", paused, err)
+	}
+
+	// --- control channel (pub/sub) ---
+	ch, unsub := s.Subscribe("W1")
+	defer unsub()
+	if !s.PushControl("W1", ControlMsg{Type: "cancel", RunID: "J1"}) {
+		t.Fatalf("PushControl: not delivered")
+	}
+	select {
+	case msg := <-ch:
+		if msg.Type != "cancel" || msg.RunID != "J1" {
+			t.Fatalf("control msg = %+v, want cancel/J1", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("control msg not received")
+	}
+
+	// --- the crux: durability across a reconnect (= producer pod restart) ---
+	_ = s.Close()
+	s2, err := Open(dsn) // reconnect to the SAME Postgres; migrate is idempotent
+	if err != nil {
+		t.Fatalf("reopen(postgres): %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+	got2, err := s2.ListRuns(ListFilter{Schedule: "daily", Status: StatusSucceeded, Limit: 1})
+	if err != nil || len(got2) != 1 || got2[0].RunID != "R2" {
+		t.Fatalf("after reconnect ListRuns = %+v (err %v), want R2 — history must survive", got2, err)
+	}
+}
+
+// resetPublicSchema drops + recreates the public schema for a clean slate.
+func resetPublicSchema(t *testing.T, dsn string) {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw pg: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+}

--- a/internal/cronicle/state/pg_secrets_test.go
+++ b/internal/cronicle/state/pg_secrets_test.go
@@ -1,0 +1,84 @@
+package state
+
+import (
+	"os"
+	"testing"
+)
+
+// TestPostgres_EncryptedSecrets validates the at-rest-encrypted secret path
+// against a real Postgres (the kind cluster runs with CRONICLE_DEK_HEX set, so
+// secrets land in the BYTEA value_ct/value_nonce columns rather than the
+// plaintext column). The plaintext round-trip is covered by the main
+// integration test; this one specifically exercises:
+//   - Seal on write -> BYTEA columns through the pgx rebind driver
+//   - Open on read after a reconnect (= producer pod restart) -> decrypt
+//   - fail-loud when the DEK is absent but the row is encrypted
+//
+// Env-guarded by TEST_PG_DSN, same as TestPostgres_Backend_Integration.
+func TestPostgres_EncryptedSecrets(t *testing.T) {
+	dsn := os.Getenv("TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set TEST_PG_DSN to run the Postgres encrypted-secret integration test")
+	}
+	resetPublicSchema(t, dsn)
+
+	// 32-byte DEK (64 hex chars), same shape as CRONICLE_DEK_HEX in prod/kind.
+	const dekHex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+	aead, err := NewAEAD(dekHex)
+	if err != nil {
+		t.Fatalf("NewAEAD: %v", err)
+	}
+
+	const name = "ANTHROPIC_API_KEY"
+	const secret = "sk-ant-xchacha-roundtrip-9f3c-AND-some-padding-to-exceed-a-block"
+
+	s, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.WithAEAD(aead)
+	if err := s.PutSecret(name, secret, "tester"); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+	_ = s.Close()
+
+	// Reopen with the SAME DEK: value_ct/value_nonce must survive the BYTEA
+	// round-trip and decrypt back to the original plaintext.
+	s2, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	s2.WithAEAD(aead)
+	got, ok, err := s2.GetSecret(name)
+	if err != nil || !ok {
+		t.Fatalf("GetSecret = (%q, %v, %v), want decrypted value", got, ok, err)
+	}
+	if got != secret {
+		t.Fatalf("decrypted = %q, want %q", got, secret)
+	}
+
+	// Confirm it was actually stored encrypted: empty plaintext column, non-empty
+	// ciphertext + nonce (the same shape we observed in the kind Postgres).
+	var plainLen, ctLen, nonceLen int
+	row := s2.db.QueryRow(
+		`SELECT COALESCE(length(value),0), COALESCE(length(value_ct),0), COALESCE(length(value_nonce),0)
+		   FROM secrets WHERE name = ?`, name)
+	if err := row.Scan(&plainLen, &ctLen, &nonceLen); err != nil {
+		t.Fatalf("inspect row: %v", err)
+	}
+	if plainLen != 0 || ctLen == 0 || nonceLen == 0 {
+		t.Fatalf("want ciphertext-only row, got plain=%d ct=%d nonce=%d", plainLen, ctLen, nonceLen)
+	}
+	_ = s2.Close()
+
+	// Fail-loud: reopening WITHOUT a DEK must refuse to read the encrypted row
+	// rather than silently returning garbage.
+	s3, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("reopen no-dek: %v", err)
+	}
+	defer s3.Close()
+	if v, _, err := s3.GetSecret(name); err == nil {
+		t.Fatalf("GetSecret without DEK should error on an encrypted row, got value %q nil err", v)
+	}
+}

--- a/internal/cronicle/state/queue.go
+++ b/internal/cronicle/state/queue.go
@@ -70,8 +70,9 @@ func (s *Store) Enqueue(runID, schedule string, payload []byte) error {
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	_, err := s.db.Exec(`
-		INSERT OR IGNORE INTO jobs(run_id, schedule, payload, status, enqueued_at)
-		VALUES (?, ?, ?, ?, ?)`,
+		INSERT INTO jobs(run_id, schedule, payload, status, enqueued_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (run_id) DO NOTHING`,
 		runID, schedule, string(payload), JobPending, now,
 	)
 	if err != nil {

--- a/internal/cronicle/state/schema.go
+++ b/internal/cronicle/state/schema.go
@@ -254,7 +254,7 @@ CREATE TABLE IF NOT EXISTS runner_state (
     reason      TEXT NOT NULL DEFAULT '',
     updated_at  TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 );
-INSERT OR IGNORE INTO runner_state(id) VALUES (1);
+INSERT INTO runner_state(id) VALUES (1) ON CONFLICT (id) DO NOTHING;
 `
 
 // schemaSQL_v9 adds the secrets table — the in-tree key/value store
@@ -292,7 +292,7 @@ CREATE TABLE IF NOT EXISTS secrets_meta (
     id              INTEGER PRIMARY KEY CHECK (id = 1),
     etag_counter    INTEGER NOT NULL DEFAULT 0
 );
-INSERT OR IGNORE INTO secrets_meta(id) VALUES (1);
+INSERT INTO secrets_meta(id) VALUES (1) ON CONFLICT (id) DO NOTHING;
 `
 
 // schemaSQL_v10 adds at-rest envelope encryption to the secrets table.

--- a/internal/cronicle/state/secrets.go
+++ b/internal/cronicle/state/secrets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 )
 
 // SecretStore implementation backed by the v9 `secrets` + `secrets_meta`
@@ -32,6 +33,9 @@ func (s *Store) PutSecret(name, value, actor string) error {
 	if name == "" {
 		return errors.New("state.PutSecret: empty name")
 	}
+	// Bind the timestamp in Go rather than SQL datetime('now') so the
+	// query is portable across sqlite/postgres.
+	now := time.Now().UTC().Format("2006-01-02 15:04:05")
 	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("state.PutSecret: begin: %w", err)
@@ -50,30 +54,30 @@ func (s *Store) PutSecret(name, value, actor string) error {
 		// crashing on a missing column).
 		if _, err := tx.Exec(`
 			INSERT INTO secrets (name, value, value_ct, value_nonce, version, updated_at, updated_by)
-			VALUES (?, '', ?, ?, 1, datetime('now'), ?)
+			VALUES (?, '', ?, ?, 1, ?, ?)
 			ON CONFLICT(name) DO UPDATE SET
 			    value       = '',
 			    value_ct    = excluded.value_ct,
 			    value_nonce = excluded.value_nonce,
 			    version     = secrets.version + 1,
-			    updated_at  = datetime('now'),
+			    updated_at  = ?,
 			    updated_by  = excluded.updated_by`,
-			name, ct, nonce, actor,
+			name, ct, nonce, now, actor, now,
 		); err != nil {
 			return fmt.Errorf("state.PutSecret: upsert: %w", err)
 		}
 	} else {
 		if _, err := tx.Exec(`
 			INSERT INTO secrets (name, value, version, updated_at, updated_by)
-			VALUES (?, ?, 1, datetime('now'), ?)
+			VALUES (?, ?, 1, ?, ?)
 			ON CONFLICT(name) DO UPDATE SET
 			    value      = excluded.value,
 			    value_ct   = NULL,
 			    value_nonce = NULL,
 			    version    = secrets.version + 1,
-			    updated_at = datetime('now'),
+			    updated_at = ?,
 			    updated_by = excluded.updated_by`,
-			name, value, actor,
+			name, value, now, actor, now,
 		); err != nil {
 			return fmt.Errorf("state.PutSecret: upsert: %w", err)
 		}

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,6 +56,7 @@ const (
 // producer. Lazy-init keeps single-node mode free of the cost.
 type Store struct {
 	db          *sql.DB
+	dialect     dialect    // sqlite (default) | postgres
 	mu          sync.Mutex // serializes write transactions
 	waitOnce    sync.Once
 	wait        *jobWaiters
@@ -163,6 +165,9 @@ func Open(dsn string) (*Store, error) {
 	if dsn == "" {
 		return nil, errors.New("state.Open: empty DSN")
 	}
+	if isPostgresDSN(dsn) {
+		return openPostgres(dsn)
+	}
 	conn := dsn
 	if dsn != ":memory:" {
 		conn = dsn + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(on)"
@@ -176,7 +181,34 @@ func Open(dsn string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("state.Open: ping: %w", err)
 	}
-	s := &Store{db: db}
+	s := &Store{db: db, dialect: dialectSQLite}
+	if err := s.migrate(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// openPostgres backs the Store with a shared, durable Postgres instead of a
+// local SQLite file. Same schema and queries (via the placeholder-rebind
+// driver + DDL dialect transform). This is what a per-deployment producer
+// uses in the managed topology so run history survives pod restarts and
+// `${last_run}` reads the authoritative record.
+func openPostgres(dsn string) (*Store, error) {
+	registerPGDriver()
+	db, err := sql.Open(pgxRebindDriverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("state.Open(postgres): %w", err)
+	}
+	// Unlike SQLite (single writer), Postgres handles concurrency; the
+	// Store's mu still serializes our write transactions.
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("state.Open(postgres): ping: %w", err)
+	}
+	s := &Store{db: db, dialect: dialectPostgres}
 	if err := s.migrate(); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -199,12 +231,27 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
+// execDDL applies one schema block: dialect-transform for Postgres, then
+// run each statement individually (pgx's extended protocol rejects
+// multi-statement Exec; splitting is harmless for SQLite too).
+func (s *Store) execDDL(block string) error {
+	if s.dialect == dialectPostgres {
+		block = dialectizePG(block)
+	}
+	for _, stmt := range splitStatements(block) {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return fmt.Errorf("execDDL: %q: %w", strings.TrimSpace(stmt)[:min(48, len(strings.TrimSpace(stmt)))], err)
+		}
+	}
+	return nil
+}
+
 // migrate runs the schema SQL idempotently and records the version.
 // Each numbered version's DDL is applied if the recorded version is < target.
 // Idempotent on re-runs because every CREATE uses IF NOT EXISTS.
 func (s *Store) migrate() error {
 	// v1: runs/tasks/events/schema_versions
-	if _, err := s.db.Exec(schemaSQL); err != nil {
+	if err := s.execDDL(schemaSQL); err != nil {
 		return fmt.Errorf("state.migrate v1: %w", err)
 	}
 	var current int
@@ -214,50 +261,50 @@ func (s *Store) migrate() error {
 	}
 	// v2: jobs (queue table)
 	if current < 2 {
-		if _, err := s.db.Exec(schemaSQL_v2); err != nil {
+		if err := s.execDDL(schemaSQL_v2); err != nil {
 			return fmt.Errorf("state.migrate v2: %w", err)
 		}
 	}
 	// v3: workers (registry)
 	if current < 3 {
-		if _, err := s.db.Exec(schemaSQL_v3); err != nil {
+		if err := s.execDDL(schemaSQL_v3); err != nil {
 			return fmt.Errorf("state.migrate v3: %w", err)
 		}
 	}
 	// v4: slim events ledger (drop payload column on upgrade)
 	if current < 4 {
-		if _, err := s.db.Exec(schemaSQL_v4); err != nil {
+		if err := s.execDDL(schemaSQL_v4); err != nil {
 			return fmt.Errorf("state.migrate v4: %w", err)
 		}
 	}
 	// v5: schedule_state (pause/drained control rows)
 	if current < 5 {
-		if _, err := s.db.Exec(schemaSQL_v5); err != nil {
+		if err := s.execDDL(schemaSQL_v5); err != nil {
 			return fmt.Errorf("state.migrate v5: %w", err)
 		}
 	}
 	// v6: task_state (per-task skip flags)
 	if current < 6 {
-		if _, err := s.db.Exec(schemaSQL_v6); err != nil {
+		if err := s.execDDL(schemaSQL_v6); err != nil {
 			return fmt.Errorf("state.migrate v6: %w", err)
 		}
 	}
 	// v7: run_state (per-run pause flag)
 	if current < 7 {
-		if _, err := s.db.Exec(schemaSQL_v7); err != nil {
+		if err := s.execDDL(schemaSQL_v7); err != nil {
 			return fmt.Errorf("state.migrate v7: %w", err)
 		}
 	}
 	// v8: runner_state (runner-wide drain flag, singleton)
 	if current < 8 {
-		if _, err := s.db.Exec(schemaSQL_v8); err != nil {
+		if err := s.execDDL(schemaSQL_v8); err != nil {
 			return fmt.Errorf("state.migrate v8: %w", err)
 		}
 	}
 	// v9: secrets table + secrets_meta(etag_counter) — the in-tree
 	// store backing the SecretStore role on Backend.
 	if current < 9 {
-		if _, err := s.db.Exec(schemaSQL_v9); err != nil {
+		if err := s.execDDL(schemaSQL_v9); err != nil {
 			return fmt.Errorf("state.migrate v9: %w", err)
 		}
 	}
@@ -266,7 +313,7 @@ func (s *Store) migrate() error {
 	// BackfillSecrets after WithAEAD — schema-level migration just
 	// adds the columns.
 	if current < 10 {
-		if _, err := s.db.Exec(schemaSQL_v10); err != nil {
+		if err := s.execDDL(schemaSQL_v10); err != nil {
 			return fmt.Errorf("state.migrate v10: %w", err)
 		}
 	}
@@ -385,8 +432,9 @@ func (s *Store) applyTrigger(tx *sql.Tx, e Event) error {
 		source = SourceHTTP // trigger events come from the listener
 	}
 	_, err := tx.Exec(`
-		INSERT OR IGNORE INTO runs(run_id, schedule, status, source, started_at)
-		VALUES (?, ?, ?, ?, NULL)`,
+		INSERT INTO runs(run_id, schedule, status, source, started_at)
+		VALUES (?, ?, ?, ?, NULL)
+		ON CONFLICT (run_id) DO NOTHING`,
 		e.RunID, e.Schedule, StatusQueued, source,
 	)
 	return err
@@ -416,8 +464,9 @@ func (s *Store) applyScheduleStart(tx *sql.Tx, e Event) error {
 	}
 	for _, name := range e.Tasks {
 		_, err := tx.Exec(`
-			INSERT OR IGNORE INTO tasks(run_id, name, status)
-			VALUES (?, ?, ?)`,
+			INSERT INTO tasks(run_id, name, status)
+			VALUES (?, ?, ?)
+			ON CONFLICT (run_id, name) DO NOTHING`,
 			e.RunID, name, StatusQueued,
 		)
 		if err != nil {

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -208,6 +208,13 @@ func openPostgres(dsn string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("state.Open(postgres): ping: %w", err)
 	}
+	// When the DSN scopes the producer to a per-deployment schema
+	// (search_path=dep_<id>), self-create it so the control plane needs no
+	// DB access. Best-effort: a restricted role that can't CREATE SCHEMA
+	// must have it pre-provisioned (migrate then fails clearly if missing).
+	if schema := schemaFromDSN(dsn); schema != "" {
+		_, _ = db.Exec(`CREATE SCHEMA IF NOT EXISTS ` + quoteIdent(schema))
+	}
 	s := &Store{db: db, dialect: dialectPostgres}
 	if err := s.migrate(); err != nil {
 		_ = db.Close()


### PR DESCRIPTION
Completes the `store.go` `TODO(postgres)` — `state.Open` now dispatches on the DSN (`postgres://` → pgx, else SQLite), so the runtime's `state.Backend` can be backed by a durable shared Postgres.

## Why
In the managed/prod topology the per-deployment **producer** runs as a `cronicle run` subprocess with a **local ephemeral SQLite** — so run history (and `${last_run}`) is wiped on every pod restart. The `state.Backend` interface was built for pluggable backends; this finally adds the Postgres one. (Root-caused from the `${last_run}`-empty-in-prod investigation.)

## How — one schema/query source, dialect-adapted
- **Placeholder-rebind driver** wrapping `pgx/v5/stdlib`: rewrites `?`→`$N` at Prepare, and forwards `PrepareContext` + `BeginTx` (the queue's atomic claim needs a non-default isolation level). Keeps ~70 query sites untouched.
- **`dialectizePG()`** on the DDL: `AUTOINCREMENT`→`BIGSERIAL`, `DEFAULT (CURRENT_TIMESTAMP)`→`::text` cast, `BLOB`→`BYTEA`.
- **Per-statement execution** (pgx rejects multi-statement `Exec`) via a comment/quote-aware splitter (a `;` inside a `-- comment` was cutting `CREATE TABLE` in half).
- `INSERT OR IGNORE`→`ON CONFLICT DO NOTHING` and `datetime('now')`→bound param — portable in both dialects.

## Safety + tests
- **No behavior change for existing users**: `Open` defaults to SQLite; full SQLite suite stays green.
- **`TestPostgres_Backend_Integration`** (env-guarded by `TEST_PG_DSN`, skipped in CI): migration of all 10 schema versions on PG, event→run projection (the `${last_run}` read), queue claim/ack, workers, secrets, drain/pause, the control channel, and — the crux — **durability across a reconnect (= pod restart)**: after `Close`+reopen the prior run is still there. Validated against Postgres 16 locally.

## Follow-ups (separate PRs)
- `cronicle run --state-source postgres://` flag (+ `cron.go` wiring).
- `cmd/cronicled` passing the per-deployment DSN.
- Per-deployment schema provisioning + the e2e `${last_run}`-survives-restart demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)