### PR TITLE
chore: remove dead monotonicSuffix in runid.go

### DIFF
--- a/internal/cronicle/runid.go
+++ b/internal/cronicle/runid.go
@@ -3,7 +3,6 @@ package cronicle
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"sync"
 	"time"
 )
 
@@ -20,11 +19,4 @@ func newRunID() string {
 	var b [4]byte
 	_, _ = rand.Read(b[:]) // crypto/rand never errors on darwin/linux
 	return time.Now().UTC().Format("20060102T150405Z") + "-" + hex.EncodeToString(b[:])
-}
-
-// monotonicSuffix is reserved for a future sortability guarantee if we
-// switch to ULIDs. Kept behind a mutex to avoid clock-skew foot-guns.
-var monotonicSuffix struct {
-	sync.Mutex
-	last time.Time
 }


### PR DESCRIPTION
## Summary
- Delete unused `monotonicSuffix` package-level var (lines 27-30 pre-change)
- Drop now-unused `sync` import

## Why
The `monotonicSuffix` struct has zero readers or writers anywhere in the codebase. Its comment marks it as "reserved for a future sortability guarantee if we switch to ULIDs" but no ULID migration is currently planned. If sortability becomes needed later, re-adding three lines is trivial.

Identified during a deadcode/reachability audit.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)