### PR TITLE
feat(cli): add version command and --version flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,11 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/jshiv/cronicle/cmd.version={{ .Version }}
+      - -X github.com/jshiv/cronicle/cmd.commit={{ .Commit }}
+      - -X github.com/jshiv/cronicle/cmd.date={{ .Date }}
     goos:
       - linux
       - darwin

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -29,6 +29,16 @@ import (
 // lets a single string assertion check either.
 func executeCmd(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	// Cobra's --help / --version bool flags persist on the shared rootCmd
+	// across Execute calls; a prior test that ran --help would otherwise
+	// leave help=true and short-circuit a later --version run into help
+	// output. Reset them so each invocation starts clean.
+	if f := rootCmd.Flags().Lookup("help"); f != nil {
+		_ = f.Value.Set("false")
+	}
+	if f := rootCmd.Flags().Lookup("version"); f != nil {
+		_ = f.Value.Set("false")
+	}
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
@@ -69,11 +79,12 @@ func TestRoot_PersistentFlagsRegistered(t *testing.T) {
 // accidentally dropping the AddCommand wiring for a subcommand.
 func TestRoot_AllSubcommandsRegistered(t *testing.T) {
 	want := map[string]bool{
-		"init":   false,
-		"run":    false,
-		"exec":   false,
-		"worker": false,
-		"secret": false,
+		"init":    false,
+		"run":     false,
+		"exec":    false,
+		"worker":  false,
+		"secret":  false,
+		"version": false,
 	}
 	for _, c := range rootCmd.Commands() {
 		if _, ok := want[c.Name()]; ok {
@@ -94,7 +105,7 @@ func TestRoot_HelpListsAllSubcommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected --help error: %v", err)
 	}
-	for _, sub := range []string{"init", "run", "exec", "worker", "secret"} {
+	for _, sub := range []string{"init", "run", "exec", "worker", "secret", "version"} {
 		if !strings.Contains(out, sub) {
 			t.Errorf("--help output missing %q; output:\n%s", sub, out)
 		}
@@ -110,6 +121,38 @@ func TestRoot_UnknownSubcommand(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown command") {
 		t.Errorf("error message should name the problem; got: %v", err)
+	}
+}
+
+// ---- version subcommand -----------------------------------------------
+
+// TestVersionCmd_PrintsVersion: `cronicle version` prints the build
+// version string. With no ldflags injected (test binary) it reports the
+// "dev" default — the assertion just guards that the command runs and
+// emits the version var rather than empty output.
+func TestVersionCmd_PrintsVersion(t *testing.T) {
+	out, err := executeCmd(t, "version")
+	if err != nil {
+		t.Fatalf("unexpected version error: %v", err)
+	}
+	if !strings.Contains(out, version) {
+		t.Errorf("version output missing %q; got: %q", version, out)
+	}
+}
+
+// TestRoot_VersionFlagWired: cobra only emits a --version flag when
+// rootCmd.Version is set. Guard that wiring so the flag doesn't silently
+// disappear if the init order changes.
+func TestRoot_VersionFlagWired(t *testing.T) {
+	if rootCmd.Version == "" {
+		t.Fatal("rootCmd.Version is empty; --version flag will not be registered")
+	}
+	out, err := executeCmd(t, "--version")
+	if err != nil {
+		t.Fatalf("unexpected --version error: %v", err)
+	}
+	if !strings.Contains(out, version) {
+		t.Errorf("--version output missing %q; got: %q", version, out)
 	}
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,52 @@
+/*
+Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Build metadata, injected at release time via goreleaser ldflags
+// (-X github.com/jshiv/cronicle/cmd.version=... etc). Untagged builds
+// (go build / go install) report "dev".
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// versionString is the one-line form used for `--version`.
+func versionString() string {
+	return fmt.Sprintf("%s (commit %s, built %s, %s)", version, commit, date, runtime.Version())
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the cronicle version and build metadata.",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Println(versionString())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+	// Wire cobra's built-in --version flag to the same string.
+	rootCmd.Version = versionString()
+}


### PR DESCRIPTION
## Summary
- Adds a `cronicle version` subcommand and wires cobra's built-in `--version` flag. Both print `version (commit <sha>, built <date>, <go version>)`.
- Build metadata is injected at release time via goreleaser ldflags (`-X .../cmd.{version,commit,date}`). Untagged `go build` / `go install` builds report `dev`.
- Extends the `cmd/` Cobra test suite to cover the new subcommand registration, help listing, and both output forms.

## Motivation
cronicle had no way to report its own version. During the v0.7.0 prod rollout, verifying which version was actually deployed meant inferring it from the cronicled image's git provenance rather than asking the binary. `cronicle version` closes that gap.

## Notes
- The prod cronicled image is built by the cronicle-infra justfile with a plain `go build` (no goreleaser), so it will report `dev` until that build is updated to inject a version — tracked as a separate infra follow-up.

## Test plan
- [x] `go test ./cmd/` passes (new `TestVersionCmd_PrintsVersion`, `TestRoot_VersionFlagWired`, plus updated registration/help tests)
- [x] `go build` (no ldflags) → `dev (commit none, built unknown, go1.26.3)`
- [x] `go build -ldflags "-X .../cmd.version=v0.7.1 ..."` → reports the injected values for both `version` and `--version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)