### PR TITLE
fix(state): scope v10 PG migration probe to current_schema() (follow-up to #159)

### DIFF
--- a/internal/cronicle/state/store.go
+++ b/internal/cronicle/state/store.go
@@ -394,10 +394,20 @@ func (s *Store) migrateV10IdempotentSQLite() error {
 // information_schema keeps the structural shape identical to the
 // SQLite path — both branches "check, then DDL when missing."
 func (s *Store) migrateV10IdempotentPG() error {
+	// MUST scope to current_schema(). Each cronicle deployment gets its
+	// own Postgres schema via search_path (dep_<id>) inside a SHARED
+	// database, so an unscoped information_schema query sees the secrets
+	// table in EVERY deployment's schema. Without the filter, the probe
+	// finds value_ct in some other (already-migrated) deployment's
+	// schema, wrongly concludes this schema is migrated, skips the
+	// ALTER — and BackfillSecrets then fails with "column value_ct does
+	// not exist". table_schema = current_schema() pins the probe to the
+	// search_path schema the rest of the migration writes to.
 	rows, err := s.db.Query(`
 		SELECT column_name
 		FROM information_schema.columns
-		WHERE table_name = 'secrets'
+		WHERE table_schema = current_schema()
+		  AND table_name = 'secrets'
 		  AND column_name IN ('value_ct', 'value_nonce')`)
 	if err != nil {
 		return fmt.Errorf("probe secrets schema: %w", err)


### PR DESCRIPTION
## What broke
Follow-up to #159. The Postgres branch of \`migrateV10Idempotent\` queried \`information_schema.columns\` with no schema filter. In cronicle-infra, every deployment gets its own Postgres **schema** (\`search_path=dep_<id>\`) inside a single shared database. The unscoped query sees the \`secrets\` table in **every** deployment's schema.

Once any one deployment has run v10, the probe finds \`value_ct\` in *that* schema and wrongly concludes the **current** (fresh) schema is already migrated — skips the ALTER, records version 10 anyway, then \`BackfillSecrets\` fails:
\`\`\`
state.BackfillSecrets: scan: ERROR: column "value_ct" does not exist (SQLSTATE 42703)
\`\`\`
…leaving the producer with "state store open failed; projection disabled", and the worker stuck on \`503 state store not enabled\`.

**The first deployment always works** (no prior schema to leak from); the **second and later** deployments break.

## How I caught it
Creating a *second* project on the kind cluster. The first project (\`smoke-test\`) had validated all the audit fixes; the DAG project (\`dag-project\`) was the second deployment and its producer couldn't enable the state store.

## Why unit tests miss it
\`:memory:\` SQLite has no shared-schema concept — each test DB is fully isolated. Only a real shared Postgres with multiple search_path schemas reproduces it. Same blind-spot class as #159 itself.

## Fix
Add \`table_schema = current_schema()\` so the probe sees only the search_path schema the rest of the migration writes to.

## Test plan
- [x] SQLite migration tests still pass
- [ ] Validated by rolling a 2nd+ deployment on the kind cluster after merge
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)