### PR TITLE
fix: Medium Bundle C — distributed/HTTP edge cases (M7+M8+M10+M11)

### DIFF
--- a/internal/cronicle/listen.go
+++ b/internal/cronicle/listen.go
@@ -43,6 +43,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jshiv/cronicle/internal/cronicle/state"
@@ -63,6 +64,21 @@ type listenServer struct {
 	confSrc     func() *Config
 	stateSrc    func() state.Backend
 	liveSinkSrc func() *state.LiveSink
+	// triggerMu serializes the trigger handlers' pause/drain check + queue
+	// push against the pause/drain mutation handlers. Without it a request
+	// flow like:
+	//
+	//   trigger:  check isPaused (false), [race window], queue push, 202
+	//   pause:    [race window], SetSchedulePaused
+	//
+	// could 202 a trigger that the operator intended to silence. Worker-
+	// side gates (DAG walker re-checks the pause flag) catch the run before
+	// it actually executes — so the practical leak is at most one queued
+	// row, not an extra task execution — but matching what the client was
+	// told ("queued") with reality is itself a contract the API should
+	// keep. The mutex is uncontended in normal operation; only trigger /
+	// pause / drain handlers acquire it.
+	triggerMu sync.Mutex
 }
 
 // startListener brings up the HTTP server in a background goroutine.
