### PR TITLE
fix(security): Medium Bundle A — secret hygiene (M5 + M6, M2 documented)

### DIFF
--- a/internal/cronicle/config.go
+++ b/internal/cronicle/config.go
@@ -290,6 +290,24 @@ type Repo struct {
 	// placeholder for git's HTTP Basic challenge. Every modern host
 	// (GitHub, GitLab, Gitea, cronicle-git) ignores the username and
 	// authenticates on the token in the password slot.
+	//
+	// SECURITY (M2, deferred): when the password uses ${env.X} the value
+	// resolves at gohcl decode (parse time), so the resolved token is
+	// present in the in-memory *Repo and flows into schedule.JSON() at
+	// queue-push time (cron.go: queue <- schedule.JSON()). In
+	// distributed mode the jobs table in state.db then stores the JSON
+	// payload at rest, and the producer→worker HTTP transport carries
+	// it on the wire. Today this is operator-restricted (state.db is
+	// chmod-protected; the HTTP API is bearer-token + intended TLS),
+	// and no production log line prints schedule.JSON, so the practical
+	// exposure is limited. The structural fix is to keep the literal
+	// "$secret.X" reference in queue payloads and re-resolve on the
+	// worker side via the SecretStore (which already plumbs through
+	// state.Backend) — that's a larger refactor pending a follow-up.
+	// Until then prefer $secret.X over ${env.X} for repo passwords in
+	// any distributed deployment; the $secret.X form is resolved at
+	// task.Execute time, after the queue pop, so it never lands in the
+	// jobs table or transport.
 	Username string `hcl:"username,optional"`
 	Password string `hcl:"password,optional"`
 	// Branch and Commit are mutually exclusive. ErrBranchAndCommitGiven

--- a/internal/cronicle/stream.go
+++ b/internal/cronicle/stream.go
@@ -2,12 +2,47 @@ package cronicle
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
 
 	"github.com/jshiv/cronicle/pkg/agent"
 )
+
+// maxLoggedToolInputBytes caps the byte length of an agent tool input
+// when it's emitted to the slog stream (file/Loki + live SSE). The full
+// input is preserved in the per-run agent transcript at
+// .cronicle/runs/{run_id}-{task}.jsonl (which is 0o600 since PR fixing
+// M5), so this truncation only restricts the observability fan-out — it
+// does not lose audit fidelity.
+//
+// Why truncate at all: an agent's bash command could embed a token or
+// header value in its args (e.g. `curl -H "Authorization: Bearer X"`)
+// from a tool_result it composed in a prior turn. Without truncation
+// the full command — including the secret — ships to Loki and the
+// frontend SSE stream. Head-truncation leaves the most diagnostic part
+// (the start of the command) intact while bounding the leak surface.
+//
+// 256 bytes is comfortably above any normal text_editor.path or git
+// arg, while short enough that pasting a typical secret-bearing bash
+// line (which usually leads with the secret-bearing flag) still loses
+// most of the value.
+const maxLoggedToolInputBytes = 256
+
+// redactToolInput returns a string suitable for slog emission from an
+// agent tool's raw JSON input. Short inputs pass through unchanged;
+// long inputs are truncated to maxLoggedToolInputBytes with an explicit
+// marker showing how many bytes were dropped. The full input remains in
+// the agent transcript file for post-hoc audit.
+func redactToolInput(input string) string {
+	if len(input) <= maxLoggedToolInputBytes {
+		return input
+	}
+	return fmt.Sprintf("%s... [+%d bytes truncated; see transcript for full]",
+		input[:maxLoggedToolInputBytes],
+		len(input)-maxLoggedToolInputBytes)
+}
 
 // lineEmitter wraps an io.Writer to emit one slog record per newline
 // AS BYTES FLOW THROUGH. The underlying writer (typically the
