### PR TITLE
chore: remove dead standalone Commit() helper

### DIFF
--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 
@@ -121,32 +120,6 @@ func (g *Git) Open(worktreePath string) error {
 	}
 
 	return nil
-}
-
-//Commit does a git commit on the repository at worktree
-func Commit(worktreeDir string, msg string) {
-	// Opens an already existing repository.
-	r, _ := git.PlainOpen(worktreeDir)
-
-	w, _ := r.Worktree()
-
-	_, _ = w.Add(".")
-
-	// We can verify the current status of the worktree using the method Status.
-	status, _ := w.Status()
-
-	fmt.Println(status)
-
-	commit, _ := w.Commit(msg, &git.CommitOptions{
-		Author: &object.Signature{
-			Name: "Cronicle user",
-			When: time.Now(),
-		},
-	})
-
-	obj, _ := r.CommitObject(commit)
-
-	fmt.Println(obj)
 }
 
 //Clone checks for the existance of worktreeDir/.git and clones if it does not exist


### PR DESCRIPTION
## Summary
- Remove unused exported `Commit()` function from `internal/cronicle/git.go` (lines 127-150)
- Drop now-unused `"time"` import

## Why
The standalone `Commit()` has zero callers in production or tests. The active commit path is `(*GitTool).commit` in `git_tool.go`, invoked by the agent's git tool. The dead helper was leftover scaffolding from before the `GitTool` path existed and had several latent bugs:
- Swallowed every error from `git.PlainOpen`, `Worktree`, `Add`, `Status`, `Commit`
- Would nil-panic if `PlainOpen` failed (next call dereferences nil repo)
- Printed status to `os.Stdout` directly, which would interleave with agent streaming output
- Hardcoded `"Cronicle user"` author with no email

Identified during a deadcode/reachability audit. Other helpers in `git.go` (`Open`, `Clone`, `Checkout`, `CleanGit`) all have live prod callers and are retained.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/cronicle/ -run Git` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)