### PR TITLE
chore: remove dead Task.Hcl and ErrRepoNotGiven

### DIFF
--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -326,9 +326,6 @@ type Queue struct {
 var (
 	//ErrBranchAndCommitGiven is thrown because commit and branch are mutually exclusive to identify a repo
 	ErrBranchAndCommitGiven = errors.New("branch and commit can not both be populated")
-	//ErrRepoNotGiven is thrown because a git repo is not given, for the case where Checkout or other git
-	//specific methods are called
-	ErrRepoNotGiven = errors.New("git repo has not been given")
 	//ErrIfRepoGivenAndPathNotGiven is thrown because a repo was given but the path to the local repo has not been provided
 	ErrIfRepoGivenAndPathNotGiven = errors.New("if repo is populated, path must also be given at runtime")
 	//ErrScheduleNameEmpty is thrown because schedule.Name == "", hcl can not be given with schedule "" {}

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -235,11 +235,3 @@ func (conf Config) Hcl() HclWriteFile {
 	return HclWriteFile{File: *f, Bytes: b}
 }
 
-//Hcl returns a hcl File object from a given task
-func (task Task) Hcl() HclWriteFile {
-	f := hclwrite.NewEmptyFile()
-	gohcl.EncodeIntoBody(&task, f.Body())
-	r := regexp.MustCompile("[$]+")
-	b := r.ReplaceAllLiteral(f.Bytes(), []byte("$"))
-	return HclWriteFile{File: *f, Bytes: b}
-}


### PR DESCRIPTION
## Summary
- Delete unused `(Task).Hcl()` method from `internal/cronicle/parse.go`
- Delete unused `ErrRepoNotGiven` sentinel from `internal/cronicle/config.go`

## Why
Both have zero callers anywhere in the codebase (verified via grep across non-test Go files):

- **`(Task).Hcl()`**: only `(Config).Hcl()` is called — at `cron_source.go:389` (for config diff) and `init.go:66` (for serialization). The Task-level method was never wired up.
- **`ErrRepoNotGiven`**: sentinel error declared in the same var block as `ErrBranchAndCommitGiven` and `ErrIfRepoGivenAndPathNotGiven`, but unlike its siblings, it's never returned by `Validate()` or any other path.

Identified during deadcode audit.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)