### PR TITLE
fix(security): redact env values in shell task transcripts

### DIFF
--- a/internal/cronicle/transcript.go
+++ b/internal/cronicle/transcript.go
@@ -5,10 +5,33 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jshiv/cronicle/pkg/exec"
 )
+
+// redactEnv returns a copy of env with each entry's value replaced by
+// "***". Keys are preserved so the transcript still shows which vars
+// the subprocess received; values are dropped because they may contain
+// secrets resolved by HCL's ${env.X} interpolation at parse time, or
+// because the operator wrote a literal secret in their HCL file. A
+// transcript on disk is a more durable exposure than HCL in process
+// memory, so default to safety here.
+func redactEnv(env []string) []string {
+	if len(env) == 0 {
+		return env
+	}
+	out := make([]string, len(env))
+	for i, kv := range env {
+		if k, _, ok := strings.Cut(kv, "="); ok {
+			out[i] = k + "=***"
+		} else {
+			out[i] = kv
+		}
+	}
+	return out
+}
 
 // writeShellTranscript writes a per-run JSONL transcript for a shell task to
 // .cronicle/runs/{run_id}-{task}.jsonl when runID is set (the listener-fired
@@ -46,7 +69,7 @@ func writeShellTranscript(runID, scheduleName, taskName, taskPath string, env []
 		"type":       "request",
 		"started_at": started.UTC(),
 		"command":    res.Command,
-		"env":        env,
+		"env":        redactEnv(env),
 		"path":       taskPath,
 	})
 	_ = enc.Encode(map[string]any{

--- a/internal/cronicle/transcript_test.go
+++ b/internal/cronicle/transcript_test.go
@@ -1,0 +1,53 @@
+package cronicle
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRedactEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty", []string{}, []string{}},
+		{
+			"basic key=value",
+			[]string{"TOKEN=abc123", "OTHER=plain"},
+			[]string{"TOKEN=***", "OTHER=***"},
+		},
+		{
+			"empty value still redacted",
+			[]string{"EMPTY="},
+			[]string{"EMPTY=***"},
+		},
+		{
+			"value containing equals",
+			[]string{"URL=https://x.io/?a=b"},
+			[]string{"URL=***"},
+		},
+		{
+			"malformed entry (no equals) preserved as-is",
+			[]string{"NOEQUALS"},
+			[]string{"NOEQUALS"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactEnv(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("redactEnv(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactEnvDoesNotMutateInput(t *testing.T) {
+	in := []string{"TOKEN=secret"}
+	_ = redactEnv(in)
+	if in[0] != "TOKEN=secret" {
+		t.Errorf("redactEnv mutated input: %v", in)
+	}
+}


### PR DESCRIPTION
## Summary
- Redact env values to \`***\` when writing per-run shell transcripts
- Keys retained for audit/debug; values dropped
- Adds \`transcript_test.go\` covering edge cases

## The leak
\`writeShellTranscript\` was writing \`task.Env\` verbatim into \`.cronicle/runs/*.jsonl\`. The original code review flagged this as Critical (C2) on the assumption that the values were post-\`\$secret\` expansion. On closer inspection the mechanism is more subtle:

- \`\$secret.NAME\` references **do not** land in the transcript — \`resolveEnv\` returns a new \`shellEnv\` slice that's used for the subprocess only.
- HCL's \`\${env.X}\` interpolation **does** land in the transcript — it resolves at \`gohcl.DecodeBody\` time, so by the time \`writeShellTranscript\` runs, \`task.Env\` already contains the actual value.

Example HCL that leaked:

\`\`\`hcl
task \"deploy\" {
  command = [\"./run.sh\"]
  env     = [\"GITHUB_TOKEN=\${env.GITHUB_TOKEN}\"]
}
\`\`\`

The transcript on disk recorded \`\"GITHUB_TOKEN=<actual-token>\"\`.

## The fix
\`redactEnv\` returns a copy of the env slice with values replaced by \`***\`. Operators auditing what env a task saw still get the keys; the values are dropped.

A transcript on disk is a more durable exposure than HCL in process memory (file backups, log shipping, multi-user hosts), so this is unconditional with no opt-out. If a future use case needs raw values for debugging, an explicit allowlist of safe-to-keep keys could be added.

## Test plan
- [x] New \`TestRedactEnv\` covers nil / empty / basic key=value / empty value / value-with-equals / no-equals shapes
- [x] \`TestRedactEnvDoesNotMutateInput\` verifies the input slice isn't aliased
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)