### PR TITLE
fix: H7 scratch collision, H8 Repo race, H9 body size limit

### DIFF
--- a/internal/cronicle/dag.go
+++ b/internal/cronicle/dag.go
@@ -301,11 +301,18 @@ func walkDAG(deps map[string][]string, fn func(string) error, continueOnFailure 
 }
 
 // scratchDirFor computes the absolute scratch dir for one schedule run.
-// Lives under <croniclePath>/.cronicle/scratch/<schedule>/<utc-runid>/ so
+// Lives under <croniclePath>/.cronicle/scratch/<schedule>/<run-id>/ so
 // concurrent runs of the same schedule don't collide and each run is
-// addressable by timestamp. Returns "" if the schedule has no tasks (no
+// addressable by id. Returns "" if the schedule has no tasks (no
 // croniclePath to resolve), in which case dag.go skips the mkdir and
 // ${scratch} substitution becomes a no-op.
+//
+// Prefers schedule.RunID (a ULID) over the truncated-to-second timestamp.
+// Two runs of the same schedule firing within the same second (e.g. a
+// cron tick coinciding with an HTTP trigger, or two concurrent triggers)
+// used to produce the same path and clobber each other's files. The
+// timestamp form is kept only as a fallback for paths that don't carry
+// a RunID (direct in-process callers from very old code).
 func (schedule *Schedule) scratchDirFor(now time.Time) string {
 	if len(schedule.Tasks) == 0 {
 		return ""
@@ -314,8 +321,11 @@ func (schedule *Schedule) scratchDirFor(now time.Time) string {
 	if croniclePath == "" {
 		return ""
 	}
-	runID := now.UTC().Format("20060102T150405Z")
-	return filepath.Join(croniclePath, ".cronicle", "scratch", schedule.Name, runID)
+	dirName := schedule.RunID
+	if dirName == "" {
+		dirName = now.UTC().Format("20060102T150405Z")
+	}
+	return filepath.Join(croniclePath, ".cronicle", "scratch", schedule.Name, dirName)
 }
 
 // downstreamTasks returns the transitive set of tasks that depend on

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -74,22 +74,33 @@ func splitAPIKey(env []string) (apiKey string, rest []string) {
 // references should resolve.
 // resolveRepoSecrets expands $secret.NAME references in the repo's
 // Password field using the secret store. Called at task execution time
-// (not at config load) so the secret store is available. No-op when
-// the store isn't configured or the password has no $secret. references.
-func resolveRepoSecrets(repo *Repo) {
+// (not at config load) so the secret store is available.
+//
+// Returns the original pointer when no expansion is needed; otherwise
+// returns a shallow-cloned *Repo with the resolved password. Crucially,
+// it does NOT mutate the input *Repo in place — PropigateTaskProperties
+// shares the schedule-level *Repo across every task in the schedule that
+// doesn't have its own repo block, so concurrent tasks in the DAG would
+// race on the Password field. Returning a per-task clone keeps each
+// goroutine's view of the secret independent.
+func resolveRepoSecrets(repo *Repo) *Repo {
 	if repo == nil || repo.Password == "" {
-		return
+		return repo
 	}
 	if !strings.Contains(repo.Password, "$secret.") {
-		return
+		return repo
 	}
 	store := secretstore.Default()
 	if !store.Configured() {
-		return
+		return repo
 	}
-	if v, err := store.ExpandValue(repo.Password); err == nil {
-		repo.Password = v
+	v, err := store.ExpandValue(repo.Password)
+	if err != nil {
+		return repo
 	}
+	clone := *repo
+	clone.Password = v
+	return &clone
 }
 
 func resolveEnv(env []string) ([]string, error) {
@@ -556,7 +567,9 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 
 	//If a repo is given, clone the repo and task.Git.Open(task.Path)
 	if task.Repo != nil {
-		resolveRepoSecrets(task.Repo)
+		// Replace task.Repo with a clone-with-resolved-password so we don't
+		// race other tasks that share the same schedule-level *Repo pointer.
+		task.Repo = resolveRepoSecrets(task.Repo)
 		opts, err := task.Repo.Auth()
 		if err != nil {
 			return exec.Result{}, err

--- a/internal/cronicle/exec_repo_secret_test.go
+++ b/internal/cronicle/exec_repo_secret_test.go
@@ -38,10 +38,19 @@ func TestResolveRepoSecrets_ExpandsSecretRef(t *testing.T) {
 	defer cleanup()
 
 	repo := &Repo{Password: "$secret.GITHUB_TOKEN"}
-	resolveRepoSecrets(repo)
+	out := resolveRepoSecrets(repo)
 
-	if repo.Password != "ghp_test123" {
-		t.Errorf("expected password %q, got %q", "ghp_test123", repo.Password)
+	if out.Password != "ghp_test123" {
+		t.Errorf("expected resolved password %q, got %q", "ghp_test123", out.Password)
+	}
+	// The original *Repo must be unchanged — that's the whole point of
+	// returning a clone instead of mutating in place. Tasks sharing the
+	// schedule-level *Repo must not see each other's resolutions.
+	if repo.Password != "$secret.GITHUB_TOKEN" {
+		t.Errorf("input repo mutated; got Password=%q", repo.Password)
+	}
+	if out == repo {
+		t.Errorf("expected a fresh *Repo, got the same pointer back")
 	}
 }
 
@@ -50,30 +59,42 @@ func TestResolveRepoSecrets_LeavesEnvSyntaxAlone(t *testing.T) {
 	defer cleanup()
 
 	repo := &Repo{Password: "${env.CRONICLE_TOKEN}"}
-	resolveRepoSecrets(repo)
+	out := resolveRepoSecrets(repo)
 
-	if repo.Password != "${env.CRONICLE_TOKEN}" {
-		t.Errorf("should not modify env syntax, got %q", repo.Password)
+	if out.Password != "${env.CRONICLE_TOKEN}" {
+		t.Errorf("should not modify env syntax, got %q", out.Password)
+	}
+	// No expansion needed → same pointer returned, no allocation.
+	if out != repo {
+		t.Errorf("expected same pointer when no expansion, got fresh clone")
 	}
 }
 
 func TestResolveRepoSecrets_NoopWhenNil(t *testing.T) {
-	resolveRepoSecrets(nil)
+	if out := resolveRepoSecrets(nil); out != nil {
+		t.Errorf("expected nil for nil input, got %v", out)
+	}
 }
 
 func TestResolveRepoSecrets_NoopWhenEmpty(t *testing.T) {
 	repo := &Repo{Password: ""}
-	resolveRepoSecrets(repo)
-	if repo.Password != "" {
-		t.Errorf("expected empty, got %q", repo.Password)
+	out := resolveRepoSecrets(repo)
+	if out.Password != "" {
+		t.Errorf("expected empty, got %q", out.Password)
+	}
+	if out != repo {
+		t.Errorf("expected same pointer for noop, got fresh clone")
 	}
 }
 
 func TestResolveRepoSecrets_NoopWhenStoreUnconfigured(t *testing.T) {
 	repo := &Repo{Password: "$secret.GITHUB_TOKEN"}
-	resolveRepoSecrets(repo)
-	if repo.Password != "$secret.GITHUB_TOKEN" {
-		t.Errorf("should leave unresolved when store not configured, got %q", repo.Password)
+	out := resolveRepoSecrets(repo)
+	if out.Password != "$secret.GITHUB_TOKEN" {
+		t.Errorf("should leave unresolved when store not configured, got %q", out.Password)
+	}
+	if out != repo {
+		t.Errorf("expected same pointer when store unconfigured, got fresh clone")
 	}
 }
 
@@ -82,9 +103,42 @@ func TestResolveRepoSecrets_PlainPasswordUnchanged(t *testing.T) {
 	defer cleanup()
 
 	repo := &Repo{Password: "my-plain-token"}
-	resolveRepoSecrets(repo)
+	out := resolveRepoSecrets(repo)
 
-	if repo.Password != "my-plain-token" {
-		t.Errorf("plain password should be unchanged, got %q", repo.Password)
+	if out.Password != "my-plain-token" {
+		t.Errorf("plain password should be unchanged, got %q", out.Password)
+	}
+	if out != repo {
+		t.Errorf("expected same pointer for plain password, got fresh clone")
+	}
+}
+
+// Two tasks sharing a single schedule-level *Repo pointer must each
+// observe their own resolved password without racing on the shared
+// memory. This is the H8 invariant: resolveRepoSecrets must not mutate
+// the input.
+func TestResolveRepoSecrets_ConcurrentSharedRepo(t *testing.T) {
+	cleanup := setupSecretStore(t, map[string]string{
+		"GITHUB_TOKEN": "ghp_concurrent",
+	})
+	defer cleanup()
+
+	shared := &Repo{Password: "$secret.GITHUB_TOKEN"}
+	const goroutines = 50
+	done := make(chan *Repo, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			done <- resolveRepoSecrets(shared)
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		out := <-done
+		if out.Password != "ghp_concurrent" {
+			t.Errorf("goroutine %d got password %q, want %q", i, out.Password, "ghp_concurrent")
+		}
+	}
+	// Original must still be untouched.
+	if shared.Password != "$secret.GITHUB_TOKEN" {
+		t.Errorf("shared repo mutated under concurrency; got %q", shared.Password)
 	}
 }

--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -517,10 +517,17 @@ func (s *listenServer) handleGetScheduleState(w http.ResponseWriter, r *http.Req
 // falling back to X-Actor / X-Reason headers. Bodyless POSTs (curl with
 // no -d) are explicitly supported — the headers and falling-through
 // empties keep the endpoint script-friendly.
+//
+// Body is capped at 64 KiB via http.MaxBytesReader so an authenticated
+// (or auth-bypassed) caller can't OOM the process by POSTing a multi-GiB
+// payload to pause/resume/skip. The pauseRequest schema is tiny — actor
+// and reason strings — so 64K is well above any legitimate use.
+// ContentLength can be -1 (chunked encoding); we treat any unknown size
+// as "maybe there's a body" so chunked POSTs aren't silently ignored.
 func readPauseBody(r *http.Request) (string, string) {
 	var req pauseRequest
 	if r.Body != nil && r.ContentLength != 0 {
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(http.MaxBytesReader(nil, r.Body, 64<<10)).Decode(&req)
 	}
 	if req.Actor == "" {
 		req.Actor = r.Header.Get("X-Actor")


### PR DESCRIPTION
## Summary
Three small high-severity fixes, bundled:

| # | File | Fix |
|---|---|---|
| **H7** | \`dag.go\` | scratchDirFor uses \`schedule.RunID\` (ULID) instead of second-truncated timestamp |
| **H8** | \`exec.go\` | \`resolveRepoSecrets\` returns a clone of \`*Repo\`; no longer mutates in place |
| **H9** | \`listen.go\` | \`readPauseBody\` caps JSON decode at 64 KiB via \`MaxBytesReader\` |

## H7 — Scratch dir collision
\`scratchDirFor\` was building \`.cronicle/scratch/<schedule>/<utc-yyyymmddThhmmssZ>/\`. The timestamp truncates to seconds, so a cron tick firing at the same second as an HTTP trigger (or two concurrent triggers) produced identical paths and clobbered each other's files. The variable was even *named* \`runID\` — it just wasn't using the actual run id.

Fixed: prefer \`schedule.RunID\` (per-trigger ULID), fall back to the timestamp form only when \`RunID\` is empty.

## H8 — Repo.Password mutation race
\`PropigateTaskProperties\` (config.go:568) assigns the schedule-level \`*Repo\` pointer to every task in the schedule that doesn't have its own repo block. At execution time, \`resolveRepoSecrets\` then mutated \`repo.Password\` in place — so two concurrent tasks in the DAG raced on the shared field.

Fixed: \`resolveRepoSecrets\` now returns a \`*Repo\` instead of mutating. When expansion happens, it returns a shallow clone with the resolved password; otherwise it returns the same pointer (no allocation). \`task.Execute\` reassigns \`task.Repo\` to the returned pointer, so the schedule-level \`Repo\` seen by sibling tasks is untouched.

### Verification
New test \`TestResolveRepoSecrets_ConcurrentSharedRepo\`:
- 50 goroutines call \`resolveRepoSecrets(shared)\` in parallel
- Each must see the resolved value (\`ghp_concurrent\`)
- The shared \`*Repo\` must still hold the literal \`\$secret.GITHUB_TOKEN\` after — proving no in-place mutation occurred
- Passes under \`go test -race\` ✓

Existing tests updated to assert that:
- No-op cases (nil, empty, plain password, store unconfigured) return the *same pointer* (no allocation)
- Expansion case returns a *different pointer* and leaves the input unchanged

## H9 — Unbounded body decode in readPauseBody
Every pause / resume / drain / skip handler funnels through \`readPauseBody\`, which did \`json.NewDecoder(r.Body).Decode(&req)\` with no size limit. An authenticated caller could POST a multi-GiB body and OOM the process. The other body-decoding sites in listen.go (event ingest at 926, the trigger handlers at 1130/1148, secrets PUT at \`listen_secrets.go:98\`) already use \`MaxBytesReader\` or \`LimitReader\`; this was the gap.

Fixed: \`http.MaxBytesReader(nil, r.Body, 64<<10)\` — 64 KiB cap. The \`pauseRequest\` schema is two short strings, so any legitimate body is far under that.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` all packages pass
- [x] \`go test -race\` on new concurrency test
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)