### PR TITLE
fix: Medium Bundle B — correctness footguns (M1 + M4 + M9)

### DIFF
--- a/internal/cronicle/dag.go
+++ b/internal/cronicle/dag.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -295,6 +296,30 @@ func walkDAG(deps map[string][]string, fn func(string) error, continueOnFailure 
 				}
 			}
 		}
+	}
+
+	// Cycle detection: any node whose inDegree is still > 0 after the
+	// walk is unreachable — its degree never decremented to zero, which
+	// means it depends on a node that itself was never visited. That
+	// only happens when those nodes form a dependency cycle (or depend
+	// on one). Without this check, a cyclic config would silently
+	// produce a zero-task no-op and return nil. Return the cycle members
+	// so the operator can see exactly what to break.
+	var unreached []string
+	for node, degree := range inDegree {
+		if degree > 0 {
+			unreached = append(unreached, node)
+		}
+	}
+	if len(unreached) > 0 {
+		sort.Strings(unreached)
+		cycleErr := fmt.Errorf("dependency cycle detected — tasks never executed: %s",
+			strings.Join(unreached, ", "))
+		// Cycle is a config-level fault. Surface it ahead of any
+		// task-level firstErr because firstErr can only happen for
+		// tasks outside the cycle, which is downstream noise compared
+		// to the structural problem.
+		return cycleErr
 	}
 
 	return firstErr

--- a/internal/cronicle/dag_cycle_test.go
+++ b/internal/cronicle/dag_cycle_test.go
@@ -1,0 +1,105 @@
+package cronicle
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestWalkDAG_DetectsCycle: a 2-node cycle (A↔B) used to produce a
+// silent no-op return (no nodes have in-degree 0, the for-running>0
+// loop never enters, function returns nil error having executed zero
+// tasks). walkDAG must return an error naming the cycle members so the
+// operator can see what to fix.
+func TestWalkDAG_DetectsCycle(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"b"},
+		"b": {"a"},
+	}
+	var called atomic.Int32
+	err := walkDAG(deps, func(name string) error {
+		called.Add(1)
+		return nil
+	}, nil, nil)
+
+	if err == nil {
+		t.Fatalf("expected cycle error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should identify the failure as a cycle; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "a") || !strings.Contains(err.Error(), "b") {
+		t.Errorf("error should name cycle members a and b; got: %v", err)
+	}
+	if got := called.Load(); got != 0 {
+		t.Errorf("fn should never run on a cyclic graph; called %d time(s)", got)
+	}
+}
+
+// TestWalkDAG_DetectsLongerCycle: a 3-node cycle (A→B→C→A) catches
+// the same class of bug but stresses the unreached-node-list logic
+// across more entries.
+func TestWalkDAG_DetectsLongerCycle(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"c"},
+		"b": {"a"},
+		"c": {"b"},
+	}
+	err := walkDAG(deps, func(name string) error { return nil }, nil, nil)
+	if err == nil {
+		t.Fatalf("expected cycle error, got nil")
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention cycle member %q; got: %v", want, err)
+		}
+	}
+}
+
+// TestWalkDAG_PartialCycleStillRunsIndependentTasks: a graph with one
+// cycle (A↔B) AND an independent task (C) should run C to completion
+// but still report the cycle so the operator notices the broken
+// portion. The function returns the cycle error rather than a nil
+// success because nil would mask the structural problem.
+func TestWalkDAG_PartialCycleStillRunsIndependentTasks(t *testing.T) {
+	deps := map[string][]string{
+		"a": {"b"},
+		"b": {"a"},
+		"c": {}, // independent
+	}
+	var ranC atomic.Bool
+	err := walkDAG(deps, func(name string) error {
+		if name == "c" {
+			ranC.Store(true)
+		}
+		return nil
+	}, nil, nil)
+
+	if err == nil {
+		t.Fatalf("expected cycle error, got nil")
+	}
+	if !ranC.Load() {
+		t.Errorf("independent task c should have run before walkDAG returned the cycle error")
+	}
+	// Cycle members (a, b) must appear in the error; the cycle error
+	// reports only unreached nodes (those that never had in-degree 0),
+	// so c — which ran successfully — must not appear.
+	if !strings.Contains(err.Error(), "a") || !strings.Contains(err.Error(), "b") {
+		t.Errorf("cycle error should name a and b; got: %v", err)
+	}
+}
+
+// TestWalkDAG_LinearGraphNoFalsePositive: a strictly linear DAG
+// (A→B→C, no cycles) must complete cleanly without the cycle-detection
+// check raising a false alarm.
+func TestWalkDAG_LinearGraphNoFalsePositive(t *testing.T) {
+	deps := map[string][]string{
+		"a": {},
+		"b": {"a"},
+		"c": {"b"},
+	}
+	err := walkDAG(deps, func(name string) error { return nil }, nil, nil)
+	if err != nil {
+		t.Errorf("acyclic graph should produce no error; got: %v", err)
+	}
+}

