### PR TITLE
fix: Medium Bundle E — M14 + M15 (finishes Medium tier)

### DIFF
--- a/internal/cronicle/mcp.go
+++ b/internal/cronicle/mcp.go
@@ -16,14 +16,17 @@
 package cronicle
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -104,13 +107,23 @@ func launchOne(ctx context.Context, m MCP, taskEnv []string, w io.Writer) (*MCPH
 	// handles teardown via stdin-close + SIGTERM grace period.
 	cmd := exec.CommandContext(ctx, m.Command[0], m.Command[1:]...)
 	cmd.Env = mcpProcessEnv(m.Env, taskEnv)
-	// Server stderr is forwarded to the agent's pretty-mode writer (or
-	// discarded when nil) so npm/install chatter and runtime logs appear
-	// in-context with the rest of the run.
+	// Server stderr routing (audit M14): in pretty mode the agent's
+	// writer renders MCP output in-context with the rest of the run.
+	// Without a pretty writer we previously dumped raw bytes to
+	// os.Stderr, which (a) bypassed the structured log file and Loki,
+	// (b) let third-party MCP servers emit arbitrary ANSI escapes
+	// directly to the operator's terminal, and (c) let any secrets that
+	// surfaced in MCP errors land in raw stderr instead of the bounded,
+	// structured logging chain.
+	//
+	// Now route nil-writer stderr through mcpStderrSlogWriter which
+	// emits one slog.Warn record per line, tagged with the MCP server
+	// name. Operators get structured, queryable MCP errors; raw bytes
+	// don't escape.
 	if w != nil {
 		cmd.Stderr = w
 	} else {
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = newMCPStderrSlogWriter(m.Name)
 	}
 
 	transport := &mcpsdk.CommandTransport{Command: cmd}
@@ -309,6 +322,60 @@ func mcpSchemaToAnthropic(in any) (anthropic.ToolInputSchemaParam, error) {
 		out.ExtraFields[k] = v
 	}
 	return out, nil
+}
+
+// mcpStderrSlogWriter buffers MCP server stderr bytes by newline and
+// emits one slog.Warn record per line, tagged with the MCP server
+// name. Replaces the previous os.Stderr passthrough so:
+//
+//   - MCP errors land in the file log (cronicle.jsonl → Loki) and
+//     LiveSink → SSE, queryable and bounded.
+//   - Untrusted ANSI escapes from third-party servers can't reach the
+//     operator's terminal directly.
+//   - Large outputs are bounded the same way lineEmitter bounds shell
+//     stdout (force-flush on cap exceeded).
+type mcpStderrSlogWriter struct {
+	name string
+	mu   sync.Mutex
+	buf  []byte
+}
+
+// mcpStderrMaxBufBytes caps the unflushed buffer. Mirrors the
+// lineEmitter cap for the same reason — a no-newline stream
+// (binary blob, malformed output) used to be able to grow without
+// bound.
+const mcpStderrMaxBufBytes = 1 << 20 // 1 MiB
+
+func newMCPStderrSlogWriter(name string) *mcpStderrSlogWriter {
+	return &mcpStderrSlogWriter{name: name}
+}
+
+func (w *mcpStderrSlogWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.buf[:i]), "\r")
+		w.buf = w.buf[i+1:]
+		if line != "" {
+			slog.Warn(line,
+				"entry_type", "mcp_stderr",
+				"mcp_server", w.name,
+			)
+		}
+	}
+	if len(w.buf) > mcpStderrMaxBufBytes {
+		slog.Warn(string(w.buf)+" [truncated: no newline]",
+			"entry_type", "mcp_stderr",
+			"mcp_server", w.name,
+		)
+		w.buf = w.buf[:0]
+	}
+	return len(p), nil
 }
 
 // MCPServerNames returns the names of the launched servers, sorted for