@@ -144,7 +179,7 @@ func NewAgentSlogBridge(runID, task, schedule string, downstream agent.StreamHan
 				"entry_type", "tool_use_start",
 				"run_id", runID, "task", task, "schedule", schedule,
 				"tool", e.ToolName,
-				"input", e.ToolInput,
+				"input", redactToolInput(e.ToolInput),
 			)
 		case agent.StreamEventToolResult:
 			slog.Info("tool result",

--- a/internal/cronicle/stream_test.go
+++ b/internal/cronicle/stream_test.go
@@ -1,0 +1,65 @@
+package cronicle
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRedactToolInput_ShortPassesThrough: inputs at or below the
+// threshold must be untouched so normal tool calls (text_editor paths,
+// short bash commands) keep full slog fidelity.
+func TestRedactToolInput_ShortPassesThrough(t *testing.T) {
+	in := `{"command":"ls -la"}`
+	if got := redactToolInput(in); got != in {
+		t.Errorf("short input mutated: got %q, want %q", got, in)
+	}
+}
+
+// TestRedactToolInput_BoundaryExact: an input exactly at the threshold
+// must still pass through unchanged — off-by-one error would surface
+// here.
+func TestRedactToolInput_BoundaryExact(t *testing.T) {
+	in := strings.Repeat("a", maxLoggedToolInputBytes)
+	if got := redactToolInput(in); got != in {
+		t.Errorf("threshold-length input mutated; len(got)=%d", len(got))
+	}
+}
+
+// TestRedactToolInput_LongTruncated: oversized inputs must lose their
+// tail to the truncation marker, and the marker must report the
+// dropped byte count so operators can identify what's missing.
+func TestRedactToolInput_LongTruncated(t *testing.T) {
+	const padBytes = 1000
+	in := strings.Repeat("h", maxLoggedToolInputBytes) + strings.Repeat("t", padBytes)
+	got := redactToolInput(in)
+
+	if len(got) == len(in) {
+		t.Fatalf("oversized input passed through unchanged")
+	}
+	// Head must be intact — operators rely on it to recognize the call.
+	wantHead := strings.Repeat("h", maxLoggedToolInputBytes)
+	if !strings.HasPrefix(got, wantHead) {
+		t.Errorf("truncated output missing head; got prefix %q", got[:50])
+	}
+	// Marker must mention truncation + the byte count.
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("truncation marker missing: %q", got)
+	}
+	if !strings.Contains(got, "1000") {
+		t.Errorf("truncation marker should report dropped count (1000); got: %q", got)
+	}
+	// The tail (which would have carried a secret in the leak scenario)
+	// must NOT appear in the output. Sample 50 tail bytes.
+	tailSample := strings.Repeat("t", 50)
+	if strings.Contains(got, tailSample) {
+		t.Errorf("tail bytes leaked through truncation: %q", got)
+	}
+}
+
+// TestRedactToolInput_EmptyAndNil: defensive cases — empty and
+// zero-length inputs must produce empty output without panicking.
+func TestRedactToolInput_EmptyAndNil(t *testing.T) {
+	if got := redactToolInput(""); got != "" {
+		t.Errorf("empty input: got %q, want \"\"", got)
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -497,7 +497,14 @@ func openTranscript(cfg Config, model string, started time.Time) (*transcriptWri
 	if err != nil || path == "" {
 		return nil, err
 	}
-	f, err := os.Create(path)
+	// 0o600 (owner-only read/write): the transcript contains the full
+	// agent conversation including any secrets the agent referenced in
+	// prompts, tool inputs, or tool results. os.Create's default 0o666
+	// mode (pre-umask) would let any user on a shared host read the
+	// transcript depending on umask settings. The cronicle process
+	// already runs as the owner, so 0o600 doesn't restrict any
+	// legitimate access.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/transcript_test.go
+++ b/pkg/agent/transcript_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOpenTranscript_FileMode0600 locks in the M5 fix: the per-run
+// agent transcript on disk contains the full conversation (prompts,
+// system prompt, tool inputs, model outputs, accounting) which can
+// include secrets the agent surfaced from tool_results. The file must
+// be created with 0o600 so even a permissive umask on a shared host
+// can't widen it.
+func TestOpenTranscript_FileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		TranscriptDir: dir,
+		RunID:         "test-run",
+	}
+	tw, err := openTranscript(cfg, "claude-opus-4-7", time.Now())
+	if err != nil {
+		t.Fatalf("openTranscript: %v", err)
+	}
+	defer tw.f.Close()
+
+	info, err := tw.f.Stat()
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// Mask off file-type bits; only permission bits matter for this check.
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("transcript perms: got %#o, want 0o600 (other users must not read agent conversation)", perm)
+	}
+}