@@ -269,6 +285,11 @@ func (s *listenServer) handleScheduleRoute(w http.ResponseWriter, r *http.Reques
 
 	switch {
 	case len(parts) == 2 && parts[1] == "trigger":
+		// triggerMu serializes the check+push against pause/drain mutations
+		// so an interleaving POST /pause can't slide between isPaused and
+		// triggerSchedule. See triggerMu doc comment on listenServer.
+		s.triggerMu.Lock()
+		defer s.triggerMu.Unlock()
 		if s.isDrained() {
 			http.Error(w, "runner is drained", http.StatusServiceUnavailable)
 			return
@@ -292,6 +313,8 @@ func (s *listenServer) handleScheduleRoute(w http.ResponseWriter, r *http.Reques
 			http.Error(w, fmt.Sprintf("task %q not in schedule %q", taskName, schedName), http.StatusNotFound)
 			return
 		}
+		s.triggerMu.Lock()
+		defer s.triggerMu.Unlock()
 		if s.isDrained() {
 			http.Error(w, "runner is drained", http.StatusServiceUnavailable)
 			return
@@ -330,6 +353,8 @@ func (s *listenServer) handleScheduleRoute(w http.ResponseWriter, r *http.Reques
 			http.Error(w, fmt.Sprintf("task %q not in schedule %q", taskName, schedName), http.StatusNotFound)
 			return
 		}
+		s.triggerMu.Lock()
+		defer s.triggerMu.Unlock()
 		if s.isDrained() {
 			http.Error(w, "runner is drained", http.StatusServiceUnavailable)
 			return
@@ -470,6 +495,11 @@ func (s *listenServer) handlePauseSchedule(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	actor, reason := readPauseBody(r)
+	// Serialize against in-flight trigger handlers so a trigger that's
+	// already past its isPaused check doesn't 202 alongside this pause.
+	// See triggerMu doc on listenServer.
+	s.triggerMu.Lock()
+	defer s.triggerMu.Unlock()
 	if err := st.SetSchedulePaused(name, actor, reason); err != nil {
 		slog.Error("pause schedule failed", "schedule", name, "error", err.Error())
 		http.Error(w, "pause failed", http.StatusInternalServerError)

--- a/internal/cronicle/listen_drain.go
+++ b/internal/cronicle/listen_drain.go
@@ -63,6 +63,11 @@ func (s *listenServer) handleRunnerDrain(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	actor, reason := readPauseBody(r)
+	// Serialize against in-flight trigger handlers so a trigger that's
+	// already past its isDrained check doesn't 202 alongside this drain.
+	// See triggerMu doc on listenServer.
+	s.triggerMu.Lock()
+	defer s.triggerMu.Unlock()
 	if err := st.SetDrained(actor, reason); err != nil {
 		slog.Error("drain failed", "error", err.Error())
 		http.Error(w, "drain failed", http.StatusInternalServerError)

--- a/internal/cronicle/state/control.go
+++ b/internal/cronicle/state/control.go
@@ -185,10 +185,7 @@ func (s *Store) Retry(runID, newRunID string) (RetryResult, error) {
 		return RetryResult{}, fmt.Errorf("Retry: enqueue: %w", err)
 	}
 	// Wake any blocked long-poll waiters.
-	w := s.waiters()
-	w.mu.Lock()
-	w.cond.Broadcast()
-	w.mu.Unlock()
+	s.signalWaiters()
 
 	return RetryResult{
 		OriginalRunID: runID,
@@ -289,10 +286,7 @@ func (s *Store) RetryFailed(runID, newRunID string) (RetryResult, error) {
 	); err != nil {
 		return RetryResult{}, fmt.Errorf("RetryFailed: enqueue: %w", err)
 	}
-	w := s.waiters()
-	w.mu.Lock()
-	w.cond.Broadcast()
-	w.mu.Unlock()
+	s.signalWaiters()
 
 	return RetryResult{
 		OriginalRunID: runID,
@@ -388,10 +382,7 @@ func (s *Store) RetryTask(runID, taskName string, keep map[string]bool, newRunID
 	); err != nil {
 		return RetryResult{}, fmt.Errorf("RetryTask: enqueue: %w", err)
 	}
-	w := s.waiters()
-	w.mu.Lock()
-	w.cond.Broadcast()
-	w.mu.Unlock()
+	s.signalWaiters()
 
 	return RetryResult{
 		OriginalRunID: runID,

--- a/internal/cronicle/state/migration_idempotency_test.go
+++ b/internal/cronicle/state/migration_idempotency_test.go
@@ -1,0 +1,59 @@
+package state
+
+import (
+	"testing"
+)
+
+// TestMigrate_V10IdempotentOnReRun simulates the crash window the
+// previous migrate() exposed: if the process died between the v10
+// ALTER TABLE and the version row insert, the next startup would
+// rerun the ALTER and fail with "duplicate column name".
+//
+// migrate() is now structured so each version's DDL + version-row
+// insert happen as adjacent steps (tiny crash window), AND v10's
+// runner probes the column list first via migrateV10Idempotent. Calling
+// migrate() repeatedly against the same DB must therefore succeed.
+func TestMigrate_V10IdempotentOnReRun(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.db.Close()
+
+	// First call set up everything to v10. Now simulate a crash-recover
+	// where the version row didn't land: roll the schema_versions row
+	// for v10 back manually, then re-invoke migrate.
+	if _, err := s.db.Exec(`DELETE FROM schema_versions WHERE version = 10`); err != nil {
+		t.Fatalf("simulate partial-migration: %v", err)
+	}
+	if err := s.migrate(); err != nil {
+		t.Fatalf("re-running migrate after partial v10 must succeed; got: %v", err)
+	}
+
+	// And the version row is back.
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM schema_versions WHERE version = 10`).Scan(&n); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected version 10 row to be recorded after recovery; got %d", n)
+	}
+}
+
+// TestMigrateV10Idempotent_DirectInvocation confirms migrateV10Idempotent
+// itself short-circuits when the columns are already present — this is
+// the helper that makes the crash-recovery path work.
+func TestMigrateV10Idempotent_DirectInvocation(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.db.Close()
+
+	// Columns are present after Open's initial migrate. A direct call
+	// to migrateV10Idempotent must not error and must not re-issue the
+	// ALTER (which would fail with "duplicate column name").
+	if err := s.migrateV10Idempotent(); err != nil {
+		t.Errorf("calling migrateV10Idempotent against a v10 schema must be a no-op; got: %v", err)
+	}
+}

--- a/internal/cronicle/state/queue.go
+++ b/internal/cronicle/state/queue.go
@@ -38,20 +38,56 @@ type Job struct {
 var ErrNoJobs = errors.New("state: no jobs available")
 
 // jobWaiters synchronizes long-poll waiters with enqueue/visibility
-// reapers. Producers Broadcast on enqueue; reapers Broadcast when they
-// move expired claims back to pending. Cheaper than a per-worker
-// wakeup channel and correct at our scale (≤100 workers).
+// reapers. Producers signal on enqueue; reapers signal when they move
+// expired claims back to pending.
+//
+// Implementation: a "broadcast channel" — a chan struct{} that
+// signal() closes and replaces. Waiters read the current channel
+// snapshot, then block on it; closing the chan wakes every waiter
+// holding a reference simultaneously. The next signal allocates a
+// fresh channel.
+//
+// Why not sync.Cond: Cond.Wait has no timeout / ctx awareness, so the
+// previous code wrapped it in a spawned goroutine + select { done /
+// timer.C / ctx.Done }. That had a goroutine-leak race: if signal()
+// fired before the spawned goroutine had acquired the mutex and
+// entered Wait, the broadcast was lost and the goroutine blocked
+// indefinitely (until the next unrelated signal). Channel-close
+// broadcast doesn't have this race — there's no "wait inside lock"
+// step that can be missed.
 type jobWaiters struct {
-	mu   sync.Mutex
-	cond *sync.Cond
+	mu sync.Mutex
+	ch chan struct{}
 }
 
 func (s *Store) waiters() *jobWaiters {
 	s.waitOnce.Do(func() {
-		s.wait = &jobWaiters{}
-		s.wait.cond = sync.NewCond(&s.wait.mu)
+		s.wait = &jobWaiters{ch: make(chan struct{})}
 	})
 	return s.wait
+}
+
+// signal wakes every waiter currently blocked in WaitForJob, then
+// reallocates the channel for the next round. Holding the mutex
+// while we swap the chan ensures concurrent signal()s don't
+// double-close or lose wakeups.
+func (s *Store) signalWaiters() {
+	w := s.waiters()
+	w.mu.Lock()
+	close(w.ch)
+	w.ch = make(chan struct{})
+	w.mu.Unlock()
+}
+
+// currentChan returns the channel each WaitForJob caller blocks on.
+// Captured under lock so a concurrent signal() can't swap the chan
+// out from under us mid-read — we either get the current chan (and
+// its close on next signal wakes us) or the next chan (and its close
+// on the next-next signal wakes us). Either way no wakeup is lost.
+func (w *jobWaiters) currentChan() chan struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.ch
 }
 
 // Enqueue persists a job for a future Claim. Idempotent on duplicate
@@ -78,12 +114,11 @@ func (s *Store) Enqueue(runID, schedule string, payload []byte) error {
 	if err != nil {
 		return fmt.Errorf("Enqueue: %w", err)
 	}
-	// Wake one waiter; if multiple long-polls are blocked, they'll race
-	// for the SQL claim and at most one wins.
-	w := s.waiters()
-	w.mu.Lock()
-	w.cond.Broadcast()
-	w.mu.Unlock()
+	// Wake every waiter; they'll race for the SQL claim and at most one
+	// wins. Broadcast-style wakeup is correct here — extra spurious
+	// wakeups for losing workers are cheaper than tracking per-worker
+	// state, and at ≤100 workers the wasted Claim calls are negligible.
+	s.signalWaiters()
 	return nil
 }
 
@@ -293,10 +328,7 @@ func (s *Store) ReapExpired() (int, error) {
 	if n > 0 {
 		// Wake any blocked long-polls so the freed jobs get claimed
 		// promptly rather than waiting for the next worker reconnect.
-		w := s.waiters()
-		w.mu.Lock()
-		w.cond.Broadcast()
-		w.mu.Unlock()
+		s.signalWaiters()
 	}
 	return int(n), nil
 }
@@ -308,40 +340,27 @@ func (s *Store) ReapExpired() (int, error) {
 // caller's next Claim will return ErrNoJobs and the long-poll will
 // return 204.
 //
-// We use sync.Cond rather than a per-waiter chan because the broadcast
-// pattern (any pending → all waiters race for the SQL lock, only one
-// wins) maps cleanly to Cond. With ≤100 workers the wasted wakeups are
-// negligible; if we ever scale past, switch to a FIFO of waiter IDs.
+// The previous sync.Cond-based implementation wrapped Cond.Wait in a
+// spawned goroutine to add timeout / ctx awareness. That had a
+// goroutine-leak race: if Broadcast fired before the goroutine had
+// acquired the cond mutex, the wakeup was lost and the goroutine
+// blocked indefinitely (until an unrelated future signal). Under idle
+// load that's a permanent leak per WaitForJob call.
+//
+// The chan-close broadcast pattern (see jobWaiters / signalWaiters)
+// is naturally ctx-aware and has no "wait inside lock" step that can
+// be missed. No goroutine spawn either.
 func (s *Store) WaitForJob(ctx context.Context, timeout time.Duration) bool {
-	w := s.waiters()
-	done := make(chan struct{})
+	ch := s.waiters().currentChan()
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	go func() {
-		w.mu.Lock()
-		defer w.mu.Unlock()
-		w.cond.Wait()
-		select {
-		case done <- struct{}{}:
-		default:
-		}
-	}()
-
 	select {
-	case <-done:
+	case <-ch:
 		return true
 	case <-timer.C:
-		// Wake the goroutine so Wait() returns and we don't leak it.
-		// A spurious broadcast is cheaper than tracking per-waiter state.
-		w.mu.Lock()
-		w.cond.Broadcast()
-		w.mu.Unlock()
 		return false
 	case <-ctx.Done():
-		w.mu.Lock()
-		w.cond.Broadcast()
-		w.mu.Unlock()
 		return false
 	}
 }

--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -288,73 +288,81 @@ func (s *Store) migrate() error {
 	if err := row.Scan(&current); err != nil {
 		return fmt.Errorf("state.migrate: read version: %w", err)
 	}
-	// v2: jobs (queue table)
-	if current < 2 {
-		if err := s.execDDL(schemaSQL_v2); err != nil {
-			return fmt.Errorf("state.migrate v2: %w", err)
+	// Per-version migration: run DDL, immediately record the version
+	// row. Previously DDLs ran in a batch and versions were inserted
+	// in a single loop at the end — if the process crashed between
+	// running v10's ALTER TABLE and writing the version row, the next
+	// startup re-ran the ALTER, which fails with "duplicate column
+	// name" because SQLite's ALTER TABLE ADD COLUMN has no
+	// IF NOT EXISTS form. Per-version recording shrinks the window
+	// dramatically (no other DDL between ALTER and version write) and
+	// recordVersion(10) below is also called from a v10-specific
+	// idempotent path that checks column existence before ALTERing.
+	steps := []struct {
+		v   int
+		ddl string
+		run func() error // optional override for non-idempotent steps
+	}{
+		{2, schemaSQL_v2, nil},
+		{3, schemaSQL_v3, nil},
+		{4, schemaSQL_v4, nil},
+		{5, schemaSQL_v5, nil},
+		{6, schemaSQL_v6, nil},
+		{7, schemaSQL_v7, nil},
+		{8, schemaSQL_v8, nil},
+		{9, schemaSQL_v9, nil},
+		{10, schemaSQL_v10, s.migrateV10Idempotent},
+	}
+	for _, step := range steps {
+		if current >= step.v {
+			continue
 		}
-	}
-	// v3: workers (registry)
-	if current < 3 {
-		if err := s.execDDL(schemaSQL_v3); err != nil {
-			return fmt.Errorf("state.migrate v3: %w", err)
+		if step.run != nil {
+			if err := step.run(); err != nil {
+				return fmt.Errorf("state.migrate v%d: %w", step.v, err)
+			}
+		} else if err := s.execDDL(step.ddl); err != nil {
+			return fmt.Errorf("state.migrate v%d: %w", step.v, err)
 		}
-	}
-	// v4: slim events ledger (drop payload column on upgrade)
-	if current < 4 {
-		if err := s.execDDL(schemaSQL_v4); err != nil {
-			return fmt.Errorf("state.migrate v4: %w", err)
-		}
-	}
-	// v5: schedule_state (pause/drained control rows)
-	if current < 5 {
-		if err := s.execDDL(schemaSQL_v5); err != nil {
-			return fmt.Errorf("state.migrate v5: %w", err)
-		}
-	}
-	// v6: task_state (per-task skip flags)
-	if current < 6 {
-		if err := s.execDDL(schemaSQL_v6); err != nil {
-			return fmt.Errorf("state.migrate v6: %w", err)
-		}
-	}
-	// v7: run_state (per-run pause flag)
-	if current < 7 {
-		if err := s.execDDL(schemaSQL_v7); err != nil {
-			return fmt.Errorf("state.migrate v7: %w", err)
-		}
-	}
-	// v8: runner_state (runner-wide drain flag, singleton)
-	if current < 8 {
-		if err := s.execDDL(schemaSQL_v8); err != nil {
-			return fmt.Errorf("state.migrate v8: %w", err)
-		}
-	}
-	// v9: secrets table + secrets_meta(etag_counter) — the in-tree
-	// store backing the SecretStore role on Backend.
-	if current < 9 {
-		if err := s.execDDL(schemaSQL_v9); err != nil {
-			return fmt.Errorf("state.migrate v9: %w", err)
-		}
-	}
-	// v10: at-rest envelope encryption columns on the secrets table.
-	// Backfill of pre-existing plaintext rows happens in Go via
-	// BackfillSecrets after WithAEAD — schema-level migration just
-	// adds the columns.
-	if current < 10 {
-		if err := s.execDDL(schemaSQL_v10); err != nil {
-			return fmt.Errorf("state.migrate v10: %w", err)
-		}
-	}
-	if current >= targetSchemaVersion {
-		return nil
-	}
-	for v := current + 1; v <= targetSchemaVersion; v++ {
-		if _, err := s.db.Exec(`INSERT INTO schema_versions(version) VALUES (?)`, v); err != nil {
-			return fmt.Errorf("state.migrate: record version %d: %w", v, err)
+		if _, err := s.db.Exec(`INSERT INTO schema_versions(version) VALUES (?)`, step.v); err != nil {
+			return fmt.Errorf("state.migrate: record version %d: %w", step.v, err)
 		}
 	}
 	return nil
+}
+
+// migrateV10Idempotent runs the v10 secrets-encryption columns ALTER
+// only when value_ct doesn't already exist. SQLite's ALTER TABLE ADD
+// COLUMN has no IF NOT EXISTS, so a crash between the DDL succeeding
+// and the version row landing would otherwise wedge startup. Probe via
+// PRAGMA table_info(secrets); if the columns are there, treat the
+// migration as already-applied.
+func (s *Store) migrateV10Idempotent() error {
+	rows, err := s.db.Query(`PRAGMA table_info(secrets)`)
+	if err != nil {
+		return fmt.Errorf("probe secrets schema: %w", err)
+	}
+	defer rows.Close()
+	hasCT, hasNonce := false, false
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return fmt.Errorf("scan secrets schema: %w", err)
+		}
+		switch name {
+		case "value_ct":
+			hasCT = true
+		case "value_nonce":
+			hasNonce = true
+		}
+	}
+	if hasCT && hasNonce {
+		return nil
+	}
+	return s.execDDL(schemaSQL_v10)
 }
 
 // Apply folds an event into the projection. Idempotent on event re-delivery

--- a/internal/cronicle/state/wait_for_job_test.go
+++ b/internal/cronicle/state/wait_for_job_test.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWaitForJob_NoGoroutineLeakOnTimeout is the M8 regression: the
+// previous Cond-based implementation spawned a goroutine per call
+// that could be permanently stranded if Broadcast fired before the
+// goroutine reached Wait. The chan-close broadcast pattern eliminates
+// that spawn entirely. Verify by snapshotting goroutine counts before
+// and after a batch of timed-out waits.
+func TestWaitForJob_NoGoroutineLeakOnTimeout(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.db.Close()
+
+	// Warm up the lazy waiters() init so the first call isn't an outlier.
+	_ = s.WaitForJob(context.Background(), time.Millisecond)
+	// Settle any background goroutines from setup before snapshotting.
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	const N = 100
+	for i := 0; i < N; i++ {
+		if got := s.WaitForJob(context.Background(), 5*time.Millisecond); got != false {
+			t.Fatalf("expected timeout (false), got true")
+		}
+	}
+
+	// Give any short-lived goroutines a moment to die before measuring.
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	// Allow a small slop for any incidental scheduler / GC goroutines.
+	// The old leak grew 1:1 with N=100, so any value below ~10 means the
+	// leak is gone.
+	if after-before > 5 {
+		t.Errorf("goroutine count grew by %d after %d WaitForJob timeouts (before=%d, after=%d)",
+			after-before, N, before, after)
+	}
+}
+
+// TestWaitForJob_WokenByEnqueue: the channel-broadcast must propagate
+// the wakeup to every waiter the same way the old Cond.Broadcast did.
+func TestWaitForJob_WokenByEnqueue(t *testing.T) {
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.db.Close()
+
+	const N = 5
+	var wg sync.WaitGroup
+	woken := make(chan bool, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			woken <- s.WaitForJob(context.Background(), 2*time.Second)
+		}()
+	}
+
+	// Give waiters a beat to register on the current channel snapshot.
+	time.Sleep(50 * time.Millisecond)
+	if err := s.Enqueue("r1", "sched", []byte(`{}`)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("waiters did not wake within 3s of enqueue")
+	}
+
+	close(woken)
+	wakeups := 0
+	for w := range woken {
+		if w {
+			wakeups++
+		}
+	}
+	if wakeups != N {
+		t.Errorf("expected all %d waiters to receive the wakeup, got %d", N, wakeups)
+	}
+}

--- a/internal/cronicle/worker_queue.go
+++ b/internal/cronicle/worker_queue.go
@@ -178,6 +178,12 @@ func (c *httpQueueClient) controlLoop(cancel func(runID string) bool) {
 		req.Header.Set("X-Cronicle-Host", host)
 
 		// SSE connection has no overall timeout — long-lived by design.
+		// (A request-level Timeout would close working streams once it
+		// expired regardless of liveness.) Liveness against a dead TCP
+		// connection is enforced by a per-stream watchdog inside
+		// consumeSSE that closes the body if no bytes arrive for
+		// 2× the producer's SSE heartbeat interval (~60s today). On
+		// close the Scan loop returns and this outer loop reconnects.
 		sseClient := &http.Client{}
 		resp, err := sseClient.Do(req)
 		if err != nil {
@@ -218,10 +224,17 @@ func (c *httpQueueClient) controlLoop(cancel func(runID string) bool) {
 }
 
 // consumeSSE parses the SSE stream until the body closes, routing each
-// control message to cancel(runID).
+// control message to cancel(runID). Wraps the body in a watchdog reader
+// that closes the body if no bytes arrive within sseIdleTimeout —
+// without that, a dead TCP connection (network partition, RST lost)
+// leaves bufio.Scanner.Scan blocked indefinitely on a Read that never
+// returns, since Scan only checks c.ctx between completed lines.
 func (c *httpQueueClient) consumeSSE(body io.ReadCloser, cancel func(runID string) bool) {
 	defer body.Close()
-	scanner := bufio.NewScanner(body)
+	wd := newSSEWatchdog(body, sseIdleTimeout)
+	defer wd.stop()
+
+	scanner := bufio.NewScanner(wd)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
 
 	var event string
@@ -265,5 +278,63 @@ func handleControl(msg state.ControlMsg, cancel func(runID string) bool) {
 		// no-op
 	default:
 		slog.Debug("control: unknown msg type", "type", msg.Type)
+	}
+}
+
+// sseIdleTimeout is the per-stream "no bytes seen" deadline for the
+// control SSE. The producer sends `event: ping` heartbeats every 15-30s
+// (see scheduleEvents in listen.go), so 60s is comfortably above any
+// healthy interval and small enough that a dead connection is detected
+// well before any operator notices a stuck cancel.
+const sseIdleTimeout = 60 * time.Second
+
+// sseWatchdog wraps a ReadCloser with an idle-timeout reader. Each
+// successful read extends the deadline; if no bytes arrive within the
+// timeout, the watchdog closes the underlying body. The Scan loop
+// reading the watchdog then returns naturally (Read returns an error
+// against a closed body) and the outer reconnect loop fires.
+//
+// This is the cure for the previous "long-lived by design" SSE client:
+// without it, a dead TCP connection (network partition, RST lost)
+// leaves bufio.Scanner.Scan blocked on a Read that never returns, since
+// Scan only consults ctx between completed lines.
+type sseWatchdog struct {
+	inner   io.ReadCloser
+	timeout time.Duration
+	timer   *time.Timer
+	done    chan struct{}
+}
+
+func newSSEWatchdog(inner io.ReadCloser, timeout time.Duration) *sseWatchdog {
+	wd := &sseWatchdog{
+		inner:   inner,
+		timeout: timeout,
+		done:    make(chan struct{}),
+	}
+	wd.timer = time.AfterFunc(timeout, func() {
+		slog.Warn("control channel: idle timeout; forcing reconnect",
+			"timeout", timeout)
+		_ = inner.Close()
+	})
+	return wd
+}
+
+func (w *sseWatchdog) Read(p []byte) (int, error) {
+	n, err := w.inner.Read(p)
+	if n > 0 {
+		// Reset the idle deadline on any progress, including heartbeat
+		// pings — those are what keep a healthy connection alive across
+		// the timeout window.
+		w.timer.Reset(w.timeout)
+	}
+	return n, err
+}
+
+func (w *sseWatchdog) stop() {
+	w.timer.Stop()
+	select {
+	case <-w.done:
+	default:
+		close(w.done)
 	}
 }

--- a/internal/cronicle/worker_sse_watchdog_test.go
+++ b/internal/cronicle/worker_sse_watchdog_test.go
@@ -1,0 +1,87 @@
+package cronicle
+
+import (
+	"bytes"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// closeCountReadCloser is a ReadCloser whose Close call increments a
+// counter so tests can verify that the watchdog closed the underlying
+// body after idling out.
+type closeCountReadCloser struct {
+	r      io.Reader
+	closes atomic.Int32
+}
+
+func (c *closeCountReadCloser) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *closeCountReadCloser) Close() error {
+	c.closes.Add(1)
+	return nil
+}
+
+// blockingReader Read always blocks until ch is closed. Simulates a
+// TCP connection that's stuck on a read that never returns — the
+// failure mode the watchdog is supposed to recover from.
+type blockingReader struct{ ch chan struct{} }
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	<-b.ch
+	return 0, io.EOF
+}
+
+// TestSSEWatchdog_ClosesBodyOnIdle is the M11 invariant: when no bytes
+// arrive within the watchdog's timeout, it must close the underlying
+// body so the SSE consumer's bufio.Scanner unblocks (Scan returns false
+// after a body close) and the outer reconnect loop fires.
+func TestSSEWatchdog_ClosesBodyOnIdle(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block) // let any lingering Read return after the test
+
+	inner := &closeCountReadCloser{r: &blockingReader{ch: block}}
+	wd := newSSEWatchdog(inner, 50*time.Millisecond)
+	defer wd.stop()
+
+	// The watchdog timer should fire within ~50ms and close inner.
+	time.Sleep(150 * time.Millisecond)
+
+	if got := inner.closes.Load(); got != 1 {
+		t.Errorf("watchdog must close idle body exactly once; got %d closes", got)
+	}
+}
+
+// TestSSEWatchdog_HealthyStreamSurvives: when bytes (including
+// heartbeats) arrive within each timeout window, the watchdog must NOT
+// close the body. Reads should keep extending the deadline.
+func TestSSEWatchdog_HealthyStreamSurvives(t *testing.T) {
+	// 100ms of heartbeats at 30ms intervals, then EOF. The watchdog
+	// timeout (60ms) is longer than the interval so a healthy stream
+	// always refreshes the deadline before it expires.
+	body := bytes.NewBufferString("event: ping\n\n")
+	inner := &closeCountReadCloser{r: body}
+	wd := newSSEWatchdog(inner, 60*time.Millisecond)
+	defer wd.stop()
+
+	// Read once — that's enough to reset the timer in the watchdog.
+	buf := make([]byte, 32)
+	if _, err := wd.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	// Sleep less than the timeout. Watchdog must NOT have fired yet.
+	time.Sleep(40 * time.Millisecond)
+	if got := inner.closes.Load(); got != 0 {
+		t.Errorf("watchdog closed body during active read window; closes=%d", got)
+	}
+}
+
+// TestSSEWatchdog_StopIsIdempotent: stop() may be called multiple
+// times (e.g., defer plus explicit cleanup) without panicking.
+func TestSSEWatchdog_StopIsIdempotent(t *testing.T) {
+	inner := &closeCountReadCloser{r: bytes.NewBufferString("")}
+	wd := newSSEWatchdog(inner, time.Second)
+	wd.stop()
+	wd.stop() // must not panic
+}


### PR DESCRIPTION
## Summary
Four fixes for distributed-mode robustness:

| Finding | Status | File | What broke |
|---|---|---|---|
| **M7** | ✅ | \`state/store.go\` | v10 ALTER re-runs after crash → \"duplicate column\" wedges startup |
| **M8** | ✅ | \`state/queue.go\`, \`state/control.go\` | Cond.Wait wrapper leaked one goroutine per timed-out WaitForJob under idle load |
| **M10** | ✅ | \`listen.go\`, \`listen_drain.go\` | TOCTOU between isPaused check and queue push → one extra 202 per race window |
| **M11** | ✅ | \`worker_queue.go\` | SSE client's scanner stuck on dead TCP, control goroutine lost forever |

## M7 — v10 migration crash-recovery
\`migrate()\` ran all DDLs first, then recorded versions in a loop. A crash between v10's \`ALTER TABLE\` and the version insert re-runs the ALTER on next startup; SQLite's ALTER TABLE ADD COLUMN has no IF NOT EXISTS, so the restart fails with \`duplicate column name: value_ct\` and wedges the producer.

Restructured \`migrate()\` so each version's DDL and version-row insert are adjacent steps (tiny crash window). v10 specifically goes through \`migrateV10Idempotent\` which probes \`PRAGMA table_info(secrets)\` and short-circuits when the columns are already present.

## M8 — WaitForJob goroutine leak
Old impl wrapped \`Cond.Wait\` in a spawned goroutine to add timeout / ctx awareness. If \`Broadcast\` fired before the goroutine acquired the cond mutex and entered Wait, the wakeup was lost and the goroutine blocked indefinitely. Under idle load (no follow-up enqueues to broadcast against) the leak was permanent and 1:1 with calls.

Replaced \`jobWaiters\` with a chan-close broadcast: \`signalWaiters\` closes the current chan and allocates a fresh one. \`WaitForJob\` is now a plain \`select { ch / timer / ctx }\` — no goroutine spawn, no race window. All three \`Retry*\` paths in \`control.go\` migrated to \`signalWaiters\`.

**New tests:**
- \`TestWaitForJob_NoGoroutineLeakOnTimeout\` — 100 timed-out calls must not grow the goroutine count by more than ~5
- \`TestWaitForJob_WokenByEnqueue\` — 5 waiters all woken by one enqueue (preserves Broadcast contract)

## M10 — TOCTOU in trigger guards
\`\`\`
POST /v1/schedules/X/trigger:
  isPaused (false)    ← request A
  [race window]       ← /pause arrives, sets paused
  triggerSchedule     ← request A queues; 202 returned
\`\`\`

Worker-side gates (DAG walker re-checks the pause flag) catch this before the run actually executes, so the practical impact was one queued row, not an extra task execution. But the API contract was off — 202 implied \"queued and will run\" while the operator was shutting it down.

Added \`s.triggerMu\` on \`listenServer\`; held across check + queue push in all three trigger paths and across \`SetSchedulePaused\` / \`SetDrained\`. Uncontended in normal operation — only trigger / pause / drain handlers acquire it.

## M11 — SSE control client idle-stuck
\`consumeSSE\` wrapped a bufio.Scanner around \`http.Client{}\` with no timeout (intentional for long-lived SSE). Scanner only consults \`ctx\` between completed lines, so a dead TCP connection (network partition, RST lost) left the inner Read blocked indefinitely. The worker's control goroutine was permanently stuck; cancel signals lost until process restart.

Added \`sseWatchdog\` — wraps the body, runs \`time.AfterFunc\` that closes the body if no bytes arrive within \`sseIdleTimeout\` (60s, comfortably above the producer's 15-30s heartbeat ping). Each successful Read resets the timer. When the timer fires, the body closes, Scan returns, the outer reconnect loop fires.

**New tests:**
- \`TestSSEWatchdog_ClosesBodyOnIdle\`
- \`TestSSEWatchdog_HealthyStreamSurvives\`
- \`TestSSEWatchdog_StopIsIdempotent\`

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` full suite (8 packages) pass
- [x] \`go test -tags smoke\` binary smoke pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)