--- a/internal/cronicle/exec.go
+++ b/internal/cronicle/exec.go
@@ -641,7 +641,14 @@ func (task *Task) Execute(t time.Time) (exec.Result, error) {
 			retryCount = task.Retry.Count
 		}
 
-		return attempt < retryCount, err
+		// try.Do passes attempt=1 for the first run, 2 for the first
+		// retry, etc. Retry.Count is documented as "number of retry
+		// attempts after the first" — so for Count=N the loop should
+		// keep going through attempt=N+1 (one initial + N retries).
+		// The previous form `attempt < retryCount` stopped one attempt
+		// too early: Count=3 produced 3 total attempts (1 initial + 2
+		// retries) instead of the documented 4.
+		return attempt <= retryCount, err
 	})
 	if err != nil {
 		return result, err

--- a/internal/cronicle/exec_retry_test.go
+++ b/internal/cronicle/exec_retry_test.go
@@ -1,0 +1,81 @@
+package cronicle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// runAndCountAttempts wires up a failing shell task with the supplied
+// Retry config and returns the number of times task.Exec actually ran.
+// The "command" appends to a counter file on each attempt and exits
+// non-zero so try.Do treats it as failed and decides whether to retry.
+func runAndCountAttempts(t *testing.T, retry *Retry) int {
+	t.Helper()
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "n")
+	// Each attempt appends one byte to the counter file then exits 1.
+	// File length after task.Execute returns equals the attempt count.
+	cmd := []string{"sh", "-c",
+		fmt.Sprintf("printf x >> %s; exit 1", counter)}
+
+	task := &Task{
+		Name:         "retrycount",
+		Command:      cmd,
+		Path:         dir,
+		CroniclePath: dir,
+		ScheduleName: "t",
+		Retry:        retry,
+	}
+	// task.Execute logs attempt info via slog; suppress noise during tests.
+	SetupLogging(LogFormatText)
+
+	_, _ = task.Execute(time.Now())
+
+	body, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return len(body)
+}
+
+// TestTaskRetry_NoRetryConfigured: a task with no Retry block runs
+// exactly once. Establishes the baseline so the Count cases below
+// can assert deltas rather than absolute numbers.
+func TestTaskRetry_NoRetryConfigured(t *testing.T) {
+	if got := runAndCountAttempts(t, nil); got != 1 {
+		t.Errorf("no Retry: got %d attempts, want 1 (no retries)", got)
+	}
+}
+
+// TestTaskRetry_CountMatchesDocumentedSemantics locks in the M4 fix.
+//
+// Retry.Count is documented as "number of retry attempts after first
+// attempt", so Count=N must produce N+1 total runs. Previously
+// `attempt < retryCount` short-circuited one attempt early, giving
+// Count=3 only 3 total attempts (2 retries) instead of 4 (3 retries).
+//
+// Backwards-incompatible behavior change: HCL configs that set
+// `count = N` will now see one additional invocation per failing run.
+func TestTaskRetry_CountMatchesDocumentedSemantics(t *testing.T) {
+	cases := []struct {
+		count       int
+		wantTotal   int
+		description string
+	}{
+		{count: 1, wantTotal: 2, description: "1 retry → 2 total"},
+		{count: 2, wantTotal: 3, description: "2 retries → 3 total"},
+		{count: 3, wantTotal: 4, description: "3 retries → 4 total"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			got := runAndCountAttempts(t, &Retry{Count: tc.count})
+			if got != tc.wantTotal {
+				t.Errorf("Count=%d: got %d total attempts, want %d",
+					tc.count, got, tc.wantTotal)
+			}
+		})
+	}
+}

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -171,7 +171,17 @@ func Open(dsn string) (*Store, error) {
 		return openPostgres(dsn)
 	}
 	conn := dsn