### PR DESCRIPTION
## Summary
Two surgical fixes and one documented deferral from the Medium tier of the audit, all about keeping resolved secrets out of places they don't belong.

| Finding | Status | File |
|---|---|---|
| **M5** | ✅ fixed | \`pkg/agent/agent.go\` — transcript opens with explicit 0o600 |
| **M6** | ✅ fixed | \`internal/cronicle/stream.go\` — tool input truncated at 256 bytes in slog |
| **M2** | 📝 documented | \`internal/cronicle/config.go\` — SECURITY comment on \`Repo.Password\` explaining the queue-payload leak surface |

## M5 — Agent transcript file mode
\`openTranscript\` used \`os.Create\` which opens with \`0o666\` (pre-umask). Depending on the host's umask, the per-run agent conversation — prompts, system, tool inputs, tool results, model output, all of which can carry secrets the agent surfaced from \`tool_result\`s — could end up world-readable on a shared host.

Now uses \`os.OpenFile\` with explicit \`0o600\`. The cronicle process already runs as the owner so this restricts nothing legitimate.

## M6 — Tool input truncation in slog
\`AgentSlogBridge\` emitted the full tool input as the \`input\` attr on every \`tool_use_start\` record. Those records flow to the JSON file log → Loki and to LiveSink → SSE. An agent that composed a curl command embedding a \`tool_result\`-sourced token would ship that token to both observability paths.

Now wraps the raw input through \`redactToolInput\` which head-truncates anything beyond **256 bytes** with a \`... [+N bytes truncated; see transcript for full]\` marker. The full input remains in the per-run transcript file (which is now \`0o600\` per M5), so audit fidelity is preserved at restricted permissions while the observability fan-out is bounded.

256 bytes is well above typical \`text_editor\` / \`git\` args; for bash commands it keeps enough of the head to recognize the call while losing the secret-carrying tail.

## M2 — Repo.Password serialization (documented)
M2's actual exploit surface is narrower than the audit framed:
- ✅ No production log line prints \`schedule.JSON()\`
- ⚠️ The jobs table in \`state.db\` stores schedule JSON at rest (operator-restricted)
- ⚠️ The producer→worker HTTP transport carries it on the wire (bearer auth + intended TLS)

When \`password = "\${env.X}"\` is used, the value resolves at gohcl parse time and flows into \`schedule.JSON()\` at queue push. The structural fix is to keep the literal \`\$secret.X\` reference in queue payloads and re-resolve on the worker side via the \`SecretStore\` — a larger refactor pending a follow-up.

This PR adds a multi-paragraph SECURITY comment on the \`Repo.Password\` field documenting all of that, and recommends \`\$secret.X\` over \`\${env.X}\` for distributed deployments since \`\$secret.X\` resolves at \`task.Execute\` (post queue-pop) and never lands in the jobs table or transport.

## Tests
- \`TestRedactToolInput_{ShortPassesThrough, BoundaryExact, LongTruncated, EmptyAndNil}\` cover the truncation function. \`LongTruncated\` explicitly asserts tail bytes (the leak vector) don't appear in the output.
- \`TestOpenTranscript_FileMode0600\` locks in the transcript permission invariant.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` full suite pass (8 packages)
- [x] \`go test -tags smoke\` binary smoke pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)