--- a/internal/cronicle/mcp_stderr_test.go
+++ b/internal/cronicle/mcp_stderr_test.go
@@ -1,0 +1,87 @@
+package cronicle
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// captureSlog routes slog records into a buffer for the duration of
+// fn, then restores the previous default handler. Returns whatever the
+// handler captured.
+func captureSlog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	_ = context.Background() // touch import for future use
+	return buf.String()
+}
+
+// TestMCPStderrSlogWriter_EmitsOneRecordPerLine is the M14 invariant.
+// Writing 3 newline-terminated lines must produce 3 slog records with
+// entry_type=mcp_stderr and mcp_server set to the server name.
+func TestMCPStderrSlogWriter_EmitsOneRecordPerLine(t *testing.T) {
+	out := captureSlog(t, func() {
+		w := newMCPStderrSlogWriter("my-mcp")
+		w.Write([]byte("line one\nline two\nline three\n"))
+	})
+
+	for _, want := range []string{"line one", "line two", "line three"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected line %q in slog output; got:\n%s", want, out)
+		}
+	}
+	// Server name must be tagged on every record.
+	if strings.Count(out, `mcp_server=my-mcp`) != 3 {
+		t.Errorf("expected mcp_server tag on each of 3 records; got:\n%s", out)
+	}
+}
+
+// TestMCPStderrSlogWriter_HandlesPartialLines: bytes that don't end
+// with '\n' must wait in the buffer until the newline arrives, then
+// emit. No fragmenting of a single line into multiple records.
+func TestMCPStderrSlogWriter_HandlesPartialLines(t *testing.T) {
+	out := captureSlog(t, func() {
+		w := newMCPStderrSlogWriter("partial")
+		w.Write([]byte("hello "))
+		w.Write([]byte("world\n"))
+	})
+	if !strings.Contains(out, "hello world") {
+		t.Errorf("expected merged line in slog output; got:\n%s", out)
+	}
+	// Reject the bug shape: two separate records for one line.
+	if strings.Count(out, "msg=") > 1 {
+		t.Errorf("multiple slog records for one logical line; got:\n%s", out)
+	}
+}
+
+// TestMCPStderrSlogWriter_TrimsCarriageReturn: progress bars or
+// Windows-style line endings shouldn't leave \r in the captured msg.
+func TestMCPStderrSlogWriter_TrimsCarriageReturn(t *testing.T) {
+	out := captureSlog(t, func() {
+		w := newMCPStderrSlogWriter("cr")
+		w.Write([]byte("with cr\r\n"))
+	})
+	if strings.Contains(out, "\r") {
+		t.Errorf("carriage return leaked into slog output: %q", out)
+	}
+}
+
+// TestMCPStderrSlogWriter_BoundedBufferOnNoNewline: no-newline data
+// past the cap must force-emit and reset, mirroring lineEmitter's
+// M13 bound.
+func TestMCPStderrSlogWriter_BoundedBufferOnNoNewline(t *testing.T) {
+	w := newMCPStderrSlogWriter("bound")
+	huge := bytes.Repeat([]byte("x"), mcpStderrMaxBufBytes+1024)
+	w.Write(huge)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if got := len(w.buf); got > mcpStderrMaxBufBytes {
+		t.Errorf("buf grew past cap; got %d bytes, cap %d", got, mcpStderrMaxBufBytes)
+	}
+}

