### PR TITLE
fix: sweep all 7 Low audit findings (finishes Low tier)

### DIFF
--- a/internal/cronicle/cron.go
+++ b/internal/cronicle/cron.go
@@ -131,7 +131,12 @@ func Run(ctx context.Context, cronicleFile string, runOptions RunOptions) {
 		}
 		go reaperLoop(ctx, stateStore)
 	} else {
-		queue := make(chan []byte)
+		// 64-slot buffer (matches the listener-mode enqueueChan) so a
+		// slow ConsumeSchedule can't stall the cron-tick goroutine on
+		// the channel send — the original unbuffered chan meant
+		// robfig/cron's serialized callback queue cascaded when any
+		// schedule body ran longer than the next tick interval (L3).
+		queue := make(chan []byte, 64)
 		triggerQueue = queue
 		closeQueue = func() { close(queue) }
 		go StartCron(ctx, cronicleFileAbs, queue)
@@ -371,10 +376,19 @@ func ConsumeSchedule(queue <-chan []byte, path string, wg *sync.WaitGroup) {
 	} else {
 		p = path
 	}
+	// L2: cap concurrent schedule goroutines so a burst (e.g. many
+	// schedules firing on the same tick or rapid HTTP triggers) can't
+	// fan out to thousands of goroutines, exhaust file descriptors, or
+	// hit API rate limits. 16 matches typical worker-pool sizing — a
+	// schedule that needs more parallelism should configure
+	// --worker-count, not rely on unbounded fan-out here.
+	sem := make(chan struct{}, 16)
 	for scheduleBytes := range queue {
+		sem <- struct{}{}
 		wg.Add(1)
 		go func(scheduleBytes []byte) {
 			defer wg.Done()
+			defer func() { <-sem }()
 			var schedule Schedule
 			err := json.Unmarshal(scheduleBytes, &schedule)
 			if err != nil {

--- a/internal/cronicle/git.go
+++ b/internal/cronicle/git.go
@@ -3,6 +3,7 @@ package cronicle
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,22 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+// redactGitURL strips userinfo from a git URL before logging so an
+// operator who embeds a token in the URL (e.g.
+// https://user:ghp_xxx@github.com/org/repo) doesn't leak it through
+// the structured log → Loki pipeline. Falls back to the original
+// string when parsing fails (SSH-style "git@host:org/repo" doesn't
+// parse as a URL; it also doesn't carry inline credentials, so
+// passing it through is fine).
+func redactGitURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
 
 // Git is the struct which associates common data structures from the go-git library.
 type Git struct {
@@ -132,7 +149,7 @@ func (g *Git) Open(worktreePath string) error {
 func Clone(worktreeDir string, url string, opts []client.Option) (Git, error) {
 
 	if !DirExists(filepath.Join(worktreeDir, ".git")) {
-		slog.Info("git clone", "url", url, "path", worktreeDir)
+		slog.Info("git clone", "url", redactGitURL(url), "path", worktreeDir)
 		cloneOptions := git.CloneOptions{URL: url, ClientOptions: opts}
 		// In pretty mode, route go-git's progress sideband straight to
 		// stdout so the user sees the live "Counting objects" / "Receiving
@@ -168,7 +185,7 @@ func Clone(worktreeDir string, url string, opts []client.Option) (Git, error) {
 				RemoteName:    "origin",
 				ClientOptions: opts,
 			}); err != nil {
-				slog.Error("git fetch failed", "url", url, "path", worktreeDir, "error", err.Error())
+				slog.Error("git fetch failed", "url", redactGitURL(url), "path", worktreeDir, "error", err.Error())
 				return Git{}, err
 			}
 			// After init+fetch, HEAD is unborn. Point it at the remote's
@@ -192,11 +209,11 @@ func Clone(worktreeDir string, url string, opts []client.Option) (Git, error) {
 		} else {
 			_, err := git.PlainClone(worktreeDir, &cloneOptions)
 			if err != nil {
-				slog.Error("git clone failed", "url", url, "path", worktreeDir, "error", err.Error())
+				slog.Error("git clone failed", "url", redactGitURL(url), "path", worktreeDir, "error", err.Error())
 				return Git{}, err
 			}
 		}
-		slog.Info("git clone complete", "url", url, "path", worktreeDir)
+		slog.Info("git clone complete", "url", redactGitURL(url), "path", worktreeDir)
 	} else {
 		slog.Info("git open", "path", worktreeDir, "note", "worktree already exists, skipping clone")
 	}

--- a/internal/cronicle/git_tool.go
+++ b/internal/cronicle/git_tool.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -31,6 +33,36 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
+
+// secretFilenamePatterns is the set of filename patterns that, if
+// staged via the agent's `git commit` tool, get a slog.Warn so an
+// operator reviewing the run can see and react. These are the names
+// that commonly carry credentials in repository checkouts. We don't
+// REFUSE to stage them — agents legitimately edit some of these in
+// reset / template workflows — but loud warnings keep the case
+// visible.
+var secretFilenamePatterns = []string{
+	".env", ".env.*",
+	"*.pem", "*.key", "*.p12", "*.pfx", "*.jks",
+	".netrc", "_netrc",
+	"id_rsa", "id_dsa", "id_ecdsa", "id_ed25519",
+}
+
+// isLikelySecretFilename reports whether a path (anywhere in the
+// worktree) ends with a name matching one of secretFilenamePatterns.
+// Public-key counterparts (*.pub) are intentionally not flagged.
+func isLikelySecretFilename(path string) bool {
+	name := filepath.Base(path)
+	if strings.HasSuffix(name, ".pub") {
+		return false
+	}
+	for _, pat := range secretFilenamePatterns {
+		if matched, _ := filepath.Match(pat, name); matched {
+			return true
+		}
+	}
+	return false
+}
 
 // GitTool exposes a small subset of git operations to the agent via go-git.
 // Workspace must be the path to a git working tree (typically task.Path
@@ -382,6 +414,21 @@ func (g *GitTool) commit(repo *git.Repository, raw json.RawMessage) (string, boo
 	if st.IsClean() {
 		return "Error: nothing to commit (working tree clean)", true
 	}
+	// L6: wt.Add(".") stages every modified/untracked file in the
+	// worktree. If the agent has written a .env, *.pem, id_rsa, .netrc
+	// or similar credential-bearing file (intentionally or as a side
+	// effect of running a tool), this will quietly fold the secret
+	// into the commit. We don't refuse — agents legitimately edit
+	// these files in some workflows — but we DO emit a structured
+	// warning so an operator reviewing the run can spot the case.
+	for path, s := range st {
+		_ = s
+		if isLikelySecretFilename(path) {
+			slog.Warn("git tool: staging likely-sensitive file (review before push)",
+				"entry_type", "git_tool_warn",
+				"path", path)
+		}
+	}
 	if _, err := wt.Add("."); err != nil {
 		return fmt.Sprintf("Error: stage: %v", err), true
 	}
@@ -433,3 +480,4 @@ func (g *GitTool) push(ctx context.Context, repo *git.Repository, raw json.RawMe
 	}
 	return fmt.Sprintf("Pushed to %s", a.Remote), false
 }
+

--- a/internal/cronicle/listen_control.go
+++ b/internal/cronicle/listen_control.go
@@ -14,6 +14,7 @@
 package cronicle
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -620,8 +621,14 @@ func writeSSE(w http.ResponseWriter, event string, payload any) error {
 	return err
 }
 
-// isNoRows returns true if err is sql.ErrNoRows. Wrapped so listen.go
-// doesn't need to import database/sql twice.
+// isNoRows returns true if err wraps sql.ErrNoRows. Wrapped so listen.go
+// doesn't need to import database/sql at every call site.
+//
+// L9: the previous strings.Contains(err.Error(), "no rows") was a string
+// shibboleth that would have matched any error whose message happened to
+// contain that substring — e.g. a future schema-validation error along
+// the lines of "no rows in expected join". errors.Is walks the chain
+// properly.
 func isNoRows(err error) bool {
-	return strings.Contains(err.Error(), "no rows")
+	return errors.Is(err, sql.ErrNoRows)
 }

--- a/internal/cronicle/log.go
+++ b/internal/cronicle/log.go
@@ -1582,11 +1582,17 @@ func escapeControl(s string) string {
 }
 
 // truncate trims s to at most n runes, appending "…" when shortened.
+// Operates on []rune so multi-byte UTF-8 input (anything beyond ASCII,
+// including pretty-printed prompts from non-English locales and the
+// emoji that occasionally surface in tool args) is sliced at codepoint
+// boundaries — the previous byte-slicing produced invalid UTF-8 when
+// the cut landed mid-rune.
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
-	return s[:n-1] + "…"
+	return string(r[:n-1]) + "…"
 }
 
 // formatDuration renders a millisecond value as "Nms" or "N.Ns" depending on

--- a/internal/cronicle/low_tier_test.go
+++ b/internal/cronicle/low_tier_test.go
@@ -1,0 +1,173 @@
+package cronicle
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestUnescapeHCLDollars_PreservesNonTemplateRuns is the L1 invariant:
+// the previous `[$]+` regex collapsed any run of '$' to a single '$',
+// damaging legitimate shell `$$` (PID) and awk `$$0` references. The
+// targeted replacement only touches the actual gohcl escape pattern
+// `$${`.
+func TestUnescapeHCLDollars_PreservesNonTemplateRuns(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain ASCII", "echo hello", "echo hello"},
+		{"unescapes gohcl-doubled template", "$${date}", "${date}"},
+		{"preserves shell PID $$", "echo $$", "echo $$"},
+		{"preserves awk $$0", "awk '{print $$0}'", "awk '{print $$0}'"},
+		{"mixed template + literal $$", "$${date} log $$.txt", "${date} log $$.txt"},
+		{"triple $ not followed by { stays put", "$$$ payday", "$$$ payday"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(unescapeHCLDollars([]byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRedactGitURL strips userinfo from URLs so embedded tokens don't
+// reach Loki / SSE through git-clone log lines (L5).
+func TestRedactGitURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"https with token in password slot",
+			"https://x:ghp_abc123@github.com/org/repo.git",
+			"https://github.com/org/repo.git",
+		},
+		{
+			"https with only username",
+			"https://alice@gitlab.example/org/repo.git",
+			"https://gitlab.example/org/repo.git",
+		},
+		{
+			"https without credentials passes through",
+			"https://github.com/org/repo.git",
+			"https://github.com/org/repo.git",
+		},
+		{
+			"ssh-style passes through (no inline creds possible)",
+			"git@github.com:org/repo.git",
+			"git@github.com:org/repo.git",
+		},
+		{
+			"local path passes through",
+			"/tmp/repo.git",
+			"/tmp/repo.git",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactGitURL(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsLikelySecretFilename verifies the L6 sensitive-name detector
+// catches the common credential filenames while leaving normal source
+// files and public-key counterparts alone.
+func TestIsLikelySecretFilename(t *testing.T) {
+	hits := []string{
+		".env",
+		".env.production",
+		"path/to/.env.local",
+		"keys/server.pem",
+		"id_rsa",
+		"id_ed25519",
+		".netrc",
+		"_netrc",
+		"subdir/server.key",
+	}
+	misses := []string{
+		"README.md",
+		"main.go",
+		"id_rsa.pub", // public key — explicitly excluded
+		"id_ed25519.pub",
+		"build.env.example", // doesn't end in .env
+		".envrc",            // direnv config, not credentials
+		"my_module.go",
+	}
+	for _, p := range hits {
+		t.Run("hit/"+p, func(t *testing.T) {
+			if !isLikelySecretFilename(p) {
+				t.Errorf("isLikelySecretFilename(%q) = false, want true", p)
+			}
+		})
+	}
+	for _, p := range misses {
+		t.Run("miss/"+p, func(t *testing.T) {
+			if isLikelySecretFilename(p) {
+				t.Errorf("isLikelySecretFilename(%q) = true, want false", p)
+			}
+		})
+	}
+}
+
+// TestTruncate_RuneSafe covers the L7 invariant: truncation must not
+// land mid-rune for multi-byte UTF-8 input. Slicing by byte (the old
+// code) produces invalid UTF-8 when the cut falls inside a multi-byte
+// codepoint.
+func TestTruncate_RuneSafe(t *testing.T) {
+	// "café" — len("café")==5 bytes (4 runes), the é is 2 bytes.
+	// Byte-slicing s[:3] yields "ca" + first byte of é = invalid UTF-8.
+	const cafe = "café"
+	got := truncate(cafe, 3)
+	if !isValidUTF8(got) {
+		t.Errorf("truncate produced invalid UTF-8: %q", got)
+	}
+	// Same idea but with a longer multi-byte string.
+	emoji := "smoke 🚀 test 🔥"
+	got2 := truncate(emoji, 8)
+	if !isValidUTF8(got2) {
+		t.Errorf("truncate of emoji produced invalid UTF-8: %q", got2)
+	}
+	// Short ASCII pass-through unchanged.
+	if got := truncate("hi", 10); got != "hi" {
+		t.Errorf("short input mutated; got %q", got)
+	}
+}
+
+// TestIsNoRows_RecognizesErrNoRowsViaErrorsIs is the L9 invariant: the
+// previous strings.Contains(err.Error(), "no rows") was sloppy and
+// would have matched any error whose message merely included "no rows"
+// — e.g. a future "no rows in expected join" validation error.
+// errors.Is walks the wrap chain properly.
+func TestIsNoRows_RecognizesErrNoRowsViaErrorsIs(t *testing.T) {
+	if !isNoRows(sql.ErrNoRows) {
+		t.Errorf("expected isNoRows(sql.ErrNoRows) = true")
+	}
+	wrapped := fmt.Errorf("lookup run X: %w", sql.ErrNoRows)
+	if !isNoRows(wrapped) {
+		t.Errorf("expected isNoRows to walk wrap chain")
+	}
+	// A non-sql error whose message happens to mention "no rows" must
+	// NOT match — the substring trap.
+	bogus := errors.New("validation: query produced no rows in expected join")
+	if isNoRows(bogus) {
+		t.Errorf("isNoRows false-matched on non-sql error: %v", bogus)
+	}
+}
+
+// isValidUTF8 reports whether s is well-formed UTF-8. We only care
+// about catching truncation that lands mid-rune; utf8.ValidString
+// detects that property directly.
+func isValidUTF8(s string) bool {
+	return utf8.ValidString(s)
+}

--- a/internal/cronicle/parse.go
+++ b/internal/cronicle/parse.go
@@ -1,10 +1,10 @@
 package cronicle
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 
-	"regexp"
 	"sync"
 	"time"
 
@@ -16,6 +16,17 @@ import (
 
 	"log/slog"
 )
+
+// unescapeHCLDollars undoes the `$${` → `${` doubling that gohcl's
+// encoder applies to template tokens like `${date}`. The previous
+// approach (regexp `[$]+` → `$`) was a blunt instrument that also
+// collapsed any innocent run of `$` in a user's literal command
+// (e.g. shell `$$` for PID, awk `$$0`). This targeted replacement
+// only touches the actual gohcl escape sequence, leaving every
+// other `$` run intact.
+func unescapeHCLDollars(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte("$${"), []byte("${"))
+}
 
 // envContextVar builds the `env` namespace exposed to HCL eval —
 // a cty object whose attributes are the names of env vars currently
@@ -153,8 +164,7 @@ var (
 func MarshallHcl(conf Config, path string) string {
 	f := hclwrite.NewEmptyFile()
 	gohcl.EncodeIntoBody(&conf, f.Body())
-	r := regexp.MustCompile("[$]+")
-	b := r.ReplaceAllLiteral(f.Bytes(), []byte("$"))
+	b := unescapeHCLDollars(f.Bytes())
 	destination, err := os.Create(path)
 	if err != nil {
 		panic(err)
@@ -264,8 +274,7 @@ func (task Task) JSON() []byte {
 func (conf Config) Hcl() HclWriteFile {
 	f := hclwrite.NewEmptyFile()
 	gohcl.EncodeIntoBody(&conf, f.Body())
-	r := regexp.MustCompile("[$]+")
-	b := r.ReplaceAllLiteral(f.Bytes(), []byte("$"))
+	b := unescapeHCLDollars(f.Bytes())
 	return HclWriteFile{File: *f, Bytes: b}
 }
 
@@ -273,7 +282,6 @@ func (conf Config) Hcl() HclWriteFile {
 func (task Task) Hcl() HclWriteFile {
 	f := hclwrite.NewEmptyFile()
 	gohcl.EncodeIntoBody(&task, f.Body())
-	r := regexp.MustCompile("[$]+")
-	b := r.ReplaceAllLiteral(f.Bytes(), []byte("$"))
+	b := unescapeHCLDollars(f.Bytes())
 	return HclWriteFile{File: *f, Bytes: b}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -7,9 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -430,9 +432,27 @@ func applyCacheBreakpoint(params *anthropic.MessageNewParams) {
 	}
 }
 
+// warnedUnknownModels remembers which model IDs we've already warned
+// about so a high-volume run doesn't flood logs with the same notice.
+// sync.Map (vs a plain map+mutex) keeps this lock-free on the hot
+// path; the rare first-encounter write happens at most once per id.
+var warnedUnknownModels sync.Map
+
 func computeCost(model string, in, out, cacheWrite, cacheRead int) float64 {
 	p, ok := pricing[priceKey(model)]
 	if !ok {
+		// L4: previously this just returned 0 silently. Result: an
+		// unattended cron with budget_usd = 5.00 configured against
+		// a model the pricing table didn't know about would NEVER
+		// trip the budget gate — the cost would stay zero regardless
+		// of token usage. Warn loudly the first time we see an
+		// unknown id so operators can either add the entry or set an
+		// alias-resolving priceKey rule. Repeat warnings would just
+		// be noise; sync.Map gates on first-sight per id.
+		if _, alreadyWarned := warnedUnknownModels.LoadOrStore(model, struct{}{}); !alreadyWarned {
+			slog.Warn("agent: model not in pricing table; cost reported as $0 (budget_usd will not trip)",
+				"model", model)
+		}
 		return 0
 	}
 	return (float64(in)*p.in +


### PR DESCRIPTION
## Summary
Bundles all remaining Low findings. Small, mechanical fixes for footguns that didn't rise to Medium severity.

| Finding | File | Fix |
|---|---|---|
| **L1** | \`parse.go\` | Targeted \`\$\${\` → \`\${\` instead of broad \`[\$]+\` → \`\$\` (was eating legitimate \`\$\$\`) |
| **L2** | \`cron.go\` | 16-slot semaphore caps ConsumeSchedule fan-out |
| **L3** | \`cron.go\` | Non-listener queue buffered to 64 (matches listener mode) |
| **L4** | \`pkg/agent/agent.go\` | Unknown-model cost warning (once per model) so budget_usd doesn't silently noop |
| **L5** | \`git.go\` | \`redactGitURL\` strips userinfo before slog emission |
| **L6** | \`git_tool.go\` | \`git commit\` warns on staging sensitive filenames (.env, *.pem, id_rsa, .netrc, etc.) |
| **L7** | \`log.go\` | \`truncate()\` uses \`[]rune\` so UTF-8 input doesn't get sliced mid-codepoint |
| **L8** | — | Already done in PR #140 |
| **L9** | \`listen_control.go\` | \`isNoRows\` uses \`errors.Is(err, sql.ErrNoRows)\` instead of string match |

## L4 callout — could trip budgets
The cost-table warning is the loudest change here. Previously, an unattended cron with \`budget_usd = 5.00\` configured against a model the pricing table didn't know about would NEVER trip the budget gate (cost stayed \$0). Now a single \`slog.Warn\` per model surfaces the gap. \`sync.Map\` gates first-sight to avoid log flooding.

## L6 callout — design choice
The sensitive-filename warning **does not refuse** to stage matching paths (\`.env\`, \`*.pem\`, \`id_rsa\`, \`.netrc\`, …). Some workflows legitimately edit these. Instead it emits a structured \`slog.Warn\` with \`entry_type=git_tool_warn\` so reviewers can spot it. \`*.pub\` counterparts are explicitly excluded.

## Tests added (5 functions, 30+ assertions)
- \`TestUnescapeHCLDollars_PreservesNonTemplateRuns\` — 7 cases including legitimate \`\$\$\` patterns the old regex broke
- \`TestRedactGitURL\` — 5 cases including SSH-style passthrough
- \`TestIsLikelySecretFilename\` — 9 hits + 7 misses (incl. \`id_rsa.pub\` explicitly not flagged)
- \`TestTruncate_RuneSafe\` — \`café\` and emoji cases assert UTF-8 validity of truncated output
- \`TestIsNoRows_RecognizesErrNoRowsViaErrorsIs\` — sentinel, wrapped, and a substring-trap false-positive case

## Audit Status After This PR
\`\`\`
Critical:  0/5 left ✓
High:      H4 ⏳   (SSH known-hosts — needs design discussion)
Medium:    0/15 fixed ✓ (M2 documented)
Low:        0/8 fixed ✓  (L8 was pre-fixed in #140)
\`\`\`

**The original audit is now closed except for H4**, which warrants a separate design pass.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` full suite (8 packages) pass
- [x] \`go test -tags smoke\` binary smoke pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)