-	if dsn != ":memory:" {
+	if dsn == ":memory:" {
+		// WAL is meaningless for in-memory and not all sqlite builds
+		// accept it on :memory:; busy_timeout matters once MaxOpenConns
+		// is raised above 1. foreign_keys(on) MUST be applied here too
+		// — the tasks table has FOREIGN KEY (run_id) REFERENCES runs
+		// with ON DELETE CASCADE, and skipping the pragma in tests +
+		// workers (which use :memory: for the local projection) lets
+		// orphan rows and missing cascades pass silently in tests
+		// while production (file DSN) enforces them.
+		conn = ":memory:?_pragma=busy_timeout(5000)&_pragma=foreign_keys(on)"
+	} else {
 		conn = dsn + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(on)"
 	}
 	db, err := sql.Open("sqlite", conn)


### PR DESCRIPTION
## Summary
Three surgical fixes for silent footguns:

| Finding | Status | File | Risk |
|---|---|---|---|
| **M1** | ✅ fixed | \`dag.go\` — walkDAG cycle detection | Cyclic config silently no-ops |
| **M4** | ✅ fixed | \`exec.go\` — retry semantics match docs | **Behavior change for Count=N users** |
| **M9** | ✅ fixed | \`state/store.go\` — \`:memory:\` gets \`foreign_keys(on)\` | Tests masked FK violations |

## M1 — DAG cycle detection
\`walkDAG\` had no cycle check. A user-defined cycle (A↔B) meant no node ever reached in-degree 0, the running counter started at 0, the for-loop never entered, and the function returned nil. Zero tasks executed; nil error returned — operator saw a \"successful\" run that did nothing.

Now any node whose in-degree never reached zero after the walk is reported as part of a cycle, with the unreached nodes named in the error. Cycle errors take precedence over per-task firstErr (since firstErr can only happen for tasks outside the cycle, which is downstream noise compared to the structural problem).

## M4 — Retry off-by-one ⚠️ Behavioral change
\`Retry.Count\` is documented as \"number of retry attempts after first attempt\", so \`Count=N\` should produce N+1 total runs. The previous form \`attempt < retryCount\` short-circuited one attempt early: \`Count=3\` ran only 3 total times (2 retries) instead of the documented 4.

Fixed: \`attempt <= retryCount\`. \`Count=3\` now produces 1 initial run plus 3 retries = 4 total.

**⚠️ Backwards-incompatible**: HCL configs that explicitly set \`count = N\` will now see one additional invocation per failing run. The new behavior matches the documented semantics; operators who had observed the old behavior and tuned \`count\` accordingly may want to decrement their value by 1 to keep total attempts unchanged.

No tests previously encoded the off-by-one behavior (verified via grep), so the test suite catches no regressions.

## M9 — :memory: foreign keys pragma
The DSN builder applied \`foreign_keys(on)\` to every DSN **except** \`:memory:\`. The tasks table has \`FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE\` — without the pragma, tests + workers (both use \`:memory:\` for the local projection) silently accepted orphan task rows and missed cascade-deletes that the production file DSN enforced.

Fixed: \`:memory:\` now gets \`busy_timeout(5000)\` + \`foreign_keys(on)\`; WAL is still skipped (meaningless for in-memory, and modernc.org/sqlite rejects it).

## Tests added
- \`TestWalkDAG_DetectsCycle\` — 2-node A↔B cycle
- \`TestWalkDAG_DetectsLongerCycle\` — 3-node A→B→C→A
- \`TestWalkDAG_PartialCycleStillRunsIndependentTasks\` — independent task C runs to completion even though A↔B form a cycle
- \`TestWalkDAG_LinearGraphNoFalsePositive\`
- \`TestTaskRetry_NoRetryConfigured\` — baseline: exactly 1 attempt
- \`TestTaskRetry_CountMatchesDocumentedSemantics\` — Count 1/2/3 → 2/3/4 total attempts

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` full suite (8 packages) pass
- [x] \`go test -tags smoke\` binary smoke pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)