### PR TITLE
fix: Medium Bundle D — concurrency + bounds (M3 + M12 + M13)

### DIFF
--- a/internal/cronicle/cron_source.go
+++ b/internal/cronicle/cron_source.go
@@ -1,6 +1,7 @@
 package cronicle
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -109,7 +110,7 @@ func RunFromSource(ctx context.Context, spec, workdir string, runOptions RunOpti
 		triggerQueue = enqueueChan
 		closeQueue = func() { close(enqueueChan) }
 		go enqueueAdapter(enqueueChan, stateStore)
-		if err := startSchedulerFromSource(ctx, src, conf, etag, enqueueChan); err != nil {
+		if err := startSchedulerFromSource(ctx, src, conf, body, etag, enqueueChan); err != nil {
 			return fmt.Errorf("scheduler start: %w", err)
 		}
 		if runOptions.RunWorker {
@@ -120,7 +121,7 @@ func RunFromSource(ctx context.Context, spec, workdir string, runOptions RunOpti
 		queue := make(chan []byte)
 		triggerQueue = queue
 		closeQueue = func() { close(queue) }
-		if err := startSchedulerFromSource(ctx, src, conf, etag, queue); err != nil {
+		if err := startSchedulerFromSource(ctx, src, conf, body, etag, queue); err != nil {
 			return fmt.Errorf("scheduler start: %w", err)
 		}
 		go ConsumeSchedule(queue, workdirAbs, &wg)
@@ -159,7 +160,7 @@ func RunFromSource(ctx context.Context, spec, workdir string, runOptions RunOpti
 // register heartbeat + config_refresh cron entries, seed the reload
 // state with the pre-fetched conf so the first tick is a true diff
 // rather than a redundant parse.
-func startSchedulerFromSource(ctx context.Context, src configsource.Source, conf *Config, etag string, queue chan<- []byte) error {
+func startSchedulerFromSource(ctx context.Context, src configsource.Source, conf *Config, body []byte, etag string, queue chan<- []byte) error {
 	loc, err := pickLocation(conf.Timezone)
 	if err != nil {
 		return err
@@ -179,11 +180,14 @@ func startSchedulerFromSource(ctx context.Context, src configsource.Source, conf
 	}
 
 	state := newReloadState(src)
-	// Seed the reload state with the already-fetched conf so the first
-	// refresh tick sees `changed=false` and we don't re-parse.
+	// Seed the reload state with the already-fetched conf + raw body so
+	// the first refresh tick's etag check short-circuits at the source
+	// (changed=false), and even if the etag turns over to identical
+	// bytes, the raw-bytes diff in fetchAndParse also short-circuits.
 	state.mu.Lock()
 	state.lastEtag = etag
 	state.lastConf = conf
+	state.lastRawBody = body
 	state.mu.Unlock()
 
 	hbID, err := c.AddFunc(heartbeat, func() {
@@ -227,16 +231,26 @@ func startSchedulerFromSource(ctx context.Context, src configsource.Source, conf
 // the source itself, the last etag, the last parsed config, and the
 // set of static cron entries that must survive a re-register pass.
 //
+// lastRawBody stores the raw bytes from the most recent fetch so
+// loadInto can do a byte-for-byte diff against the new body. The
+// previous approach used Hcl() round-trip (encode → bytes) which is
+// lossy — gohcl drops the repo block, comments, and formatting — so
+// two structurally different configs could produce identical
+// round-trip bytes and the reload would never trigger. The file path
+// already migrated to raw-byte comparison; this brings the source
+// path in line (audit M3).
+//
 // All access is serialized through the cron loop (single goroutine),
 // but a mutex guards the fields for safe inspection from heartbeat
 // callbacks that fire concurrently.
 type reloadState struct {
-	src       configsource.Source
-	mu        sync.Mutex
-	lastEtag  string
-	lastConf  *Config
-	static    map[cron.EntryID]bool
-	lastError error
+	src         configsource.Source
+	mu          sync.Mutex
+	lastEtag    string
+	lastConf    *Config
+	lastRawBody []byte
+	static      map[cron.EntryID]bool
+	lastError   error
 }
 
 func newReloadState(src configsource.Source) *reloadState {
@@ -253,26 +267,43 @@ func (s *reloadState) scheduleCount() int {
 }
 
 // fetchAndParse pulls from the source, parses on change, and updates
-// the state's lastEtag/lastConf. Returns the current config (which may
-// be the cached one when changed=false). Errors are surfaced; callers
-// decide whether to abort or warn-and-keep-previous.
-func (s *reloadState) fetchAndParse(ctx context.Context, initial bool) (*Config, error) {
+// the state's lastEtag/lastConf/lastRawBody. Returns the current config
+// (which may be the cached one when changed=false) and a bytesChanged
+// flag indicating whether the raw body actually differs from the
+// previous load — set to false when the new body is byte-equal to
+// lastRawBody (audit M3: catches the case where the source-side etag
+// indicates "changed" but the bytes round to identical content). Errors
+// are surfaced; callers decide whether to abort or warn-and-keep-prev.
+func (s *reloadState) fetchAndParse(ctx context.Context, initial bool) (conf *Config, bytesChanged bool, err error) {
 	s.mu.Lock()
 	prev := s.lastEtag
 	cached := s.lastConf
+	cachedRaw := s.lastRawBody
 	s.mu.Unlock()
 
 	body, etag, changed, err := s.src.Fetch(ctx, prev)
 	if err != nil {
-		return cached, err
+		return cached, false, err
 	}
 	if !changed {
-		return cached, nil
+		return cached, false, nil
 	}
+	// Raw-bytes diff: the source said "changed" (new etag, no
+	// If-None-Match match) but the body might still be identical. In
+	// that case skip the reload.
+	if cachedRaw != nil && bytes.Equal(cachedRaw, body) {
+		// Refresh the etag so the next If-None-Match short-circuits at
+		// the HTTP layer.
+		s.mu.Lock()
+		s.lastEtag = etag
+		s.mu.Unlock()
+		return cached, false, nil
+	}
+
 	parser := hclparse.NewParser()
 	conf, diags := ParseBytes(body, "cronicle.hcl", parser)
 	if diags.HasErrors() {
-		return cached, fmt.Errorf("parse: %s", diags.Error())
+		return cached, false, fmt.Errorf("parse: %s", diags.Error())
 	}
 
 	// On the very first fetch we don't have a directory context to
@@ -286,8 +317,9 @@ func (s *reloadState) fetchAndParse(ctx context.Context, initial bool) (*Config,
 	s.mu.Lock()
 	s.lastEtag = etag
 	s.lastConf = conf
+	s.lastRawBody = body
 	s.mu.Unlock()
-	return conf, nil
+	return conf, true, nil
 }
 
 // loadInto runs on every refresh tick. Pulls fresh bytes; if changed,
@@ -297,7 +329,7 @@ func (s *reloadState) loadInto(ctx context.Context, c *cron.Cron, queue chan<- [
 	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	conf, err := s.fetchAndParse(fetchCtx, false)
+	conf, bytesChanged, err := s.fetchAndParse(fetchCtx, false)
 	if err != nil {
 		slog.Warn("config refresh failed; keeping previous schedules in place",
 			"source", s.src.String(), "err", err.Error())
@@ -310,17 +342,10 @@ func (s *reloadState) loadInto(ctx context.Context, c *cron.Cron, queue chan<- [
 		return // no cache yet and fetch returned no body
 	}
 
-	// Diff at the rendered-HCL level. Identical bytes → no-op.
-	// NOTE (M3 from audit): Hcl() round-trip is lossy — gohcl drops the
-	// repo block, comments, and formatting — so two structurally different
-	// configs can produce equal bytes here. The file path migrated to a
-	// raw-byte comparison; this path still uses the lossy form pending a
-	// separate fix.
-	if !force {
-		prior := globalRuntime.snapshotConf()
-		if prior != nil && string(prior.Hcl().Bytes) == string(conf.Hcl().Bytes) {
-			return
-		}
+	// Reload only when the raw bytes actually changed (or force). The
+	// diff happens inside fetchAndParse so this is just a flag check.
+	if !force && !bytesChanged {
+		return
 	}
 
 	slog.Info("Refreshing config...", "source", s.src.String(),

--- a/internal/cronicle/cron_source_diff_test.go
+++ b/internal/cronicle/cron_source_diff_test.go
@@ -1,0 +1,108 @@
+package cronicle
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeSource always returns the supplied body, claiming changed=true
+// regardless of whether the etag matches. Simulates a config source
+// that rewrites the etag on every response (some HTTP servers do this
+// on 200 even when the content is unchanged). Without the M3
+// raw-bytes diff, this would force a reload on every refresh tick
+// even when the content is stable.
+type fakeSource struct {
+	body    []byte
+	etag    string
+	fetches int
+}
+
+func (f *fakeSource) Fetch(ctx context.Context, prevEtag string) ([]byte, string, bool, error) {
+	f.fetches++
+	return f.body, f.etag, true, nil
+}
+func (f *fakeSource) String() string { return "fake://" }
+
+// TestFetchAndParse_RawBytesDiffShortCircuits is the M3 invariant.
+// Two consecutive fetches return identical body bytes but different
+// etags. The previous Hcl()-round-trip diff would lose comments and
+// the repo block; the new raw-bytes diff catches them. The second
+// fetch must report bytesChanged=false.
+func TestFetchAndParse_RawBytesDiffShortCircuits(t *testing.T) {
+	body := []byte(`
+schedule "s" {
+  cron = "@every 1h"
+  task "t" {
+    command = ["true"]
+  }
+}
+`)
+	src := &fakeSource{body: body, etag: "etag-v1"}
+	state := newReloadState(src)
+
+	// First fetch — initial, seeds lastRawBody.
+	conf1, changed1, err := state.fetchAndParse(context.Background(), true)
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if conf1 == nil {
+		t.Fatalf("first fetch returned nil config")
+	}
+	if !changed1 {
+		t.Errorf("first fetch should report changed=true (no prior cache)")
+	}
+
+	// Server rewrites the etag but keeps the bytes identical.
+	src.etag = "etag-v2"
+	conf2, changed2, err := state.fetchAndParse(context.Background(), false)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if changed2 {
+		t.Errorf("second fetch with identical bytes should report changed=false; got true")
+	}
+	// The conf pointer should be the same (cached).
+	if conf1 != conf2 {
+		t.Errorf("expected cached conf to be returned on no-change; got fresh pointer")
+	}
+}
+
+// TestFetchAndParse_DetectsRealByteChange: when the body actually
+// differs, bytesChanged must be true and the parsed conf must reflect
+// the new content.
+func TestFetchAndParse_DetectsRealByteChange(t *testing.T) {
+	v1 := []byte(`
+schedule "s1" {
+  cron = "@every 1h"
+  task "t" {
+    command = ["true"]
+  }
+}
+`)
+	v2 := []byte(`
+schedule "s2" {
+  cron = "@every 1h"
+  task "t" {
+    command = ["true"]
+  }
+}
+`)
+	src := &fakeSource{body: v1, etag: "v1"}
+	state := newReloadState(src)
+	if _, _, err := state.fetchAndParse(context.Background(), true); err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+
+	src.body = v2
+	src.etag = "v2"
+	conf, changed, err := state.fetchAndParse(context.Background(), false)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if !changed {
+		t.Errorf("real byte change must set changed=true")
+	}
+	if conf == nil || len(conf.Schedules) == 0 || conf.Schedules[0].Name != "s2" {
+		t.Errorf("parsed conf should reflect the new schedule name; got %+v", conf)
+	}
+}

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -198,8 +198,14 @@ type StreamingWriter struct {
 	leader bool
 	buf    bytes.Buffer
 	out    io.Writer
-	closed bool
-	mu     sync.Mutex // guards buf for concurrent Write calls within one task
+	// closeOnce wraps the cleanup logic so concurrent Close calls don't
+	// race on the `closed` flag. The previous unguarded read/write of a
+	// bool field meant two goroutines could both pass the check and
+	// both enter the unlock path — for a leader, that's a panic on
+	// double-Unlock of streamLock; for a follower, the second caller
+	// would deadlock on the streamLock.Lock it expects to acquire.
+	closeOnce sync.Once
+	mu        sync.Mutex // guards buf for concurrent Write calls within one task
 }
 
 // NewStreamingWriter returns a writer for one task's streaming output.
@@ -223,21 +229,20 @@ func (s *StreamingWriter) Write(p []byte) (int, error) {
 }
 
 // Close releases the leader lock, or — for followers — blocks to acquire the
-// lock, flushes the accumulated buffer atomically, and releases. Idempotent.
+// lock, flushes the accumulated buffer atomically, and releases. Idempotent
+// and concurrency-safe via sync.Once.
 func (s *StreamingWriter) Close() {
-	if s.closed {
-		return
-	}
-	s.closed = true
-	if s.leader {
+	s.closeOnce.Do(func() {
+		if s.leader {
+			streamLock.Unlock()
+			return
+		}
+		streamLock.Lock()
+		s.mu.Lock()
+		_, _ = s.out.Write(s.buf.Bytes())
+		s.mu.Unlock()
 		streamLock.Unlock()
-		return
-	}
-	streamLock.Lock()
-	s.mu.Lock()
-	_, _ = s.out.Write(s.buf.Bytes())
-	s.mu.Unlock()
-	streamLock.Unlock()
+	})
 }
 
 // FileLoggingEnabled reports whether --log-to-file was passed on the

--- a/internal/cronicle/stream.go
+++ b/internal/cronicle/stream.go
@@ -70,6 +70,18 @@ func (e *lineEmitter) Write(p []byte) (int, error) {
 // consume buffers bytes and emits one slog record per newline. Holds
 // the mutex briefly to keep stdout and stderr writers from interleaving
 // half-lines into each other's buffers.
+// maxLineEmitterBufBytes caps the unflushed buffer that a stream emits
+// no-newline bytes into. A subprocess that writes a long binary blob
+// or a progress bar with carriage-return updates can otherwise grow
+// this buffer without bound. When the cap is exceeded we force-emit
+// the current buffer as one synthetic line — operators see the partial
+// output rather than the process OOMing on multi-GB no-newline streams.
+//
+// 1 MiB is well above any reasonable single-line output (the maximum
+// bash truncation budget is 30 KiB) and small enough that even
+// pathological output is bounded to that per Flush window.
+const maxLineEmitterBufBytes = 1 << 20
+
 func (e *lineEmitter) consume(p []byte) {
 	e.mu.Lock()
 	e.buf = append(e.buf, p...)
@@ -81,6 +93,13 @@ func (e *lineEmitter) consume(p []byte) {
 		line := string(e.buf[:i])
 		e.buf = e.buf[i+1:]
 		e.emit(line)
+	}
+	// Cap the unflushed buffer (M13): a stream that never emits a
+	// newline used to grow this buffer indefinitely. Force-emit the
+	// current contents as one synthetic line so memory stays bounded.
+	if len(e.buf) > maxLineEmitterBufBytes {
+		e.emit(string(e.buf) + " [truncated: no newline]")
+		e.buf = e.buf[:0]
 	}
 	e.mu.Unlock()
 }

--- a/internal/cronicle/stream_bound_test.go
+++ b/internal/cronicle/stream_bound_test.go
@@ -1,0 +1,66 @@
+package cronicle
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// TestLineEmitter_BoundedBufferOnNoNewline locks in the M13 fix: a
+// stream that never emits a '\n' used to grow the internal buffer
+// without bound until Flush. We now force-emit when the buffer
+// exceeds maxLineEmitterBufBytes and reset.
+func TestLineEmitter_BoundedBufferOnNoNewline(t *testing.T) {
+	emitter := newLineEmitter(io.Discard, "r", "t", "s", "stdout")
+
+	// Push 4x the cap in newline-free chunks.
+	chunk := bytes.Repeat([]byte("x"), maxLineEmitterBufBytes/4)
+	for i := 0; i < 6; i++ {
+		emitter.Write(chunk)
+	}
+
+	emitter.mu.Lock()
+	defer emitter.mu.Unlock()
+	if got := len(emitter.buf); got > maxLineEmitterBufBytes {
+		t.Errorf("lineEmitter buf grew past cap: got %d bytes, cap %d", got, maxLineEmitterBufBytes)
+	}
+}
+
+// TestLineEmitter_EmitsTruncationMarker: when the buffer cap fires,
+// the synthetic line must signal that it was a truncated emission.
+// Captures the line by routing emit through an in-memory writer.
+func TestLineEmitter_EmitsTruncationMarker(t *testing.T) {
+	emitter := newLineEmitter(io.Discard, "r", "t", "s", "stdout")
+	// Two chunks just over the cap, no newlines.
+	huge := bytes.Repeat([]byte("x"), maxLineEmitterBufBytes+1)
+	emitter.Write(huge)
+
+	// Force a Flush to drain anything remaining, then check that the
+	// emitted lines included a truncation marker. We can't observe the
+	// internal slog emit directly here without a handler swap, but we
+	// CAN observe that the buffer was drained — the truncation reset
+	// it to empty.
+	emitter.mu.Lock()
+	defer emitter.mu.Unlock()
+	if got := len(emitter.buf); got > maxLineEmitterBufBytes {
+		t.Errorf("buf still oversized after consume: %d", got)
+	}
+}
+
+// TestLineEmitter_NormalLinesStillFlow: a well-behaved producer
+// (regular newline-terminated lines) must keep its existing pass-
+// through semantics. The bound only kicks in for pathological no-
+// newline streams.
+func TestLineEmitter_NormalLinesStillFlow(t *testing.T) {
+	emitter := newLineEmitter(io.Discard, "r", "t", "s", "stdout")
+	emitter.Write([]byte("line1\nline2\nline3\n"))
+	emitter.Flush()
+
+	emitter.mu.Lock()
+	defer emitter.mu.Unlock()
+	if got := len(emitter.buf); got != 0 {
+		t.Errorf("buf should be empty after newline-terminated input + Flush; got %d bytes: %q",
+			got, string(emitter.buf))
+	}
+}
+

--- a/internal/cronicle/streaming_writer_test.go
+++ b/internal/cronicle/streaming_writer_test.go
@@ -1,0 +1,59 @@
+package cronicle
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestStreamingWriter_ConcurrentClose_Leader is the M12 race
+// regression: a leader's Close had to release streamLock exactly once.
+// The previous unguarded `closed` field meant two concurrent Close
+// calls could both pass the check and both call streamLock.Unlock,
+// which panics on the second invocation.
+//
+// sync.Once now guards the cleanup. We can't reliably reproduce a
+// panic in a single test run, but we CAN drive many concurrent Close
+// calls and assert none panic — a regression would surface as a
+// "sync: unlock of unlocked mutex" panic on at least one goroutine.
+func TestStreamingWriter_ConcurrentClose_Leader(t *testing.T) {
+	sw := NewStreamingWriter()
+	if !sw.leader {
+		// Only the first writer wins streamLock in a fresh process. If
+		// another test left it held, skip — this test runs in isolation
+		// in normal CI.
+		t.Skip("streamLock held by a prior test; skipping leader-Close test")
+	}
+
+	const concurrentCloses = 50
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentCloses; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Close panicked: %v", r)
+				}
+			}()
+			sw.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestStreamingWriter_CloseIsIdempotent: sequential repeated Close
+// calls must succeed. Documents the intended contract.
+func TestStreamingWriter_CloseIsIdempotent(t *testing.T) {
+	sw := NewStreamingWriter()
+	if !sw.leader {
+		t.Skip("streamLock held by a prior test; skipping idempotency test")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("second Close panicked: %v", r)
+		}
+	}()
+	sw.Close()
+	sw.Close()
+	sw.Close()
+}


### PR DESCRIPTION
## Summary
Three fixes for silent footguns in the streaming and config-reload paths.

| Finding | Status | File | What broke |
|---|---|---|---|
| **M3** | ✅ | \`cron_source.go\` | Source-path config diff was lossy (Hcl round-trip), missed real changes silently |
| **M12** | ✅ | \`log.go\` | StreamingWriter.Close had unguarded \`closed\` flag — panic on double-close as leader, deadlock as follower |
| **M13** | ✅ | \`stream.go\` | lineEmitter buffer grew without bound on no-newline streams |

## M3 — Source-path raw-bytes diff
The file path migrated to byte-for-byte HCL comparison in PR \`2de15e9\`; the source path lagged with the lossy Hcl round-trip. \`gohcl\` drops the repo block, comments, and formatting, so structurally different configs could round-trip to identical bytes — the reload silently never triggered.

\`fetchAndParse\` now stores \`lastRawBody\` and returns a \`bytesChanged\` flag based on \`bytes.Equal\` against the new fetch. \`loadInto\`'s diff collapses to a flag check. Updated \`startSchedulerFromSource\` to seed \`lastRawBody\` from \`RunFromSource\`'s initial fetch so the first refresh tick has a baseline.

## M12 — StreamingWriter.Close race
Old code:
\`\`\`go
if s.closed { return }
s.closed = true
// ... streamLock.Unlock or streamLock.Lock
\`\`\`

Two concurrent Close calls could both pass the check and both enter the unlock path. For a **leader**, that's a \"sync: unlock of unlocked mutex\" panic on \`streamLock\`. For a **follower**, the second caller deadlocks on the \`streamLock.Lock\` it expects to acquire.

Wrapped the cleanup in \`sync.Once\`. Concurrent Close calls now serialize correctly. The \`closed bool\` field is gone — \`sync.Once\` subsumes its role.

## M13 — lineEmitter unbounded buffer
\`consume()\` appended bytes to an internal buffer that only drained at \`'\\n'\`. A subprocess writing a long binary blob or a progress bar with carriage-return updates (no newline ever arrives) used to grow the buffer without bound until exit's Flush. Multi-GB streams could OOM the worker.

Added \`maxLineEmitterBufBytes\` (1 MiB) cap. When the cap is exceeded the accumulated bytes are force-emitted as one synthetic line with a \`\" [truncated: no newline]\"\` suffix and the buffer is reset. 1 MiB is well above any reasonable single-line output (bash tool tops out at 30 KiB).

## Tests added (7 total)
- \`TestFetchAndParse_RawBytesDiffShortCircuits\` — rewriting etag with stable body → bytesChanged=false
- \`TestFetchAndParse_DetectsRealByteChange\` — different body → bytesChanged=true, parses new content
- \`TestStreamingWriter_ConcurrentClose_Leader\` — 50 concurrent Close calls must not panic
- \`TestStreamingWriter_CloseIsIdempotent\` — sequential calls safe
- \`TestLineEmitter_BoundedBufferOnNoNewline\` — 6× cap of newline-free bytes keeps buf ≤ cap
- \`TestLineEmitter_EmitsTruncationMarker\` — verifies reset path runs
- \`TestLineEmitter_NormalLinesStillFlow\` — well-behaved producers unaffected

## ⚠️ Conflict heads-up
This PR is based on current main (no PR G/H/I merged yet). \`stream.go\` is also modified by **PR #153 (Bundle A)** which adds \`redactToolInput\`. When G merges first, J will need a trivial rebase to coexist (additive — both edits go in adjacent sections).

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` full suite (8 packages) pass
- [x] \`go test -tags smoke\` binary smoke pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)