### PR TITLE
test(state): Postgres multi-schema migration coverage (#159/#160 guard)

### DIFF
--- a/internal/cronicle/state/pg_integration_test.go
+++ b/internal/cronicle/state/pg_integration_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"database/sql"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -142,5 +143,172 @@ func resetPublicSchema(t *testing.T, dsn string) {
 	defer db.Close()
 	if _, err := db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {
 		t.Fatalf("reset schema: %v", err)
+	}
+}
+
+// withSearchPath returns dsn with its search_path query param set to
+// schema — the same shape the cronicle-infra control plane hands each
+// per-deployment producer (postgres://…?search_path=dep_<id>).
+func withSearchPath(t *testing.T, dsn, schema string) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	q := u.Query()
+	q.Set("search_path", schema)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// dropSchema removes a per-deployment schema (CASCADE) so the test is
+// rerunnable. Best-effort cleanup.
+func dropSchema(t *testing.T, dsn, schema string) {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw pg: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`DROP SCHEMA IF EXISTS ` + quoteIdent(schema) + ` CASCADE`); err != nil {
+		t.Fatalf("drop schema %s: %v", schema, err)
+	}
+}
+
+// secretsColumnExists reports whether the named column is present on the
+// secrets table in the given schema. This is the probe that #160 got
+// wrong — an unscoped information_schema query returned a sibling
+// schema's column and made the migration skip the ALTER.
+func secretsColumnExists(t *testing.T, dsn, schema, col string) bool {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw pg: %v", err)
+	}
+	defer db.Close()
+	var n int
+	err = db.QueryRow(`
+		SELECT count(*) FROM information_schema.columns
+		WHERE table_schema = $1 AND table_name = 'secrets' AND column_name = $2`,
+		schema, col).Scan(&n)
+	if err != nil {
+		t.Fatalf("probe %s.secrets.%s: %v", schema, col, err)
+	}
+	return n > 0
+}
+
+// TestPostgres_MultiSchema_MigrationIsolation is the #160 regression
+// guard. cronicle-infra runs MANY producers against ONE shared
+// Postgres, each pinned to its own schema via search_path=dep_<id>.
+//
+// The v10 migration probes whether the secrets-encryption columns
+// (value_ct/value_nonce) already exist before running the ALTER. Before
+// #160 that probe used an unscoped information_schema query, so the
+// SECOND deployment's migration saw the FIRST deployment's columns,
+// wrongly concluded its own schema was migrated, skipped the ALTER, and
+// then BackfillSecrets failed with "column value_ct does not exist" —
+// killing every 2nd+ producer's state store.
+//
+// This test reproduces that exact topology: migrate schema A (which
+// creates the columns), then migrate a fresh schema B in the same
+// database, and assert B got its OWN columns and a working secrets
+// round-trip. A single :memory: SQLite store can never model this —
+// which is why both #159 and #160 escaped to a live cluster.
+func TestPostgres_MultiSchema_MigrationIsolation(t *testing.T) {
+	dsn := os.Getenv("TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set TEST_PG_DSN to run the Postgres multi-schema migration test")
+	}
+
+	const schemaA = "dep_test_aaaa"
+	const schemaB = "dep_test_bbbb"
+	dropSchema(t, dsn, schemaA)
+	dropSchema(t, dsn, schemaB)
+	t.Cleanup(func() {
+		dropSchema(t, dsn, schemaA)
+		dropSchema(t, dsn, schemaB)
+	})
+
+	// --- Deployment A: first producer in the cluster. Always worked,
+	// even before #160, because there's no sibling schema to leak from.
+	sa, err := Open(withSearchPath(t, dsn, schemaA))
+	if err != nil {
+		t.Fatalf("Open(schema A): %v", err)
+	}
+	t.Cleanup(func() { _ = sa.Close() })
+	if !secretsColumnExists(t, dsn, schemaA, "value_ct") ||
+		!secretsColumnExists(t, dsn, schemaA, "value_nonce") {
+		t.Fatalf("schema A missing v10 columns after migrate")
+	}
+
+	// --- Deployment B: the second producer. This is where #160 bit:
+	// its migration must NOT be fooled by schema A's columns into
+	// skipping its own ALTER.
+	sb, err := Open(withSearchPath(t, dsn, schemaB))
+	if err != nil {
+		t.Fatalf("Open(schema B): %v (this is the #160 failure mode — "+
+			"BackfillSecrets fails when the v10 ALTER was skipped)", err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	if !secretsColumnExists(t, dsn, schemaB, "value_ct") {
+		t.Errorf("schema B missing value_ct — the v10 probe leaked across schemas (#160)")
+	}
+	if !secretsColumnExists(t, dsn, schemaB, "value_nonce") {
+		t.Errorf("schema B missing value_nonce — the v10 probe leaked across schemas (#160)")
+	}
+
+	// --- The symptom the operator actually saw: secrets unusable on B.
+	// PutSecret writes to value_ct/value_nonce (when AEAD is bound) or
+	// the plaintext column; GetSecret reads back. Without the columns,
+	// the producer logged "state store open failed; projection disabled"
+	// and the worker got 503 on every claim.
+	if err := sb.PutSecret("API_KEY", "secret-b", "tester"); err != nil {
+		t.Fatalf("PutSecret on schema B: %v", err)
+	}
+	v, ok, err := sb.GetSecret("API_KEY")
+	if err != nil || !ok || v != "secret-b" {
+		t.Fatalf("GetSecret on schema B = (%q,%v,%v), want (secret-b,true,nil)", v, ok, err)
+	}
+
+	// --- Isolation: A and B share one database but must not see each
+	// other's secrets (different schemas → different secrets tables).
+	if _, ok, _ := sa.GetSecret("API_KEY"); ok {
+		t.Errorf("schema A sees schema B's secret — schemas are not isolated")
+	}
+}
+
+// TestPostgres_MigrateTwiceIdempotent guards the #159/M7 crash-recovery
+// path explicitly: running migrate() twice against the same schema must
+// be a clean no-op. The v10 step in particular has no ALTER … IF NOT
+// EXISTS on SQLite and relies on the column probe; a re-run that
+// re-issued the ALTER would error with "duplicate column".
+func TestPostgres_MigrateTwiceIdempotent(t *testing.T) {
+	dsn := os.Getenv("TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set TEST_PG_DSN to run the Postgres migrate-twice test")
+	}
+	const schema = "dep_test_idem"
+	dropSchema(t, dsn, schema)
+	t.Cleanup(func() { dropSchema(t, dsn, schema) })
+
+	scoped := withSearchPath(t, dsn, schema)
+	s1, err := Open(scoped)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	_ = s1.Close()
+
+	// Reopen = reconnect = producer pod restart. migrate() runs again.
+	s2, err := Open(scoped)
+	if err != nil {
+		t.Fatalf("second Open (migrate must be idempotent): %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	// And a third time via a direct migrate() call on the live store,
+	// to exercise migrateV10Idempotent's already-applied branch.
+	if err := s2.migrate(); err != nil {
+		t.Fatalf("third migrate() call must be a no-op: %v", err)
 	}
 }


### PR DESCRIPTION
## Why
The `state` package was tested **only** against `:memory:` SQLite, which can't model the two things that broke production:
- **#159** — SQLite-only `PRAGMA` syntax vs. Postgres `information_schema`
- **#160** — shared-database multi-schema column leakage

Both reached a live kind cluster because no test exercised a real Postgres with the per-deployment-schema topology cronicle-infra uses (one managed Postgres, each deployment pinned to `search_path=dep_<id>`).

## What's added
Two `TEST_PG_DSN`-gated tests. They **skip cleanly when the env var is unset**, so default `go test ./...` stays fast and dependency-free.

### `TestPostgres_MultiSchema_MigrationIsolation` — the #160 guard
Reproduces the exact failure topology: migrate schema A (creates `value_ct`/`value_nonce`), then migrate a **fresh schema B in the same database**. Asserts B got its own columns + a working secrets round-trip + cross-schema isolation.

**Proven to catch the regression:** with the #160 fix reverted, it fails with the identical error the operator saw:
```
schema B missing value_ct — the v10 probe leaked across schemas (#160)
PutSecret on schema B: ... column "value_ct" of relation "secrets" does not exist (SQLSTATE 42703)
```
With the fix restored, it passes.

### `TestPostgres_MigrateTwiceIdempotent` — the #159/M7 guard
Migrate → reconnect (= pod restart) → direct `migrate()` call must all be clean no-ops, despite SQLite's `ALTER` having no `IF NOT EXISTS`.

## How to run
```
kubectl -n cronicle-platform port-forward svc/postgres-postgresql 5433:5432
TEST_PG_DSN="postgres://postgres:devpassword@127.0.0.1:5433/cronicle?sslmode=disable" \
  go test ./internal/cronicle/state/ -run TestPostgres
```

## Test plan
- [x] Compiles + skips without `TEST_PG_DSN`
- [x] Passes against the kind cluster's real Postgres
- [x] **Fails** with the #160 fix reverted (proves it has teeth)
- [x] Full state suite green with `TEST_PG_DSN` set
- [ ] CI passes (skips, no PG service yet — follow-up could add one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)