--- a/internal/cronicle/tools.go
+++ b/internal/cronicle/tools.go
@@ -301,9 +301,16 @@ func (t *TextEditorTool) insert(absPath string, insertLine int, newStr string) (
 // wins; rejection means no root matched. Path-traversal `..` is checked
 // against each root, so the agent can't break out via the additional
 // roots either.
+//
+// A nil receiver or empty Workspace is rejected (audit M15). The previous
+// behavior fell through to resolveInWorkspace("", p) which used
+// filepath.Abs("") — that returns the process CWD, silently breaking the
+// workspace-containment guarantee. Failing loud here means callers that
+// forgot to set Workspace get a recognizable error instead of unbounded
+// CWD access.
 func (t *TextEditorTool) resolvePath(p string) (string, error) {
 	if t == nil || t.Workspace == "" {
-		return resolveInWorkspace(t.Workspace, p)
+		return "", fmt.Errorf("text_editor: workspace not configured")
 	}
 	if abs, err := resolveInWorkspace(t.Workspace, p); err == nil {
 		return abs, nil

--- a/internal/cronicle/tools_test.go
+++ b/internal/cronicle/tools_test.go
@@ -156,6 +156,22 @@ func TestResolveInWorkspace_NonExistentLeaf(t *testing.T) {
 	}
 }
 
+// TestTextEditorTool_NilOrEmptyWorkspaceRejected: the M15 fix.
+// Previously, a nil receiver or empty Workspace fell through to
+// resolveInWorkspace("", p) which used filepath.Abs("") → process CWD,
+// silently breaking workspace containment. We now reject explicitly.
+func TestTextEditorTool_NilOrEmptyWorkspaceRejected(t *testing.T) {
+	// Nil receiver
+	if _, err := (*TextEditorTool)(nil).resolvePath("a.txt"); err == nil {
+		t.Errorf("nil receiver should return error, got nil")
+	}
+	// Empty workspace
+	tool := &TextEditorTool{Workspace: ""}
+	if _, err := tool.resolvePath("a.txt"); err == nil {
+		t.Errorf("empty Workspace should return error, got nil")
+	}
+}
+
 // defaultAgentToolNames is local-only by default (bash + text_editor + git).
 // web_search / web_fetch bill per call and are opt-in — adding them by
 // default would surprise unattended cron jobs.


### PR DESCRIPTION
## Summary
Two small fixes that **complete the Medium tier** of the audit.

| Finding | Status | File | What broke |
|---|---|---|---|
| **M14** | ✅ | \`mcp.go\` | MCP server stderr bypassed structured logging; ANSI from third parties hit operator terminal |
| **M15** | ✅ | \`tools.go\` | TextEditorTool with empty Workspace silently fell through to process CWD |

## M14 — MCP server stderr through slog
\`launchOne\` used \`os.Stderr\` as the fallback when no pretty-mode writer was supplied. That:
- Bypassed the structured log file (\`cronicle.jsonl\` → Loki) and the live SSE stream
- Let third-party MCP servers emit arbitrary ANSI escapes straight at the operator's terminal
- Let any secrets that surfaced in MCP errors land in raw stderr instead of the bounded, structured logging chain

Replaced with \`mcpStderrSlogWriter\` — buffers bytes by newline, emits one \`slog.Warn\` per line tagged \`entry_type=mcp_stderr\` and \`mcp_server=<name>\`. Same 1 MiB unflushed-buffer cap as the M13 \`lineEmitter\` fix so a no-newline producer can't OOM. \`\\r\` stripped to keep Windows / progress-bar output clean.

## M15 — TextEditorTool empty workspace
\`resolvePath\` checked \`t == nil || t.Workspace == \"\"\` and fell through to \`resolveInWorkspace(\"\", p)\`. With empty workspace, \`filepath.Abs(\"\")\` returns the **process CWD** — silently breaking the workspace-containment guarantee. An agent's \`text_editor\` would gain read/write access to whatever directory cronicle was started in.

Now returns \`\"text_editor: workspace not configured\"\` instead. Agents see a clean error in \`tool_result\` and stop trying to use the tool, rather than silently writing to a path the operator never authorized.

## Tests added (5)
- \`TestMCPStderrSlogWriter_EmitsOneRecordPerLine\` — 3 lines → 3 slog records, tagged
- \`TestMCPStderrSlogWriter_HandlesPartialLines\` — no fragmenting across Write calls
- \`TestMCPStderrSlogWriter_TrimsCarriageReturn\`
- \`TestMCPStderrSlogWriter_BoundedBufferOnNoNewline\` — cap enforced
- \`TestTextEditorTool_NilOrEmptyWorkspaceRejected\` — both nil receiver and empty Workspace return error

## Audit Progress
After this PR, the **Medium tier is fully cleared**:

\`\`\`
Critical:  0/5 left ✓
High:      H4 ⏳   (SSH known-hosts — design needed)
Medium:    M1, M3, M4, M5, M6, M7, M8, M9, M10, M11, M12, M13, M14, M15 fixed
           M2 documented
           → 0 left ✓
Low:        8 untouched
\`\`\`

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` full suite (8 packages) pass
- [x] \`go test -tags smoke\` binary smoke pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)