### PR TITLE
chore(deps): bump anthropic-sdk-go to v1.46.0 (fork rebased)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jshiv/cronicle
 go 1.26
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.45.0
+	github.com/anthropics/anthropic-sdk-go v1.46.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
@@ -104,4 +104,4 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-replace github.com/anthropics/anthropic-sdk-go => github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260529110403-ee8571291242
+replace github.com/anthropics/anthropic-sdk-go => github.com/jshiv/anthropic-sdk-go v1.46.1-0.20260602022625-c3415d621638

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260529110403-ee8571291242 h1:T6wSLA5Vrl0gdvVVcsD14vLWBm9356Bs8OLhU6vnplM=
-github.com/jshiv/anthropic-sdk-go v1.45.1-0.20260529110403-ee8571291242/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
+github.com/jshiv/anthropic-sdk-go v1.46.1-0.20260602022625-c3415d621638 h1:8MsXg9w5lpIWbbTP3QJbrC5pkm6mwN3ohtAye4vhiuI=
+github.com/jshiv/anthropic-sdk-go v1.46.1-0.20260602022625-c3415d621638/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=


### PR DESCRIPTION
Keeps our anthropic-sdk-go fork current with upstream while [anthropics/anthropic-sdk-go#346](https://github.com/anthropics/anthropic-sdk-go/issues/346) (web-tools `ToParam` serialization) stays open.

## What
- Rebased `jshiv/anthropic-sdk-go` branch `fix/toparam-web-tools` from v1.45.0 → **v1.46.0** (6 patch commits, **clean rebase** — `messageutil.go` is byte-identical between the two upstream tags, so the patch applies without conflict). New fork HEAD `c3415d6`; pushed the v1.46.0 tag + fast-forwarded fork `main` so the pseudo-version reads `v1.46.1-0…`.
- go.mod: base require `v1.45.0 → v1.46.0`; `replace` → fork `c3415d6`.

## Verified
- Fork's own tests pass: `TestWebSearchToParamRoundTrip`, `TestWebFetchToParamRoundTrip`.
- cronicle: `go build ./...` clean; `pkg/agent` green incl. `TestToParamPreservesWebSearchContent`.
- The one upstream unit test the fork intentionally diverges on (`TestContentBlockUnionToParam/WebSearchToolResultBlock_with_search_results`, expects typed field; fork raw-passes by design) fails **identically pre- and post-rebase** — pre-existing, not a regression.

## Note
Drop the fork entirely once #346 lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)