### PR TITLE
fix(security): bundle of three primitives (C3, C4, H5)

### DIFF
--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -35,6 +35,7 @@ package cronicle
 import (
 	"bufio"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,7 +171,11 @@ func (s *listenServer) authed(r *http.Request) bool {
 	if !strings.HasPrefix(h, prefix) {
 		return false
 	}
-	return strings.TrimPrefix(h, prefix) == s.token
+	// Constant-time compare so an attacker can't recover s.token byte-by-byte
+	// via response-latency probing. subtle.ConstantTimeCompare returns 0 if
+	// the lengths differ, so callers can't infer the token length either.
+	got := strings.TrimPrefix(h, prefix)
+	return subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) == 1
 }
 
 func (s *listenServer) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/cronicle/state/secrets.go
+++ b/internal/cronicle/state/secrets.go
@@ -33,6 +33,13 @@ func (s *Store) PutSecret(name, value, actor string) error {
 	if name == "" {
 		return errors.New("state.PutSecret: empty name")
 	}
+	// Serialize with every other Store write (Apply, BackfillSecrets, queue
+	// ops, etc.). Without this lock, a PUT /v1/secrets racing with the
+	// startup BackfillSecrets pass could double-seal a row or seal stale
+	// plaintext. SQLite's busy_timeout helps but doesn't make the higher-
+	// level invariants safe; the explicit mutex does.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	// Bind the timestamp in Go rather than SQL datetime('now') so the
 	// query is portable across sqlite/postgres.
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
@@ -189,6 +196,10 @@ func (s *Store) ListSecretNames() ([]string, error) {
 // observers may care about regardless. ok reports actual deletion so
 // the CLI can print "removed" vs "no such secret".
 func (s *Store) DeleteSecret(name, actor string) (bool, error) {
+	// Same rationale as PutSecret: serialize with every other Store write
+	// so DELETE doesn't race with BackfillSecrets / etag bumps.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	tx, err := s.db.Begin()
 	if err != nil {
 		return false, fmt.Errorf("state.DeleteSecret: begin: %w", err)

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -322,6 +322,14 @@ func (t *TextEditorTool) resolvePath(p string) (string, error) {
 // resolveInWorkspace turns a model-supplied path (relative or absolute) into
 // an absolute path *guaranteed* to live under workspace, or an error. Used
 // by every text_editor operation as the workspace-containment gate.
+//
+// Symlink handling: lexical containment via filepath.Clean is not sufficient
+// — an agent could create a symlink inside the workspace pointing at
+// /etc/passwd, then ask text_editor to "view" it. We resolve symlinks on
+// both the workspace root and the deepest existing ancestor of the target,
+// then re-check containment against the symlink-free roots. Non-existent
+// leaves are legitimate for create operations, so we only require the
+// nearest existing ancestor to resolve.
 func resolveInWorkspace(workspace, p string) (string, error) {
 	if p == "" {
 		return "", fmt.Errorf("path required")
@@ -330,6 +338,13 @@ func resolveInWorkspace(workspace, p string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("workspace abs: %w", err)
 	}
+	// Resolve symlinks in the workspace root itself so a symlinked workspace
+	// doesn't fail the post-EvalSymlinks containment check below. If the
+	// workspace dir doesn't exist yet we keep the lexical form; the per-target
+	// EvalSymlinks below will reject anything that escapes anyway.
+	if resolved, err := filepath.EvalSymlinks(wsAbs); err == nil {
+		wsAbs = resolved
+	}
 	var abs string
 	if filepath.IsAbs(p) {
 		abs = p
@@ -337,14 +352,55 @@ func resolveInWorkspace(workspace, p string) (string, error) {
 		abs = filepath.Join(wsAbs, p)
 	}
 	abs = filepath.Clean(abs)
-	rel, err := filepath.Rel(wsAbs, abs)
+
+	// Resolve symlinks against the deepest existing ancestor. A non-existent
+	// leaf is fine (creating a new file), but every existing path component
+	// MUST resolve under wsAbs after symlink expansion.
+	resolved, err := evalSymlinksTolerant(abs)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", p, err)
+	}
+	rel, err := filepath.Rel(wsAbs, resolved)
 	if err != nil {
 		return "", fmt.Errorf("path %s outside workspace", p)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %s escapes workspace", p)
 	}
-	return abs, nil
+	return resolved, nil
+}
+
+// evalSymlinksTolerant resolves abs through symlinks, walking up to the
+// deepest existing ancestor when the leaf doesn't exist. Returns a path
+// whose existing-prefix is symlink-free; any non-existing suffix is
+// appended verbatim. Used by resolveInWorkspace so that "create new file"
+// operations don't fail the containment check just because the file
+// hasn't been written yet.
+func evalSymlinksTolerant(abs string) (string, error) {
+	suffix := ""
+	cur := abs
+	for {
+		resolved, err := filepath.EvalSymlinks(cur)
+		if err == nil {
+			if suffix == "" {
+				return resolved, nil
+			}
+			return filepath.Join(resolved, suffix), nil
+		}
+		// Only walk up on os.IsNotExist; any other error (perm denied, etc.)
+		// is a real failure that the caller should see.
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root and nothing exists. Return the lexical path —
+			// the containment check in the caller still catches escapes.
+			return abs, nil
+		}
+		suffix = filepath.Join(filepath.Base(cur), suffix)
+		cur = parent
+	}
 }
 
 // isBinary reports whether the data looks like binary (any null byte in the

--- a/internal/cronicle/tools_test.go
+++ b/internal/cronicle/tools_test.go
@@ -61,16 +61,24 @@ func TestIsBinary(t *testing.T) {
 }
 
 // resolveInWorkspace blocks `..` traversal and absolute paths outside the
-// workspace, allows relative paths inside.
+// workspace, allows relative paths inside, and resolves symlinks before
+// the containment check so an agent can't escape via a planted symlink.
 func TestResolveInWorkspace(t *testing.T) {
 	ws := t.TempDir()
+	// Resolve the workspace's own symlinks so HasPrefix checks below
+	// compare against the canonical form. On macOS, t.TempDir() returns
+	// a /var/folders/... path that resolves to /private/var/folders/...
+	wsResolved, err := filepath.EvalSymlinks(ws)
+	if err != nil {
+		t.Fatalf("workspace eval: %v", err)
+	}
 
 	abs, err := resolveInWorkspace(ws, "sub/file.txt")
 	if err != nil {
 		t.Fatalf("relative inside: %v", err)
 	}
-	if !strings.HasPrefix(abs, ws) {
-		t.Fatalf("resolved path %q outside workspace %q", abs, ws)
+	if !strings.HasPrefix(abs, wsResolved) {
+		t.Fatalf("resolved path %q outside workspace %q", abs, wsResolved)
 	}
 
 	if _, err := resolveInWorkspace(ws, "../escape.txt"); err == nil {
@@ -82,6 +90,69 @@ func TestResolveInWorkspace(t *testing.T) {
 	}
 	if _, err := resolveInWorkspace(ws, ""); err == nil {
 		t.Fatalf("empty path allowed")
+	}
+}
+
+// resolveInWorkspace rejects paths that traverse OUT of the workspace
+// via a symlink. An attacker who can write inside the workspace (the
+// agent's bash tool) must not be able to plant a link and then use
+// text_editor to read or write the link target.
+func TestResolveInWorkspace_SymlinkEscape(t *testing.T) {
+	ws := t.TempDir()
+	outside := t.TempDir()
+	// Plant a target file in the outside directory and a symlink to it
+	// inside the workspace.
+	target := filepath.Join(outside, "stolen.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	link := filepath.Join(ws, "loot")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := resolveInWorkspace(ws, "loot"); err == nil {
+		t.Fatalf("symlink escape to outside-workspace target was allowed")
+	}
+}
+
+// A symlink that points to a sibling INSIDE the workspace is benign and
+// must continue to resolve cleanly.
+func TestResolveInWorkspace_SymlinkInside(t *testing.T) {
+	ws := t.TempDir()
+	wsResolved, err := filepath.EvalSymlinks(ws)
+	if err != nil {
+		t.Fatalf("workspace eval: %v", err)
+	}
+	target := filepath.Join(ws, "real.txt")
+	if err := os.WriteFile(target, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	link := filepath.Join(ws, "alias")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	abs, err := resolveInWorkspace(ws, "alias")
+	if err != nil {
+		t.Fatalf("intra-workspace symlink rejected: %v", err)
+	}
+	if !strings.HasPrefix(abs, wsResolved) {
+		t.Fatalf("resolved path %q escapes workspace %q", abs, wsResolved)
+	}
+}
+
+// Create operations must work for a leaf path that doesn't exist yet —
+// resolveInWorkspace can't EvalSymlinks a non-existent file, so it must
+// walk up to the nearest existing ancestor.
+func TestResolveInWorkspace_NonExistentLeaf(t *testing.T) {
+	ws := t.TempDir()
+	abs, err := resolveInWorkspace(ws, "new-dir/new-file.txt")
+	if err != nil {
+		t.Fatalf("create-new path rejected: %v", err)
+	}
+	if !strings.Contains(abs, "new-dir/new-file.txt") {
+		t.Fatalf("leaf lost in resolution: got %q", abs)
 	}
 }
 


### PR DESCRIPTION
## Summary
Three small surgical security fixes from the deep-dive audit:

| Finding | File | Change |
|---|---|---|
| **C4** | \`internal/cronicle/listen.go\` | constant-time bearer-token compare |
| **C3** | \`internal/cronicle/state/secrets.go\` | mutex on PutSecret / DeleteSecret |
| **H5** | \`internal/cronicle/tools.go\` | EvalSymlinks in workspace containment check |

## C4 — Constant-time bearer-token compare
The \`/v1/*\` auth gate compared the supplied token against \`s.token\` with Go's \`==\` operator, which short-circuits on the first non-matching byte. An attacker probing the listener could in principle recover the token byte-by-byte via response-latency measurements. Replaced with \`crypto/subtle.ConstantTimeCompare\`. Behavior for legitimate clients is unchanged.

## C3 — Mutex on Store secrets writes
Every other Store write method (\`Apply\`, \`Enqueue\`, \`Claim\`, \`Ack\`, \`BackfillSecrets\`, …) acquires \`s.mu\` before opening a transaction. \`PutSecret\` and \`DeleteSecret\` didn't. With the single-connection SQLite pool the higher-level invariants usually held by accident, but a \`PUT /v1/secrets\` racing with the startup \`BackfillSecrets\` pass could double-seal a row or seal stale plaintext. Added the lock to match the convention.

## H5 — Symlink-resolving workspace containment
\`resolveInWorkspace\` gates every \`text_editor\` operation. The lexical \`filepath.Clean\` check it used was bypassable: an agent can use \`bash\` to create a symlink inside the workspace pointing at \`/etc/passwd\`, then call \`text_editor\` on the symlink path. Lexical check passes; the actual read/write hits the target.

Now resolves symlinks on both the workspace root and the deepest existing ancestor of the target before the containment check. Non-existent leaves (legitimate for create operations) walk up to the nearest existing parent. New helper \`evalSymlinksTolerant\` handles the walk.

## Test plan
- [x] \`TestResolveInWorkspace\` updated to expect symlink-resolved paths (macOS \`/var/folders\` → \`/private/var/folders\`)
- [x] \`TestResolveInWorkspace_SymlinkEscape\` — planted symlink to outside-workspace target is rejected ✓
- [x] \`TestResolveInWorkspace_SymlinkInside\` — intra-workspace symlink still works ✓
- [x] \`TestResolveInWorkspace_NonExistentLeaf\` — create operations still work ✓
- [x] Bearer-token compare path covered by existing \`listen_*_test.go\` integration tests
- [x] Secrets-store concurrency path covered by existing \`state/*_test.go\` and listener tests
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)